### PR TITLE
Use auth store for login/logout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { useAuthStore } from "../store/auth";
 import "./Header.css";
 
 const Header: React.FC = () => {
   const navigate = useNavigate();
+  const setToken = useAuthStore(s => s.setToken);
   const logout = () => {
-    localStorage.removeItem("token");
+    setToken(null);
     navigate("/login");
   };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
+import { useAuthStore } from "../store/auth";
 import "./LoginPage.css";
 
 const LoginPage: React.FC = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
+  const setToken = useAuthStore(s => s.setToken);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
       const res = await api.post("/login", { email, password });
-      localStorage.setItem("token", res.data.access_token);
+      setToken(res.data.access_token);
       navigate("/");
     } catch {
       alert("Credenziali errate");


### PR DESCRIPTION
## Summary
- wire LoginPage to Zustand store for auth token
- reset auth token on logout via Header

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685dbce818a48323acfbb310bc97d054