### PR TITLE
Fix date-fns import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "axios": "^1.3.4",
+    "date-fns": "^4.1.0",
     "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-big-calendar": "^1.5.0",


### PR DESCRIPTION
## Summary
- include `date-fns` as a runtime dependency

## Testing
- `git show -n 1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685dbdc897448323a606d88d99ad2aee