### PR TITLE
Switch events and todo pages to API

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -1,30 +1,100 @@
-import React, { useState } from 'react';
-import useLocalStorage from '../hooks/useLocalStorage';
+import React, { useEffect, useState } from 'react';
+import api from '../api/axios';
 import './ListPages.css';
 
 interface EventItem { id: string; title: string; date: string; }
 
 export default function EventsPage() {
-  const [events, setEvents] = useLocalStorage<EventItem[]>('events', []);
+  const [events, setEvents] = useState<EventItem[]>([]);
   const [title, setTitle] = useState('');
   const [date, setDate] = useState('');
   const [editingId, setEditingId] = useState<string | null>(null);
 
   const resetForm = () => { setTitle(''); setDate(''); setEditingId(null); };
 
-  const onSubmit = (e: React.FormEvent) => {
+  const saveLocal = (data: EventItem[]) => {
+    localStorage.setItem('events', JSON.stringify(data));
+  };
+
+  useEffect(() => {
+    const fetchEvents = async () => {
+      if (navigator.onLine) {
+        try {
+          const res = await api.get<EventItem[]>('/events');
+          setEvents(res.data);
+          saveLocal(res.data);
+          return;
+        } catch {
+          // fall back to local storage
+        }
+      }
+      const stored = localStorage.getItem('events');
+      if (stored) setEvents(JSON.parse(stored));
+    };
+    fetchEvents();
+  }, []);
+
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!title || !date) return;
+
     if (editingId) {
-      setEvents(events.map(ev => ev.id === editingId ? { ...ev, title, date } : ev));
+      if (navigator.onLine) {
+        try {
+          const res = await api.put<EventItem>(`/events/${editingId}`,
+            { title, date });
+          const updated = events.map(ev => ev.id === editingId ? res.data : ev);
+          setEvents(updated);
+          saveLocal(updated);
+        } catch {
+          const updated = events.map(ev =>
+            ev.id === editingId ? { ...ev, title, date } : ev);
+          setEvents(updated);
+          saveLocal(updated);
+        }
+      } else {
+        const updated = events.map(ev =>
+          ev.id === editingId ? { ...ev, title, date } : ev);
+        setEvents(updated);
+        saveLocal(updated);
+      }
     } else {
-      setEvents([...events, { id: Date.now().toString(), title, date }]);
+      if (navigator.onLine) {
+        try {
+          const res = await api.post<EventItem>('/events', { title, date });
+          const updated = [...events, res.data];
+          setEvents(updated);
+          saveLocal(updated);
+        } catch {
+          const newItem = { id: Date.now().toString(), title, date };
+          const updated = [...events, newItem];
+          setEvents(updated);
+          saveLocal(updated);
+        }
+      } else {
+        const newItem = { id: Date.now().toString(), title, date };
+        const updated = [...events, newItem];
+        setEvents(updated);
+        saveLocal(updated);
+      }
     }
+
     resetForm();
   };
 
   const onEdit = (item: EventItem) => { setEditingId(item.id); setTitle(item.title); setDate(item.date); };
-  const onDelete = (id: string) => setEvents(events.filter(e => e.id !== id));
+  const onDelete = async (id: string) => {
+    if (navigator.onLine) {
+      try {
+        await api.delete(`/events/${id}`);
+      } catch {
+        // ignore and remove locally
+      }
+    }
+    const updated = events.filter(e => e.id !== id);
+    setEvents(updated);
+    saveLocal(updated);
+  };
 
   return (
     <div className="list-page">

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,30 +1,97 @@
-import React, { useState } from 'react';
-import useLocalStorage from '../hooks/useLocalStorage';
+import React, { useEffect, useState } from 'react';
+import api from '../api/axios';
 import './ListPages.css';
 
 interface TodoItem { id: string; text: string; due: string; }
 
 export default function TodoPage() {
-  const [todos, setTodos] = useLocalStorage<TodoItem[]>('todos', []);
+  const [todos, setTodos] = useState<TodoItem[]>([]);
   const [text, setText] = useState('');
   const [due, setDue] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
 
   const reset = () => { setText(''); setDue(''); setEdit(null); };
 
-  const onSubmit = (e: React.FormEvent) => {
+  const saveLocal = (data: TodoItem[]) => {
+    localStorage.setItem('todos', JSON.stringify(data));
+  };
+
+  useEffect(() => {
+    const fetchTodos = async () => {
+      if (navigator.onLine) {
+        try {
+          const res = await api.get<TodoItem[]>('/todos');
+          setTodos(res.data);
+          saveLocal(res.data);
+          return;
+        } catch {
+          // use fallback
+        }
+      }
+      const stored = localStorage.getItem('todos');
+      if (stored) setTodos(JSON.parse(stored));
+    };
+    fetchTodos();
+  }, []);
+
+  const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!text || !due) return;
+
     if (edit) {
-      setTodos(todos.map(t => t.id === edit ? { ...t, text, due } : t));
+      if (navigator.onLine) {
+        try {
+          const res = await api.put<TodoItem>(`/todos/${edit}`, { text, due });
+          const updated = todos.map(t => t.id === edit ? res.data : t);
+          setTodos(updated);
+          saveLocal(updated);
+        } catch {
+          const updated = todos.map(t => t.id === edit ? { ...t, text, due } : t);
+          setTodos(updated);
+          saveLocal(updated);
+        }
+      } else {
+        const updated = todos.map(t => t.id === edit ? { ...t, text, due } : t);
+        setTodos(updated);
+        saveLocal(updated);
+      }
     } else {
-      setTodos([...todos, { id: Date.now().toString(), text, due }]);
+      if (navigator.onLine) {
+        try {
+          const res = await api.post<TodoItem>('/todos', { text, due });
+          const updated = [...todos, res.data];
+          setTodos(updated);
+          saveLocal(updated);
+        } catch {
+          const newItem = { id: Date.now().toString(), text, due };
+          const updated = [...todos, newItem];
+          setTodos(updated);
+          saveLocal(updated);
+        }
+      } else {
+        const newItem = { id: Date.now().toString(), text, due };
+        const updated = [...todos, newItem];
+        setTodos(updated);
+        saveLocal(updated);
+      }
     }
+
     reset();
   };
 
   const onEdit = (t: TodoItem) => { setEdit(t.id); setText(t.text); setDue(t.due); };
-  const onDelete = (id: string) => setTodos(todos.filter(t => t.id !== id));
+  const onDelete = async (id: string) => {
+    if (navigator.onLine) {
+      try {
+        await api.delete(`/todos/${id}`);
+      } catch {
+        // ignore
+      }
+    }
+    const updated = todos.filter(t => t.id !== id);
+    setTodos(updated);
+    saveLocal(updated);
+  };
 
   return (
     <div className="list-page">


### PR DESCRIPTION
## Summary
- switch EventsPage to load and update events via axios
- switch TodoPage to load and update todos via axios
- save responses to localStorage as offline fallback

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685dbf57c9a48323a64c0e0b3cb98409