### PR TITLE
Add notifications fetching and display

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,22 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../store/auth";
+import { useNotificheStore } from "../store/notifiche";
 import "./Header.css";
 
 const Header: React.FC = () => {
   const navigate = useNavigate();
   const setToken = useAuthStore(s => s.setToken);
+  const count = useNotificheStore(s => s.notifications.filter(n => !n.read).length);
+  const fetchNotifications = useNotificheStore(s => s.fetch);
   const logout = () => {
     setToken(null);
     navigate("/login");
   };
+
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
 
   return (
     <header className="site-header">
@@ -22,7 +29,7 @@ const Header: React.FC = () => {
         <Link to="/events">Eventi</Link>
         <Link to="/todo">To-Do</Link>
         <Link to="/determinazioni">Determine</Link>
-        <Link to="/notifiche">Notifiche 🔔</Link>
+        <Link to="/notifiche">Notifiche 🔔{count ? ` (${count})` : ''}</Link>
         <button onClick={logout}>Esci</button>
       </nav>
     </header>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
+import { useNotificheStore } from '../store/notifiche';
 
 interface EventItem { id: string; title: string; date: string; }
 interface TodoItem { id: string; text: string; due: string; }
@@ -11,11 +12,18 @@ export default function Dashboard() {
   const [events] = useLocalStorage<EventItem[]>('events', []);
   const [todos] = useLocalStorage<TodoItem[]>('todos', []);
   const [determinations] = useLocalStorage<Determination[]>('determinations', []);
+  const notifications = useNotificheStore(s => s.notifications);
+  const fetchNotifications = useNotificheStore(s => s.fetch);
+
+  useEffect(() => {
+    fetchNotifications();
+  }, [fetchNotifications]);
 
   const today = new Date();
   const upcomingEvents = events.filter(e => differenceInCalendarDays(parseISO(e.date), today) <= 3);
   const upcomingTodos = todos.filter(t => differenceInCalendarDays(parseISO(t.due), today) <= 3);
   const upcomingDeterminations = determinations.filter(d => differenceInCalendarDays(parseISO(d.due), today) <= 7);
+  const unreadNotifications = notifications.filter(n => !n.read);
 
   return (
     <div className="dashboard">
@@ -27,6 +35,17 @@ export default function Dashboard() {
           width="100%"
           height="600"
         ></iframe>
+      </div>
+      <div className="notifications">
+        <h2>Ultime notifiche</h2>
+        <ul>
+          {unreadNotifications.map(n => (
+            <li key={n.id}>{n.message}</li>
+          ))}
+          {!unreadNotifications.length && (
+            <li>Nessuna notifica.</li>
+          )}
+        </ul>
       </div>
       <div className="notifications">
         <h2>Prossime scadenze</h2>

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,10 +1,24 @@
-import React from "react";
+import React, { useEffect } from 'react';
+import { useNotificheStore } from '../store/notifiche';
+import './ListPages.css';
 
 const NotificationsPage: React.FC = () => {
+  const notifications = useNotificheStore(s => s.notifications);
+  const fetch = useNotificheStore(s => s.fetch);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
   return (
     <div className="list-page">
       <h2>Notifiche</h2>
-      <p>Non ci sono notifiche da mostrare.</p>
+      <ul className="item-list">
+        {notifications.map(n => (
+          <li key={n.id}>{n.message}</li>
+        ))}
+        {!notifications.length && <li>Nessuna notifica.</li>}
+      </ul>
     </div>
   );
 };

--- a/src/store/notifiche.ts
+++ b/src/store/notifiche.ts
@@ -1,3 +1,26 @@
 import { create } from 'zustand';
-interface NotificheState { count: number; setCount: (n: number) => void; }
-export const useNotificheStore = create<NotificheState>(set => ({ count: 0, setCount: (n) => set({ count: n }) }));
+import api from '../api/axios';
+import { useAuthStore } from './auth';
+
+export interface Notification {
+  id: number;
+  message: string;
+  read?: boolean;
+}
+
+interface NotificheState {
+  notifications: Notification[];
+  fetch: () => Promise<void>;
+}
+
+export const useNotificheStore = create<NotificheState>((set) => ({
+  notifications: [],
+  fetch: async () => {
+    const token = useAuthStore.getState().token;
+    if (!token) return;
+    const res = await api.get('/notifications', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    set({ notifications: res.data });
+  }
+}));


### PR DESCRIPTION
## Summary
- fetch notifications from API via zustand store
- show notifications in their own page
- display unread notifications and upcoming deadlines on dashboard
- show unread notification count in header link

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dbf55e028832396e6a4e9f9ffa93b