### PR TITLE
Fix login page styles

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { useAuthStore } from "../store/auth";
-import "./LoginPage.css";
 
 const LoginPage: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -22,26 +21,28 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="login-wrapper">
-      <img src="/logo.png" alt="Logo" className="login-logo" />
-      <form className="login-form" onSubmit={onSubmit}>
-        <h1>Segretaria Digitale</h1>
-        <input
-          type="email"
-          placeholder="Email istituzionale"
-          value={email}
-          onChange={e => setEmail(e.target.value)}
-          required
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={e => setPassword(e.target.value)}
-          required
-        />
-        <button type="submit">Accedi</button>
-      </form>
+    <div className="login-page">
+      <div className="login-card">
+        <img src="/logo.png" alt="Logo" className="login-logo" />
+        <form className="login-form" onSubmit={onSubmit}>
+          <h1>Segretaria Digitale</h1>
+          <input
+            type="email"
+            placeholder="Email istituzionale"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+          <button type="submit">Accedi</button>
+        </form>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove nonexistent LoginPage.css import
- wrap login content in `login-page` and `login-card` containers

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_685dc13256108323bcf7817548eac790