### PR TITLE
Integrate Google Calendar events

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://apis.google.com/js/api.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -1,0 +1,58 @@
+interface GapiWindow extends Window {
+  gapi: any;
+}
+
+const CLIENT_ID = import.meta.env.VITE_GAPI_CLIENT_ID;
+const API_KEY = import.meta.env.VITE_GAPI_API_KEY;
+const DISCOVERY_DOCS = [
+  'https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest',
+];
+const SCOPES = 'https://www.googleapis.com/auth/calendar.events';
+
+export const signIn = () => {
+  return new Promise<void>((resolve, reject) => {
+    const gapi = (window as GapiWindow).gapi;
+    if (!gapi) {
+      reject(new Error('gapi not loaded'));
+      return;
+    }
+    gapi.load('client:auth2', async () => {
+      try {
+        await gapi.client.init({
+          apiKey: API_KEY,
+          clientId: CLIENT_ID,
+          discoveryDocs: DISCOVERY_DOCS,
+          scope: SCOPES,
+        });
+        await gapi.auth2.getAuthInstance().signIn();
+        resolve();
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+};
+
+export const listEvents = async () => {
+  const gapi = (window as GapiWindow).gapi;
+  const res = await gapi.client.calendar.events.list({
+    calendarId: 'primary',
+    singleEvents: true,
+    orderBy: 'startTime',
+    timeMin: new Date(0).toISOString(),
+  });
+  return res.result.items || [];
+};
+
+export const createEvent = async (event: {
+  summary: string;
+  start: { date: string };
+  end: { date: string };
+}) => {
+  const gapi = (window as GapiWindow).gapi;
+  const res = await gapi.client.calendar.events.insert({
+    calendarId: 'primary',
+    resource: event,
+  });
+  return res.result;
+};


### PR DESCRIPTION
## Summary
- add Google Calendar helper module with sign-in, list and create functions
- load gapi script
- refactor EventsPage to pull and create events via Google Calendar

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685dc25391548323b5a2e2ba9ade212a