### PR TITLE
Add Jest and initial tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ npm run serve
 
 This serves the `dist` directory using Vite's preview mode.
 
+## Testing
+
+Run the Jest test suite:
+
+```bash
+npm test
+```
+
+The tests use Jest together with React Testing Library.
+
 ## Backend API
 
 The frontend expects a REST backend exposing at least the following endpoints:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,10 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testMatch: ['**/?(*.)+(test).[tj]s?(x)']
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "vite --host --port 3000",
     "build": "chmod +x node_modules/.bin/vite && vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^1.3.4",
@@ -19,6 +20,12 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.3",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.1",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/components/__tests__/ProtectedRoute.test.tsx
+++ b/src/components/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import ProtectedRoute from '../ProtectedRoute';
+import { useAuthStore } from '../../store/auth';
+
+jest.mock('../../store/auth');
+
+const mockedUseAuthStore = useAuthStore as jest.Mock;
+
+describe('ProtectedRoute', () => {
+  it('renders children when token exists', () => {
+    mockedUseAuthStore.mockImplementation((sel: any) => sel({ token: 'abc' }));
+
+    render(
+      <MemoryRouter initialEntries={["/private"]}>
+        <Routes>
+          <Route
+            path="/private"
+            element={
+              <ProtectedRoute>
+                <div>Private</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Private')).toBeInTheDocument();
+  });
+
+  it('redirects to login when token is missing', () => {
+    mockedUseAuthStore.mockImplementation((sel: any) => sel({ token: null }));
+
+    render(
+      <MemoryRouter initialEntries={["/private"]}>
+        <Routes>
+          <Route
+            path="/private"
+            element={
+              <ProtectedRoute>
+                <div>Private</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>Login</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Login')).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EventsPage from '../EventsPage';
+import api from '../../api/axios';
+
+jest.mock('../../api/axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+beforeEach(() => {
+  localStorage.clear();
+  mockedApi.get.mockResolvedValue({ data: [] });
+});
+
+describe('EventsPage', () => {
+  it('loads events from localStorage', async () => {
+    localStorage.setItem('events', JSON.stringify([{ id: '1', title: 'Test', date: '2023-01-01' }]));
+
+    render(<EventsPage />);
+
+    expect(await screen.findByText('Test')).toBeInTheDocument();
+  });
+
+  it('adds new event offline', async () => {
+    Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
+
+    const { container } = render(<EventsPage />);
+
+    await userEvent.type(screen.getByPlaceholderText('Titolo'), 'My Event');
+    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
+    await userEvent.type(dateInput, '2023-05-01');
+    await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
+
+    expect(await screen.findByText('My Event')).toBeInTheDocument();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add Jest with React Testing Library configuration
- write tests for `ProtectedRoute` and `EventsPage`
- document test execution in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc256f8148323885ac7b4a0ac9f95