### PR TITLE
Improve styling and add footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Segretaria Digitale</title>
 
-    <!-- Poppins font -->
+    <!-- Roboto font -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-router-dom";
 
 import Header from "./components/Header";
+import Footer from "./components/Footer";
 import ProtectedRoute from "./components/ProtectedRoute";
 
 import LoginPage from "./pages/LoginPage";
@@ -25,6 +26,7 @@ const ProtectedLayout: React.FC = () => (
     <main className="app-container">
       <Outlet />
     </main>
+    <Footer />
   </>
 );
 

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,0 +1,7 @@
+.site-footer {
+  text-align: center;
+  padding: 0.5rem 0;
+  font-size: 0.9rem;
+  background: #f4f4f4;
+  color: #333;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './Footer.css';
+
+const Footer: React.FC = () => (
+  <footer className="site-footer">© M.Fenaroli 2k25</footer>
+);
+
+export default Footer;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -5,16 +5,25 @@
   align-items: center;
   background-color: #0066cc;
   color: #fff;
-  padding: 0.5rem 1rem;
+  padding: 1rem 1.5rem;
 }
-.site-header a {
+.site-header nav a {
   color: #fff;
   margin-right: 1rem;
   text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+}
+.site-header nav a:hover {
+  text-decoration: underline;
 }
 .site-header .logo-title {
   display: flex;
   align-items: center;
+}
+.site-header h1 {
+  font-size: 1.6rem;
+  margin: 0;
 }
 .small-logo {
   height: 40px;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 /* Styles based on the "grafica istituzionale" guidelines
    https://designers.italia.it/kit/grafica/ */
-@import url('https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
 * {
   box-sizing: border-box;
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  font-family: 'Titillium Web', sans-serif;
+  font-family: 'Roboto', sans-serif;
   background-color: #f4f4f4;
   color: #333;
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { useAuthStore } from "../store/auth";
+import Footer from "../components/Footer";
 
 const LoginPage: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -21,10 +22,11 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <div className="login-page">
-      <div className="login-card">
-        <img src="/logo.png" alt="Logo" className="login-logo" />
-        <form className="login-form" onSubmit={onSubmit}>
+    <>
+      <div className="login-page">
+        <div className="login-card">
+          <img src="/logo.png" alt="Logo" className="login-logo" />
+          <form className="login-form" onSubmit={onSubmit}>
           <h1>Segretaria Digitale</h1>
           <input
             type="email"
@@ -40,10 +42,12 @@ const LoginPage: React.FC = () => {
             onChange={e => setPassword(e.target.value)}
             required
           />
-          <button type="submit">Accedi</button>
-        </form>
+            <button type="submit">Accedi</button>
+          </form>
+        </div>
       </div>
-    </div>
+      <Footer />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- use the Roboto font instead of Poppins
- enhance header navigation look and larger title
- add a site footer component with copyright notice
- use the footer across protected pages and the login page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc67a2b9c8323b642f5dca952c9dc