### PR TITLE
Enhance header style

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Segretaria Digitale</title>
 
-    <!-- Roboto font -->
+    <!-- Titillium Web font -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -3,16 +3,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background-color: #0066cc;
+  background-color: #A52019;
   color: #fff;
-  padding: 1rem 1.5rem;
+  padding: 1.5rem 1.5rem;
 }
 .site-header nav a {
   color: #fff;
   margin-right: 1rem;
   text-decoration: none;
   font-weight: 600;
-  font-size: 1rem;
+  font-size: 1.1rem;
 }
 .site-header nav a:hover {
   text-decoration: underline;
@@ -22,16 +22,16 @@
   align-items: center;
 }
 .site-header h1 {
-  font-size: 1.6rem;
+  font-size: 2rem;
   margin: 0;
 }
 .small-logo {
-  height: 40px;
+  height: 60px;
   margin-right: 0.5rem;
 }
 .site-header button {
   background: #fff;
-  color: #0066cc;
+  color: #A52019;
   border: none;
   padding: 0.25rem 0.5rem;
   cursor: pointer;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 /* Styles based on the "grafica istituzionale" guidelines
    https://designers.italia.it/kit/grafica/ */
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&display=swap');
 
 * {
   box-sizing: border-box;
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Titillium Web', sans-serif;
   background-color: #f4f4f4;
   color: #333;
 }


### PR DESCRIPTION
## Summary
- enlarge site header and logo
- switch theme color to institutional red #A52019
- use Titillium Web font across the site

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc8f412d083238c0d4f7dfaa884e4