### PR TITLE
Update event forms with description and time

### DIFF
--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -46,8 +46,9 @@ export const listEvents = async () => {
 
 export const createEvent = async (event: {
   summary: string;
-  start: { date: string };
-  end: { date: string };
+  description?: string;
+  start: { dateTime: string };
+  end: { dateTime: string };
 }) => {
   const gapi = (window as GapiWindow).gapi;
   const res = await gapi.client.calendar.events.insert({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,13 @@ import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { useNotificheStore } from '../store/notifiche';
 
-interface EventItem { id: string; title: string; date: string; }
+interface EventItem {
+  id: string;
+  title: string;
+  description: string;
+  dateTime: string;
+  isPublic: boolean;
+}
 interface TodoItem { id: string; text: string; due: string; }
 interface Determination { id: string; title: string; due: string; }
 
@@ -20,7 +26,9 @@ export default function Dashboard() {
   }, [fetchNotifications]);
 
   const today = new Date();
-  const upcomingEvents = events.filter(e => differenceInCalendarDays(parseISO(e.date), today) <= 3);
+  const upcomingEvents = events.filter(
+    e => differenceInCalendarDays(parseISO(e.dateTime), today) <= 3
+  );
   const upcomingTodos = todos.filter(t => differenceInCalendarDays(parseISO(t.due), today) <= 3);
   const upcomingDeterminations = determinations.filter(d => differenceInCalendarDays(parseISO(d.due), today) <= 7);
   const unreadNotifications = notifications.filter(n => !n.read);
@@ -51,7 +59,9 @@ export default function Dashboard() {
         <h2>Prossime scadenze</h2>
         <ul>
           {upcomingEvents.map(e => (
-            <li key={e.id}>Evento: {e.title} – {new Date(e.date).toLocaleDateString()}</li>
+            <li key={e.id}>
+              Evento: {e.title} – {new Date(e.dateTime).toLocaleDateString()}
+            </li>
           ))}
           {upcomingTodos.map(t => (
             <li key={t.id}>To-Do: {t.text} – {new Date(t.due).toLocaleDateString()}</li>

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -2,15 +2,29 @@ import React, { useEffect, useState } from 'react';
 import { signIn, listEvents, createEvent } from '../api/googleCalendar';
 import './ListPages.css';
 
-interface EventItem { id: string; title: string; date: string; }
+interface EventItem {
+  id: string;
+  title: string;
+  description: string;
+  dateTime: string;
+  isPublic: boolean;
+}
 
 export default function EventsPage() {
   const [events, setEvents] = useState<EventItem[]>([]);
   const [title, setTitle] = useState('');
-  const [date, setDate] = useState('');
+  const [description, setDescription] = useState('');
+  const [dateTime, setDateTime] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const resetForm = () => { setTitle(''); setDate(''); setEditingId(null); };
+  const resetForm = () => {
+    setTitle('');
+    setDescription('');
+    setDateTime('');
+    setIsPublic(false);
+    setEditingId(null);
+  };
 
   const saveLocal = (data: EventItem[]) => {
     localStorage.setItem('events', JSON.stringify(data));
@@ -25,7 +39,9 @@ export default function EventsPage() {
           const mapped = res.map((ev: any) => ({
             id: ev.id,
             title: ev.summary,
-            date: ev.start?.date || ev.start?.dateTime?.slice(0, 10),
+            description: ev.description || '',
+            dateTime: ev.start?.dateTime || ev.start?.date || '',
+            isPublic: ev.visibility === 'public',
           }));
           setEvents(mapped);
           saveLocal(mapped);
@@ -35,18 +51,30 @@ export default function EventsPage() {
         }
       }
       const stored = localStorage.getItem('events');
-      if (stored) setEvents(JSON.parse(stored));
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        const normalized = parsed.map((ev: any) => ({
+          id: ev.id,
+          title: ev.title || ev.titolo,
+          description: ev.description || ev.descrizione || '',
+          dateTime: ev.dateTime || ev.date || ev.data_ora || '',
+          isPublic: ev.isPublic ?? ev.is_public ?? false,
+        }));
+        setEvents(normalized);
+      }
     };
     fetchEvents();
   }, []);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!title || !date) return;
+    if (!title || !dateTime) return;
 
     if (editingId) {
       const updated = events.map(ev =>
-        ev.id === editingId ? { ...ev, title, date } : ev);
+        ev.id === editingId
+          ? { ...ev, title, description, dateTime, isPublic }
+          : ev);
       setEvents(updated);
       saveLocal(updated);
     } else {
@@ -54,21 +82,40 @@ export default function EventsPage() {
         try {
           const res = await createEvent({
             summary: title,
-            start: { date },
-            end: { date },
+            description,
+            start: { dateTime },
+            end: { dateTime },
           });
-          const newItem = { id: res.id, title, date } as EventItem;
+          const newItem: EventItem = {
+            id: res.id,
+            title,
+            description,
+            dateTime,
+            isPublic,
+          };
           const updated = [...events, newItem];
           setEvents(updated);
           saveLocal(updated);
         } catch {
-          const newItem = { id: Date.now().toString(), title, date };
+          const newItem: EventItem = {
+            id: Date.now().toString(),
+            title,
+            description,
+            dateTime,
+            isPublic,
+          };
           const updated = [...events, newItem];
           setEvents(updated);
           saveLocal(updated);
         }
       } else {
-        const newItem = { id: Date.now().toString(), title, date };
+        const newItem: EventItem = {
+          id: Date.now().toString(),
+          title,
+          description,
+          dateTime,
+          isPublic,
+        };
         const updated = [...events, newItem];
         setEvents(updated);
         saveLocal(updated);
@@ -78,7 +125,13 @@ export default function EventsPage() {
     resetForm();
   };
 
-  const onEdit = (item: EventItem) => { setEditingId(item.id); setTitle(item.title); setDate(item.date); };
+  const onEdit = (item: EventItem) => {
+    setEditingId(item.id);
+    setTitle(item.title);
+    setDescription(item.description);
+    setDateTime(item.dateTime);
+    setIsPublic(item.isPublic);
+  };
   const onDelete = (id: string) => {
     const updated = events.filter(e => e.id !== id);
     setEvents(updated);
@@ -89,15 +142,44 @@ export default function EventsPage() {
     <div className="list-page">
       <h2>Eventi</h2>
       <form onSubmit={onSubmit} className="item-form">
-        <input placeholder="Titolo" value={title} onChange={e => setTitle(e.target.value)} />
-        <input type="date" value={date} onChange={e => setDate(e.target.value)} />
+        <input
+          placeholder="Titolo"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <textarea
+          placeholder="Descrizione"
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+        />
+        <input
+          type="datetime-local"
+          value={dateTime}
+          onChange={e => setDateTime(e.target.value)}
+        />
+        <label>
+          <input
+            type="checkbox"
+            checked={isPublic}
+            onChange={e => setIsPublic(e.target.checked)}
+          />
+          Pubblico
+        </label>
         <button type="submit">{editingId ? 'Salva' : 'Aggiungi'}</button>
-        {editingId && <button type="button" onClick={resetForm}>Annulla</button>}
+        {editingId && (
+          <button type="button" onClick={resetForm}>
+            Annulla
+          </button>
+        )}
       </form>
       <ul className="item-list">
         {events.map(ev => (
           <li key={ev.id}>
-            <span>{ev.title} – {new Date(ev.date).toLocaleDateString()}</span>
+            <span>
+              {ev.title} – {new Date(ev.dateTime).toLocaleString()}
+              {ev.description && ` – ${ev.description}`}
+              {ev.isPublic && ' (Pubblico)'}
+            </span>
             <div>
               <button onClick={() => onEdit(ev)}>Modifica</button>
               <button onClick={() => onDelete(ev.id)}>Elimina</button>

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -22,7 +22,18 @@ beforeEach(() => {
 
 describe('EventsPage', () => {
   it('loads events from localStorage', async () => {
-    localStorage.setItem('events', JSON.stringify([{ id: '1', title: 'Test', date: '2023-01-01' }]));
+    localStorage.setItem(
+      'events',
+      JSON.stringify([
+        {
+          id: '1',
+          title: 'Test',
+          description: 'desc',
+          dateTime: '2023-01-01T10:00',
+          isPublic: false,
+        },
+      ])
+    );
 
     render(<EventsPage />);
 
@@ -35,8 +46,13 @@ describe('EventsPage', () => {
     const { container } = render(<EventsPage />);
 
     await userEvent.type(screen.getByPlaceholderText('Titolo'), 'My Event');
-    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
-    await userEvent.type(dateInput, '2023-05-01');
+    await userEvent.type(
+      screen.getByPlaceholderText('Descrizione'),
+      'Desc'
+    );
+    const dateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+    await userEvent.type(dateInput, '2023-05-01T12:00');
+    await userEvent.click(screen.getByLabelText(/pubblico/i));
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 
     expect(await screen.findByText('My Event')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- support description, dateTime and visibility when creating events
- adjust event display and dashboard view
- extend Google Calendar API wrapper
- update tests for new form fields

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e48d2610483239d4ae896c2801166