### PR TITLE
Add auth header interceptor

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,3 +1,15 @@
 import axios from 'axios';
+import { useAuthStore } from '../store/auth';
+
 const api = axios.create({ baseURL: import.meta.env.VITE_API_URL || '' });
+
+api.interceptors.request.use((config) => {
+  const token = useAuthStore.getState().token || localStorage.getItem('token');
+  if (token) {
+    config.headers = config.headers || {};
+    (config.headers as any).Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export default api;

--- a/src/store/notifiche.ts
+++ b/src/store/notifiche.ts
@@ -18,9 +18,7 @@ export const useNotificheStore = create<NotificheState>((set) => ({
   fetch: async () => {
     const token = useAuthStore.getState().token;
     if (!token) return;
-    const res = await api.get('/notifications', {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await api.get('/notifications');
     set({ notifications: res.data });
   }
 }));


### PR DESCRIPTION
## Summary
- auto inject `Authorization` header using request interceptor
- call notifications API without manual header

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4fee868483239ec741d644e2242e