### PR TITLE
Extend determinations fields

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,12 +12,21 @@ interface EventItem {
   isPublic: boolean;
 }
 interface TodoItem { id: string; text: string; due: string; }
-interface Determination { id: string; title: string; due: string; }
+interface Determination {
+  id: string;
+  capitolo: string;
+  numero: string;
+  somma: number;
+  scadenza: string;
+}
 
 export default function Dashboard() {
   const [events] = useLocalStorage<EventItem[]>('events', []);
   const [todos] = useLocalStorage<TodoItem[]>('todos', []);
-  const [determinations] = useLocalStorage<Determination[]>('determinations', []);
+  const [determinations] = useLocalStorage<Determination[]>(
+    'determinations-v2',
+    []
+  );
   const notifications = useNotificheStore(s => s.notifications);
   const fetchNotifications = useNotificheStore(s => s.fetch);
 
@@ -30,7 +39,9 @@ export default function Dashboard() {
     e => differenceInCalendarDays(parseISO(e.dateTime), today) <= 3
   );
   const upcomingTodos = todos.filter(t => differenceInCalendarDays(parseISO(t.due), today) <= 3);
-  const upcomingDeterminations = determinations.filter(d => differenceInCalendarDays(parseISO(d.due), today) <= 7);
+  const upcomingDeterminations = determinations.filter(
+    d => differenceInCalendarDays(parseISO(d.scadenza), today) <= 7
+  );
   const unreadNotifications = notifications.filter(n => !n.read);
 
   return (
@@ -67,7 +78,10 @@ export default function Dashboard() {
             <li key={t.id}>To-Do: {t.text} – {new Date(t.due).toLocaleDateString()}</li>
           ))}
           {upcomingDeterminations.map(d => (
-            <li key={d.id}>Determina: {d.title} – {new Date(d.due).toLocaleDateString()}</li>
+            <li key={d.id}>
+              Determina: {d.capitolo}/{d.numero} –{' '}
+              {new Date(d.scadenza).toLocaleDateString()}
+            </li>
           ))}
           {!upcomingEvents.length && !upcomingTodos.length && !upcomingDeterminations.length && (
             <li>Nessuna scadenza imminente.</li>

--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -2,43 +2,99 @@ import React, { useState } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import './ListPages.css';
 
-interface Determination { id: string; title: string; due: string; }
+interface Determination {
+  id: string;
+  capitolo: string;
+  numero: string;
+  somma: number;
+  scadenza: string;
+}
 
 const DeterminationsPage: React.FC = () => {
-  const [items, setItems] = useLocalStorage<Determination[]>('determinations', []);
-  const [title, setTitle] = useState('');
-  const [due, setDue] = useState('');
+  const [items, setItems] = useLocalStorage<Determination[]>(
+    'determinations-v2',
+    []
+  );
+  const [capitolo, setCapitolo] = useState('');
+  const [numero, setNumero] = useState('');
+  const [somma, setSomma] = useState('');
+  const [scadenza, setScadenza] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
 
-  const reset = () => { setTitle(''); setDue(''); setEdit(null); };
+  const reset = () => {
+    setCapitolo('');
+    setNumero('');
+    setSomma('');
+    setScadenza('');
+    setEdit(null);
+  };
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!title || !due) return;
+    if (!capitolo || !numero || !somma || !scadenza) return;
+    const parsedSomma = parseFloat(somma);
+    if (isNaN(parsedSomma)) return;
     if (edit) {
-      setItems(items.map(d => d.id === edit ? { ...d, title, due } : d));
+      setItems(
+        items.map(d =>
+          d.id === edit
+            ? { ...d, capitolo, numero, somma: parsedSomma, scadenza }
+            : d
+        )
+      );
     } else {
-      setItems([...items, { id: Date.now().toString(), title, due }]);
+      setItems([
+        ...items,
+        { id: Date.now().toString(), capitolo, numero, somma: parsedSomma, scadenza },
+      ]);
     }
     reset();
   };
 
-  const onEdit = (d: Determination) => { setEdit(d.id); setTitle(d.title); setDue(d.due); };
+  const onEdit = (d: Determination) => {
+    setEdit(d.id);
+    setCapitolo(d.capitolo);
+    setNumero(d.numero);
+    setSomma(d.somma.toString());
+    setScadenza(d.scadenza);
+  };
   const onDelete = (id: string) => setItems(items.filter(d => d.id !== id));
 
   return (
     <div className="list-page">
       <h2>Determine</h2>
       <form onSubmit={onSubmit} className="item-form">
-        <input placeholder="Titolo" value={title} onChange={e => setTitle(e.target.value)} />
-        <input type="date" value={due} onChange={e => setDue(e.target.value)} />
+        <input
+          placeholder="Capitolo"
+          value={capitolo}
+          onChange={e => setCapitolo(e.target.value)}
+        />
+        <input
+          placeholder="Numero"
+          value={numero}
+          onChange={e => setNumero(e.target.value)}
+        />
+        <input
+          type="number"
+          placeholder="Somma"
+          value={somma}
+          onChange={e => setSomma(e.target.value)}
+        />
+        <input
+          type="datetime-local"
+          value={scadenza}
+          onChange={e => setScadenza(e.target.value)}
+        />
         <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>
       <ul className="item-list">
         {items.map(d => (
           <li key={d.id}>
-            <span>{d.title} – {new Date(d.due).toLocaleDateString()}</span>
+            <span>
+              {d.capitolo}/{d.numero} – {d.somma} –{' '}
+              {new Date(d.scadenza).toLocaleString()}
+            </span>
             <div>
               <button onClick={() => onEdit(d)}>Modifica</button>
               <button onClick={() => onDelete(d.id)}>Elimina</button>

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DeterminationsPage from '../DeterminationsPage';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('DeterminationsPage', () => {
+  it('loads determinations from localStorage', async () => {
+    localStorage.setItem(
+      'determinations-v2',
+      JSON.stringify([
+        {
+          id: '1',
+          capitolo: 'A',
+          numero: '1',
+          somma: 10,
+          scadenza: '2023-01-01T00:00',
+        },
+      ])
+    );
+
+    render(<DeterminationsPage />);
+
+    expect(await screen.findByText(/A\/1/)).toBeInTheDocument();
+  });
+
+  it('adds new determination offline', async () => {
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      configurable: true,
+    });
+
+    const { container } = render(<DeterminationsPage />);
+
+    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'B');
+    await userEvent.type(screen.getByPlaceholderText('Numero'), '2');
+    await userEvent.type(screen.getByPlaceholderText('Somma'), '20');
+    const dateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
+    await userEvent.type(dateInput, '2023-05-01T12:00');
+    await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
+
+    expect(await screen.findByText(/B\/2/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- support capitolo/numero/somma/scadenza fields in DeterminationsPage
- reflect new fields in Dashboard
- test DeterminationsPage

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685e4ff3ccd083238d8d2c6a953f922b