### PR TITLE
Add vite env file and react-dom types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jest": "^29.6.0",
     "ts-jest": "^29.1.0",
     "@types/jest": "^29.5.3",
+    "@types/react-dom": "^18.2.7",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.0.1",
     "@testing-library/user-event": "^14.4.3"

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client", "jest"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add `vite-env.d.ts`
- reference `vite/client` and `jest` types in tsconfig
- add `@types/react-dom` as dev dependency

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5287ca4c83239d1b1ddf64de4ff1