### PR TITLE
Refactor auth store initialization

### DIFF
--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,6 +1,22 @@
 import { create } from 'zustand';
-interface AuthState { token: string | null; setToken: (token: string | null) => void; }
-export const useAuthStore = create<AuthState>(set => ({
-  token: localStorage.getItem('token'),
-  setToken: (token) => { if (token) localStorage.setItem('token', token); else localStorage.removeItem('token'); set({ token }); }
-}));
+
+interface AuthState {
+  token: string | null;
+  setToken: (token: string | null) => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => {
+  const getInitialToken = (): string | null => {
+    if (typeof window === 'undefined') return null;
+    return localStorage.getItem('token');
+  };
+
+  return {
+    token: getInitialToken(),
+    setToken: (token) => {
+      if (token) localStorage.setItem('token', token);
+      else localStorage.removeItem('token');
+      set({ token });
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- avoid referencing `localStorage` at module scope
- get token inside the zustand `create` initializer

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5287f8c08323a4ef3059a495be3f