### PR TITLE
Enhance determinazioni form

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,7 +12,13 @@ interface EventItem {
   isPublic: boolean;
 }
 interface TodoItem { id: string; text: string; due: string; }
-interface Determination { id: string; title: string; due: string; }
+interface Determination {
+  id: string;
+  capitolo: string;
+  numero: string;
+  somma: number;
+  scadenza: string;
+}
 
 export default function Dashboard() {
   const [events] = useLocalStorage<EventItem[]>('events', []);
@@ -30,7 +36,9 @@ export default function Dashboard() {
     e => differenceInCalendarDays(parseISO(e.dateTime), today) <= 3
   );
   const upcomingTodos = todos.filter(t => differenceInCalendarDays(parseISO(t.due), today) <= 3);
-  const upcomingDeterminations = determinations.filter(d => differenceInCalendarDays(parseISO(d.due), today) <= 7);
+  const upcomingDeterminations = determinations.filter(
+    d => differenceInCalendarDays(parseISO(d.scadenza), today) <= 7
+  );
   const unreadNotifications = notifications.filter(n => !n.read);
 
   return (
@@ -67,7 +75,10 @@ export default function Dashboard() {
             <li key={t.id}>To-Do: {t.text} – {new Date(t.due).toLocaleDateString()}</li>
           ))}
           {upcomingDeterminations.map(d => (
-            <li key={d.id}>Determina: {d.title} – {new Date(d.due).toLocaleDateString()}</li>
+            <li key={d.id}>
+              Determina: {d.capitolo} – {d.numero} –{' '}
+              {new Date(d.scadenza).toLocaleDateString()}
+            </li>
           ))}
           {!upcomingEvents.length && !upcomingTodos.length && !upcomingDeterminations.length && (
             <li>Nessuna scadenza imminente.</li>

--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -2,43 +2,106 @@ import React, { useState } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import './ListPages.css';
 
-interface Determination { id: string; title: string; due: string; }
+interface Determination {
+  id: string;
+  capitolo: string;
+  numero: string;
+  somma: number;
+  scadenza: string;
+}
 
 const DeterminationsPage: React.FC = () => {
   const [items, setItems] = useLocalStorage<Determination[]>('determinations', []);
-  const [title, setTitle] = useState('');
-  const [due, setDue] = useState('');
+  const [capitolo, setCapitolo] = useState('');
+  const [numero, setNumero] = useState('');
+  const [somma, setSomma] = useState('');
+  const [scadenza, setScadenza] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
 
-  const reset = () => { setTitle(''); setDue(''); setEdit(null); };
+  const reset = () => {
+    setCapitolo('');
+    setNumero('');
+    setSomma('');
+    setScadenza('');
+    setEdit(null);
+  };
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!title || !due) return;
+    if (!capitolo || !numero || !somma || !scadenza) return;
     if (edit) {
-      setItems(items.map(d => d.id === edit ? { ...d, title, due } : d));
+      setItems(items.map(d =>
+        d.id === edit
+          ? {
+              ...d,
+              capitolo,
+              numero,
+              somma: parseFloat(somma),
+              scadenza,
+            }
+          : d
+      ));
     } else {
-      setItems([...items, { id: Date.now().toString(), title, due }]);
+      setItems([
+        ...items,
+        {
+          id: Date.now().toString(),
+          capitolo,
+          numero,
+          somma: parseFloat(somma),
+          scadenza,
+        },
+      ]);
     }
     reset();
   };
 
-  const onEdit = (d: Determination) => { setEdit(d.id); setTitle(d.title); setDue(d.due); };
+  const onEdit = (d: Determination) => {
+    setEdit(d.id);
+    setCapitolo(d.capitolo);
+    setNumero(d.numero);
+    setSomma(String(d.somma));
+    setScadenza(d.scadenza);
+  };
   const onDelete = (id: string) => setItems(items.filter(d => d.id !== id));
 
   return (
     <div className="list-page">
       <h2>Determine</h2>
       <form onSubmit={onSubmit} className="item-form">
-        <input placeholder="Titolo" value={title} onChange={e => setTitle(e.target.value)} />
-        <input type="date" value={due} onChange={e => setDue(e.target.value)} />
+        <input
+          placeholder="Capitolo"
+          value={capitolo}
+          onChange={e => setCapitolo(e.target.value)}
+        />
+        <input
+          placeholder="Numero"
+          value={numero}
+          onChange={e => setNumero(e.target.value)}
+        />
+        <input
+          type="number"
+          step="0.01"
+          placeholder="Somma"
+          value={somma}
+          onChange={e => setSomma(e.target.value)}
+        />
+        <input
+          type="date"
+          value={scadenza}
+          onChange={e => setScadenza(e.target.value)}
+        />
         <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>
       <ul className="item-list">
         {items.map(d => (
           <li key={d.id}>
-            <span>{d.title} – {new Date(d.due).toLocaleDateString()}</span>
+            <span>
+              {d.capitolo} – {d.numero} – €{d.somma} –
+              {" "}
+              {new Date(d.scadenza).toLocaleDateString()}
+            </span>
             <div>
               <button onClick={() => onEdit(d)}>Modifica</button>
               <button onClick={() => onDelete(d.id)}>Elimina</button>

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -10,31 +10,37 @@ describe('DeterminationsPage', () => {
   it('creates a new determination', async () => {
     const { container } = render(<DeterminationsPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Titolo'), 'Det 1');
+    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'C1');
+    await userEvent.type(screen.getByPlaceholderText('Numero'), '001');
+    await userEvent.type(screen.getByPlaceholderText('Somma'), '10');
     const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
     await userEvent.type(dateInput, '2023-06-10');
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 
-    expect(await screen.findByText('Det 1')).toBeInTheDocument();
+    expect(await screen.findByText(/C1/)).toBeInTheDocument();
   });
 
   it('edits an existing determination', async () => {
     localStorage.setItem(
       'determinations',
-      JSON.stringify([{ id: '1', title: 'Det', due: '2023-01-01' }])
+      JSON.stringify([{ id: '1', capitolo: 'A', numero: '1', somma: 5, scadenza: '2023-01-01' }])
     );
 
     const { container } = render(<DeterminationsPage />);
 
-    await screen.findByText('Det');
+    await screen.findByText(/A/);
     await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
-    await userEvent.clear(screen.getByPlaceholderText('Titolo'));
-    await userEvent.type(screen.getByPlaceholderText('Titolo'), 'Updated');
+    await userEvent.clear(screen.getByPlaceholderText('Capitolo'));
+    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'B');
+    await userEvent.clear(screen.getByPlaceholderText('Numero'));
+    await userEvent.type(screen.getByPlaceholderText('Numero'), '2');
+    await userEvent.clear(screen.getByPlaceholderText('Somma'));
+    await userEvent.type(screen.getByPlaceholderText('Somma'), '6');
     const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
     await userEvent.clear(dateInput);
     await userEvent.type(dateInput, '2023-02-02');
     await userEvent.click(screen.getByRole('button', { name: /salva/i }));
 
-    expect(await screen.findByText('Updated')).toBeInTheDocument();
+    expect(await screen.findByText(/B/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- expand determination interface to include capitolo/numero/somma/scadenza
- show new fields in Determinations page and handle editing/deleting
- adapt Dashboard page to new fields
- update DeterminationsPage tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9ab5e24883238952d0296a547875