### PR TITLE
Handle notification fetch errors

### DIFF
--- a/src/store/notifiche.ts
+++ b/src/store/notifiche.ts
@@ -18,7 +18,12 @@ export const useNotificheStore = create<NotificheState>((set) => ({
   fetch: async () => {
     const token = useAuthStore.getState().token;
     if (!token) return;
-    const res = await api.get('/notifications');
-    set({ notifications: res.data });
+    try {
+      const res = await api.get('/notifications');
+      set({ notifications: res.data });
+    } catch (err) {
+      console.error('Failed to fetch notifications', err);
+      set((state) => ({ notifications: state.notifications || [] }));
+    }
   }
 }));


### PR DESCRIPTION
## Summary
- wrap notifications API call in a try/catch
- log errors and retain existing notifications

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec7c79d1c83238595898b0f16fcea