### PR TITLE
Switch pages to table layout

### DIFF
--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -94,21 +94,31 @@ const DeterminationsPage: React.FC = () => {
         <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>
-      <ul className="item-list">
-        {items.map(d => (
-          <li key={d.id}>
-            <span>
-              {d.capitolo} – {d.numero} – €{d.somma} –
-              {" "}
-              {new Date(d.scadenza).toLocaleDateString()}
-            </span>
-            <div>
-              <button onClick={() => onEdit(d)}>Modifica</button>
-              <button onClick={() => onDelete(d.id)}>Elimina</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <table className="item-table">
+        <thead>
+          <tr>
+            <th>Capitolo</th>
+            <th>Numero</th>
+            <th>Somma</th>
+            <th>Scadenza</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map(d => (
+            <tr key={d.id}>
+              <td>{d.capitolo}</td>
+              <td>{d.numero}</td>
+              <td>€{d.somma}</td>
+              <td>{new Date(d.scadenza).toLocaleDateString()}</td>
+              <td>
+                <button onClick={() => onEdit(d)}>Modifica</button>
+                <button onClick={() => onDelete(d.id)}>Elimina</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -172,21 +172,31 @@ export default function EventsPage() {
           </button>
         )}
       </form>
-      <ul className="item-list">
-        {events.map(ev => (
-          <li key={ev.id}>
-            <span>
-              {ev.title} – {new Date(ev.dateTime).toLocaleString()}
-              {ev.description && ` – ${ev.description}`}
-              {ev.isPublic && ' (Pubblico)'}
-            </span>
-            <div>
-              <button onClick={() => onEdit(ev)}>Modifica</button>
-              <button onClick={() => onDelete(ev.id)}>Elimina</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <table className="item-table">
+        <thead>
+          <tr>
+            <th>Titolo</th>
+            <th>Data</th>
+            <th>Descrizione</th>
+            <th>Pubblico?</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.map(ev => (
+            <tr key={ev.id}>
+              <td>{ev.title}</td>
+              <td>{new Date(ev.dateTime).toLocaleString()}</td>
+              <td>{ev.description}</td>
+              <td>{ev.isPublic ? 'S\u00ec' : 'No'}</td>
+              <td>
+                <button onClick={() => onEdit(ev)}>Modifica</button>
+                <button onClick={() => onDelete(ev.id)}>Elimina</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -55,3 +55,34 @@
 .item-list button:hover {
   background: #8B1B13;
 }
+
+.item-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+.item-table th,
+.item-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+.item-table th {
+  background: #f5f5f5;
+  text-align: left;
+}
+.item-table td:last-child {
+  white-space: nowrap;
+}
+.item-table button {
+  margin-left: 0.5rem;
+  background: #A52019;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+.item-table button:hover {
+  background: #8B1B13;
+}

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -13,12 +13,25 @@ const NotificationsPage: React.FC = () => {
   return (
     <div className="list-page">
       <h2>Notifiche</h2>
-      <ul className="item-list">
-        {notifications.map(n => (
-          <li key={n.id}>{n.message}</li>
-        ))}
-        {!notifications.length && <li>Nessuna notifica.</li>}
-      </ul>
+      <table className="item-table">
+        <thead>
+          <tr>
+            <th>Messaggio</th>
+          </tr>
+        </thead>
+        <tbody>
+          {notifications.map(n => (
+            <tr key={n.id}>
+              <td>{n.message}</td>
+            </tr>
+          ))}
+          {!notifications.length && (
+            <tr>
+              <td>Nessuna notifica.</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -102,17 +102,27 @@ export default function TodoPage() {
         <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>
-      <ul className="item-list">
-        {todos.map(t => (
-          <li key={t.id}>
-            <span>{t.text} – {new Date(t.due).toLocaleDateString()}</span>
-            <div>
-              <button onClick={() => onEdit(t)}>Modifica</button>
-              <button onClick={() => onDelete(t.id)}>Elimina</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <table className="item-table">
+        <thead>
+          <tr>
+            <th>Attività</th>
+            <th>Scadenza</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {todos.map(t => (
+            <tr key={t.id}>
+              <td>{t.text}</td>
+              <td>{new Date(t.due).toLocaleDateString()}</td>
+              <td>
+                <button onClick={() => onEdit(t)}>Modifica</button>
+                <button onClick={() => onDelete(t.id)}>Elimina</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display EventsPage list in a table
- display TodoPage list in a table
- display DeterminationsPage list in a table
- display NotificationsPage list in a table
- style `.item-table` for a consistent look

## Testing
- `npm test` *(fails: jest not found)*
- `npm run dev` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685ec8ffbf448323b0b035bb1e007f78