### PR TITLE
Remove unused moment dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "dependencies": {
         "axios": "^1.3.4",
         "date-fns": "^4.1.0",
-        "moment": "^2.29.4",
         "react": "^18.2.0",
-        "react-big-calendar": "^1.5.0",
         "react-calendar": "^6.0.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.0",
@@ -1813,27 +1811,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.48",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
-      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
-      "license": "MIT",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1948,34 +1925,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-big-calendar": {
-      "version": "1.19.4",
-      "resolved": "https://registry.npmjs.org/react-big-calendar/-/react-big-calendar-1.19.4.tgz",
-      "integrity": "sha512-FrvbDx2LF6JAWFD96LU1jjloppC5OgIvMYUYIPzAw5Aq+ArYFPxAjLqXc4DyxfsQDN0TJTMuS/BIbcSB7Pg0YA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "clsx": "^1.2.1",
-        "date-arithmetic": "^4.1.0",
-        "dayjs": "^1.11.7",
-        "dom-helpers": "^5.2.1",
-        "globalize": "^0.1.1",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "luxon": "^3.2.1",
-        "memoize-one": "^6.0.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40",
-        "prop-types": "^15.8.1",
-        "react-overlays": "^5.2.1",
-        "uncontrollable": "^7.2.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17 || ^18 || ^19",
-        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-calendar": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   "dependencies": {
     "axios": "^1.3.4",
     "date-fns": "^4.1.0",
-    "moment": "^2.29.4",
     "react": "^18.2.0",
-    "react-big-calendar": "^1.5.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
     "vite": "^4.5.14",


### PR DESCRIPTION
## Summary
- drop `moment` and `react-big-calendar` from package.json
- manually prune these packages from package-lock

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run build` *(fails: cannot find module `@rollup/rollup-linux-x64-gnu`)*

------
https://chatgpt.com/codex/tasks/task_e_685efe7313ac8323b7c791a2f5291d23