### PR TITLE
Load determinations from backend

### DIFF
--- a/src/api/determinations.ts
+++ b/src/api/determinations.ts
@@ -1,0 +1,26 @@
+import api from './axios'
+
+export interface Determination {
+  id: string
+  capitolo: string
+  numero: string
+  somma: number
+  scadenza: string
+}
+
+export const listDeterminations = (): Promise<Determination[]> =>
+  api.get<Determination[]>('/determinazioni').then(r => r.data)
+
+export const createDetermination = (
+  data: Omit<Determination, 'id'>
+): Promise<Determination> =>
+  api.post<Determination>('/determinazioni', data).then(r => r.data)
+
+export const updateDetermination = (
+  id: string,
+  data: Partial<Omit<Determination, 'id'>>
+): Promise<Determination> =>
+  api.put<Determination>(`/determinazioni/${id}`, data).then(r => r.data)
+
+export const deleteDetermination = (id: string): Promise<void> =>
+  api.delete(`/determinazioni/${id}`).then(() => undefined)


### PR DESCRIPTION
## Summary
- fetch determinations from REST API with new helper methods
- sync Determinations page with server when online, use local storage as fallback

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f07b286348323b09eaccfe5f2b9c3