### PR TITLE
Add GcEvent type

### DIFF
--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -1,5 +1,5 @@
 // src/api/googleCalendar.ts
-import type { GcEvent } from './types'   // definisci GcEvent in un file types.ts se vuoi
+import type { GcEvent } from './types'
 
 const CALENDAR_ID = 'primary'
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,14 @@
+export interface GcEvent {
+  id: string
+  summary: string
+  description?: string
+  start?: {
+    dateTime?: string
+    date?: string
+  }
+  end?: {
+    dateTime?: string
+    date?: string
+  }
+  visibility?: string
+}


### PR DESCRIPTION
## Summary
- add a `GcEvent` interface under `src/api/types.ts`
- remove outdated comment and import `GcEvent` in `googleCalendar.ts`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f098637b4832391094a6611218c61