### PR TITLE
Add Todo API module and refactor TodoPage

### DIFF
--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -1,0 +1,22 @@
+import api from './axios'
+
+export interface Todo {
+  id: string
+  text: string
+  due: string
+}
+
+export const listTodos = (): Promise<Todo[]> =>
+  api.get<Todo[]>('/todos').then(r => r.data)
+
+export const createTodo = (data: Omit<Todo, 'id'>): Promise<Todo> =>
+  api.post<Todo>('/todos', data).then(r => r.data)
+
+export const updateTodo = (
+  id: string,
+  data: Partial<Omit<Todo, 'id'>>
+): Promise<Todo> =>
+  api.put<Todo>(`/todos/${id}`, data).then(r => r.data)
+
+export const deleteTodo = (id: string): Promise<void> =>
+  api.delete(`/todos/${id}`).then(() => undefined)

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,5 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import api from '../api/axios';
+import {
+  listTodos,
+  createTodo,
+  updateTodo,
+  deleteTodo,
+} from '../api/todos';
 import './ListPages.css';
 
 interface TodoItem { id: string; text: string; due: string; }
@@ -20,9 +25,9 @@ export default function TodoPage() {
     const fetchTodos = async () => {
       if (navigator.onLine) {
         try {
-          const res = await api.get<TodoItem[]>('/todos');
-          setTodos(res.data);
-          saveLocal(res.data);
+          const data = await listTodos();
+          setTodos(data);
+          saveLocal(data);
           return;
         } catch {
           // use fallback
@@ -41,25 +46,29 @@ export default function TodoPage() {
     if (edit) {
       if (navigator.onLine) {
         try {
-          const res = await api.put<TodoItem>(`/todos/${edit}`, { text, due });
-          const updated = todos.map(t => t.id === edit ? res.data : t);
+          const res = await updateTodo(edit, { text, due });
+          const updated = todos.map(t => (t.id === edit ? res : t));
           setTodos(updated);
           saveLocal(updated);
         } catch {
-          const updated = todos.map(t => t.id === edit ? { ...t, text, due } : t);
+          const updated = todos.map(t =>
+            t.id === edit ? { ...t, text, due } : t
+          );
           setTodos(updated);
           saveLocal(updated);
         }
       } else {
-        const updated = todos.map(t => t.id === edit ? { ...t, text, due } : t);
+        const updated = todos.map(t =>
+          t.id === edit ? { ...t, text, due } : t
+        );
         setTodos(updated);
         saveLocal(updated);
       }
     } else {
       if (navigator.onLine) {
         try {
-          const res = await api.post<TodoItem>('/todos', { text, due });
-          const updated = [...todos, res.data];
+          const res = await createTodo({ text, due });
+          const updated = [...todos, res];
           setTodos(updated);
           saveLocal(updated);
         } catch {
@@ -83,7 +92,7 @@ export default function TodoPage() {
   const onDelete = async (id: string) => {
     if (navigator.onLine) {
       try {
-        await api.delete(`/todos/${id}`);
+        await deleteTodo(id);
       } catch {
         // ignore
       }

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -1,23 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TodoPage from '../TodoPage';
-import api from '../../api/axios';
+import * as todosApi from '../../api/todos';
 
-jest.mock('../../api/axios', () => ({
+jest.mock('../../api/todos', () => ({
   __esModule: true,
-  default: {
-    get: jest.fn(),
-    post: jest.fn(),
-    put: jest.fn(),
-    delete: jest.fn(),
-  },
+  listTodos: jest.fn(),
+  createTodo: jest.fn(),
+  updateTodo: jest.fn(),
+  deleteTodo: jest.fn(),
 }));
 
-const mockedApi = api as jest.Mocked<typeof api>;
+const mockedApi = todosApi as jest.Mocked<typeof todosApi>;
 
 beforeEach(() => {
   localStorage.clear();
-  mockedApi.get.mockResolvedValue({ data: [] });
+  mockedApi.listTodos.mockResolvedValue([]);
 });
 
 describe('TodoPage offline', () => {


### PR DESCRIPTION
## Summary
- add new API helpers for todos
- refactor TodoPage to use the helpers instead of axios
- update TodoPage tests to mock the new API module

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f09846538832396ea6defb4eeda8f