### PR TITLE
Add integration widget to dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 VITE_API_URL=<backend-url>
 VITE_GAPI_CLIENT_ID=<google-client-id>
 VITE_GAPI_API_KEY=<google-api-key>
+VITE_INTEGRATION_TOKEN=<integration-token>

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ npm install
 cp .env.example .env
 ```
 
-Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID` and
-`VITE_GAPI_API_KEY`.
+Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID`,
+`VITE_GAPI_API_KEY` and `VITE_INTEGRATION_TOKEN`.
+The integration token is required for the third-party widget displayed on the
+dashboard.
 
 ## Development
 

--- a/src/components/IntegrationBox.tsx
+++ b/src/components/IntegrationBox.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+
+const IntegrationBox: React.FC = () => {
+  useEffect(() => {
+    const token = import.meta.env.VITE_INTEGRATION_TOKEN;
+    if (!token) {
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://third-party.example.com/widget.js?token=${token}`;
+    script.async = true;
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
+  return (
+    <div className="integration-box dashboard-section">
+      <h2>Integration</h2>
+      <div id="integration-widget" />
+    </div>
+  );
+};
+
+export default IntegrationBox;
+

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -13,6 +13,16 @@
 .calendar-container {
   width: 100%;
 }
+
+.top-wrapper {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.top-wrapper .dashboard-section {
+  flex: 1;
+}
 .notifications ul {
   list-style: none;
   padding: 0;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
+import IntegrationBox from '../components/IntegrationBox';
 
 interface EventItem {
   id: string;
@@ -25,14 +26,17 @@ export default function Dashboard() {
   return (
     <div className="dashboard">
       <h1>Dashboard</h1>
-      <div className="calendar-container dashboard-section">
-        <iframe
-          title="calendar"
-          src="https://calendar.google.com/calendar/embed?mode=AGENDA"
-          style={{ border: 0 }}
-          width="100%"
-          height="600"
-        ></iframe>
+      <div className="top-wrapper">
+        <div className="calendar-container dashboard-section">
+          <iframe
+            title="calendar"
+            src="https://calendar.google.com/calendar/embed?mode=AGENDA"
+            style={{ border: 0 }}
+            width="100%"
+            height="600"
+          ></iframe>
+        </div>
+        <IntegrationBox />
       </div>
       <div className="upcoming-wrapper">
         <div className="notifications dashboard-section">


### PR DESCRIPTION
## Summary
- add `IntegrationBox` component that loads third-party widget using `VITE_INTEGRATION_TOKEN`
- show `IntegrationBox` next to calendar in dashboard
- tweak dashboard styles with new `.top-wrapper`
- document integration token in README and `.env.example`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c51c8908323b1492e680abaeff7