### PR TITLE
Add labels and update tests

### DIFF
--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -151,24 +151,32 @@ const DeterminationsPage: React.FC = () => {
     <div className="list-page">
       <h2>Determine</h2>
       <form onSubmit={onSubmit} className="item-form">
+        <label htmlFor="det-capitolo">Capitolo</label>
         <input
+          id="det-capitolo"
           placeholder="Capitolo"
           value={capitolo}
           onChange={e => setCapitolo(e.target.value)}
         />
+        <label htmlFor="det-numero">Numero</label>
         <input
+          id="det-numero"
           placeholder="Numero"
           value={numero}
           onChange={e => setNumero(e.target.value)}
         />
+        <label htmlFor="det-somma">Somma</label>
         <input
+          id="det-somma"
           type="number"
           step="0.01"
           placeholder="Somma"
           value={somma}
           onChange={e => setSomma(e.target.value)}
         />
+        <label htmlFor="det-scadenza">Scadenza</label>
         <input
+          id="det-scadenza"
           type="date"
           value={scadenza}
           onChange={e => setScadenza(e.target.value)}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -226,29 +226,34 @@ export default function EventsPage() {
     <div className="list-page">
       <h2>Eventi</h2>
       <form onSubmit={onSubmit} className="item-form">
+        <label htmlFor="ev-title">Titolo</label>
         <input
+          id="ev-title"
           placeholder="Titolo"
           value={form.title}
           onChange={e => setForm({ ...form, title: e.target.value })}
         />
+        <label htmlFor="ev-description">Descrizione</label>
         <textarea
+          id="ev-description"
           placeholder="Descrizione"
           value={form.description}
           onChange={e => setForm({ ...form, description: e.target.value })}
         />
+        <label htmlFor="ev-date">Data e ora</label>
         <input
+          id="ev-date"
           type="datetime-local"
           value={form.dateTime}
           onChange={e => setForm({ ...form, dateTime: e.target.value })}
         />
-        <label>
-          <input
-            type="checkbox"
-            checked={form.isPublic}
-            onChange={e => setForm({ ...form, isPublic: e.target.checked })}
-          />
-          Pubblico
-        </label>
+        <input
+          id="ev-public"
+          type="checkbox"
+          checked={form.isPublic}
+          onChange={e => setForm({ ...form, isPublic: e.target.checked })}
+        />
+        <label htmlFor="ev-public">Pubblico</label>
         <button type="submit">{editing ? 'Salva' : 'Aggiungi'}</button>
         {editing && (
           <button type="button" onClick={resetForm}>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -28,14 +28,18 @@ const LoginPage: React.FC = () => {
           <img src="/logo.png" alt="Logo" className="login-logo" />
           <form className="login-form" onSubmit={onSubmit}>
           <h1>Segretaria Digitale<br/> Polizia Locale Castione della Presolana</h1>
+          <label htmlFor="login-email">Email</label>
           <input
+            id="login-email"
             type="email"
             placeholder="Email istituzionale"
             value={email}
             onChange={e => setEmail(e.target.value)}
             required
           />
+          <label htmlFor="login-password">Password</label>
           <input
+            id="login-password"
             type="password"
             placeholder="Password"
             value={password}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -106,8 +106,10 @@ export default function TodoPage() {
     <div className="list-page">
       <h2>To-Do</h2>
       <form onSubmit={onSubmit} className="item-form">
-        <input placeholder="Attività" value={text} onChange={e => setText(e.target.value)} />
-        <input type="date" value={due} onChange={e => setDue(e.target.value)} />
+        <label htmlFor="todo-text">Attività</label>
+        <input id="todo-text" placeholder="Attività" value={text} onChange={e => setText(e.target.value)} />
+        <label htmlFor="todo-due">Scadenza</label>
+        <input id="todo-due" type="date" value={due} onChange={e => setDue(e.target.value)} />
         <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -10,11 +10,10 @@ describe('DeterminationsPage', () => {
   it('creates a new determination', async () => {
     const { container } = render(<DeterminationsPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'C1');
-    await userEvent.type(screen.getByPlaceholderText('Numero'), '001');
-    await userEvent.type(screen.getByPlaceholderText('Somma'), '10');
-    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
-    await userEvent.type(dateInput, '2023-06-10');
+    await userEvent.type(screen.getByLabelText('Capitolo'), 'C1');
+    await userEvent.type(screen.getByLabelText('Numero'), '001');
+    await userEvent.type(screen.getByLabelText('Somma'), '10');
+    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-06-10');
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 
     expect(await screen.findByText(/C1/)).toBeInTheDocument();
@@ -30,15 +29,14 @@ describe('DeterminationsPage', () => {
 
     await screen.findByText(/A/);
     await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
-    await userEvent.clear(screen.getByPlaceholderText('Capitolo'));
-    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'B');
-    await userEvent.clear(screen.getByPlaceholderText('Numero'));
-    await userEvent.type(screen.getByPlaceholderText('Numero'), '2');
-    await userEvent.clear(screen.getByPlaceholderText('Somma'));
-    await userEvent.type(screen.getByPlaceholderText('Somma'), '6');
-    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
-    await userEvent.clear(dateInput);
-    await userEvent.type(dateInput, '2023-02-02');
+    await userEvent.clear(screen.getByLabelText('Capitolo'));
+    await userEvent.type(screen.getByLabelText('Capitolo'), 'B');
+    await userEvent.clear(screen.getByLabelText('Numero'));
+    await userEvent.type(screen.getByLabelText('Numero'), '2');
+    await userEvent.clear(screen.getByLabelText('Somma'));
+    await userEvent.type(screen.getByLabelText('Somma'), '6');
+    await userEvent.clear(screen.getByLabelText('Scadenza'));
+    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-02-02');
     await userEvent.click(screen.getByRole('button', { name: /salva/i }));
 
     expect(await screen.findByText(/B/)).toBeInTheDocument();

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -45,11 +45,8 @@ describe('EventsPage', () => {
 
     const { container } = render(<EventsPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Titolo'), 'My Event');
-    await userEvent.type(
-      screen.getByPlaceholderText('Descrizione'),
-      'Desc'
-    );
+    await userEvent.type(screen.getByLabelText('Titolo'), 'My Event');
+    await userEvent.type(screen.getByLabelText('Descrizione'), 'Desc');
     const dateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
     await userEvent.type(dateInput, '2023-05-01T12:00');
     await userEvent.click(screen.getByLabelText(/pubblico/i));

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -22,11 +22,10 @@ describe('TodoPage offline', () => {
   it('adds new todo offline', async () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
-    const { container } = render(<TodoPage />);
+    render(<TodoPage />);
 
-    await userEvent.type(screen.getByPlaceholderText('Attività'), 'Task 1');
-    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
-    await userEvent.type(dateInput, '2023-06-01');
+    await userEvent.type(screen.getByLabelText('Attività'), 'Task 1');
+    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-06-01');
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 
     expect(await screen.findByText('Task 1')).toBeInTheDocument();
@@ -36,16 +35,15 @@ describe('TodoPage offline', () => {
     localStorage.setItem('todos', JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01' }]));
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
-    const { container } = render(<TodoPage />);
+    render(<TodoPage />);
 
     await screen.findByText('Task');
     await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
 
-    await userEvent.clear(screen.getByPlaceholderText('Attività'));
-    await userEvent.type(screen.getByPlaceholderText('Attività'), 'Task edited');
-    const dateInput = container.querySelector('input[type="date"]') as HTMLInputElement;
-    await userEvent.clear(dateInput);
-    await userEvent.type(dateInput, '2023-02-02');
+    await userEvent.clear(screen.getByLabelText('Attività'));
+    await userEvent.type(screen.getByLabelText('Attività'), 'Task edited');
+    await userEvent.clear(screen.getByLabelText('Scadenza'));
+    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-02-02');
     await userEvent.click(screen.getByRole('button', { name: /salva/i }));
 
     expect(await screen.findByText('Task edited')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- add `<label>` elements for inputs in Determinations, Events, Todo and Login pages
- update tests to query fields using `getByLabelText`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0e4bc6c483238479aa833460b3d5