### PR TITLE
Add basic OpenAI chat integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ VITE_API_URL=<backend-url>
 VITE_GAPI_CLIENT_ID=<google-client-id>
 VITE_GAPI_API_KEY=<google-api-key>
 VITE_INTEGRATION_TOKEN=<integration-token>
+VITE_OPENAI_KEY=<openai-api-key>

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ cp .env.example .env
 ```
 
 Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID`,
-`VITE_GAPI_API_KEY` and `VITE_INTEGRATION_TOKEN`.
-The integration token is required for the third-party widget displayed on the
-dashboard.
+`VITE_GAPI_API_KEY`, `VITE_INTEGRATION_TOKEN` and `VITE_OPENAI_KEY`.
+The integration token was originally used for a third-party widget. The
+`VITE_OPENAI_KEY` variable is required to enable the chat box shown on the
+dashboard, which sends prompts to the OpenAI API.
 
 ## Development
 
@@ -57,6 +58,11 @@ npm test
 ```
 
 The tests use Jest together with React Testing Library.
+
+## Chat Integration
+
+The dashboard displays a small chat box powered by OpenAI. Configure
+`VITE_OPENAI_KEY` in your `.env` file with a valid API key to enable it.
 
 ## Backend API
 

--- a/src/components/IntegrationBox.tsx
+++ b/src/components/IntegrationBox.tsx
@@ -1,29 +1,64 @@
-import React, { useEffect } from 'react';
+import React, { useState } from 'react';
+import axios from 'axios';
+
+interface Message {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
 
 const IntegrationBox: React.FC = () => {
-  useEffect(() => {
-    const token = import.meta.env.VITE_INTEGRATION_TOKEN;
-    if (!token) {
-      return;
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  const apiKey = import.meta.env.VITE_OPENAI_KEY;
+
+  const sendMessage = async () => {
+    if (!input.trim()) return;
+    const userMessage: Message = { role: 'user', content: input };
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+
+    if (!apiKey) return;
+
+    try {
+      const res = await axios.post(
+        'https://api.openai.com/v1/chat/completions',
+        {
+          model: 'gpt-3.5-turbo',
+          messages: [...messages, userMessage],
+        },
+        { headers: { Authorization: `Bearer ${apiKey}` } }
+      );
+      const assistant = res.data.choices[0].message as Message;
+      setMessages(prev => [...prev, assistant]);
+    } catch (err) {
+      setMessages(prev => [
+        ...prev,
+        { role: 'system', content: 'Error communicating with API' },
+      ]);
     }
-
-    const script = document.createElement('script');
-    script.src = `https://third-party.example.com/widget.js?token=${token}`;
-    script.async = true;
-    document.body.appendChild(script);
-
-    return () => {
-      document.body.removeChild(script);
-    };
-  }, []);
+  };
 
   return (
     <div className="integration-box dashboard-section">
-      <h2>Integration</h2>
-      <div id="integration-widget" />
+      <h2>Chat</h2>
+      <div className="messages">
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.role}>
+            {m.content}
+          </div>
+        ))}
+      </div>
+      <div className="input-row">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Ask something..."
+        />
+        <button onClick={sendMessage}>Send</button>
+      </div>
     </div>
   );
 };
 
 export default IntegrationBox;
-


### PR DESCRIPTION
## Summary
- add `VITE_OPENAI_KEY` placeholder to `.env.example`
- replace IntegrationBox widget with a simple OpenAI-powered chat
- document the new environment variable and chat box usage in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0f8225008323a4279c3e4b5366a2