### PR TITLE
Remove duplicate Titillium font link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Segretaria Digitale</title>
 
-    <!-- Titillium Web font -->
-    <link
-      href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
-
-
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- remove Titillium Web font link from `index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f100a5fb48323b8c8379e47c9cdaa