### PR TITLE
Add backend chat endpoint and update integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,3 @@ VITE_API_URL=<backend-url>
 VITE_GAPI_CLIENT_ID=<google-client-id>
 VITE_GAPI_API_KEY=<google-api-key>
 VITE_INTEGRATION_TOKEN=<integration-token>
-VITE_OPENAI_KEY=<openai-api-key>

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ cp .env.example .env
 ```
 
 Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID`,
-`VITE_GAPI_API_KEY`, `VITE_INTEGRATION_TOKEN` and `VITE_OPENAI_KEY`.
-The integration token was originally used for a third-party widget. The
-`VITE_OPENAI_KEY` variable is required to enable the chat box shown on the
-dashboard, which sends prompts to the OpenAI API.
+`VITE_GAPI_API_KEY` and `VITE_INTEGRATION_TOKEN`.
+The integration token was originally used for a third-party widget.
+The chat box now sends prompts to a backend endpoint instead of directly to
+OpenAI, so no OpenAI key is needed in the client.
 
 ## Development
 
@@ -61,8 +61,10 @@ The tests use Jest together with React Testing Library.
 
 ## Chat Integration
 
-The dashboard displays a small chat box powered by OpenAI. Configure
-`VITE_OPENAI_KEY` in your `.env` file with a valid API key to enable it.
+The dashboard displays a small chat box powered by OpenAI. Messages are sent to
+`/chat` on your backend, which must forward them to OpenAI. Configure the
+backend with an `OPENAI_KEY` environment variable containing a valid API key to
+enable the feature.
 
 ## Backend API
 
@@ -71,6 +73,7 @@ The frontend expects a REST backend exposing at least the following endpoints:
 - `POST /login` – authenticate the user and return an `access_token`.
 - `GET /determinazioni` – list existing determinations.
 - `POST /determinazioni` – create a new determination.
+- `POST /chat` – forward chat messages to OpenAI using the `OPENAI_KEY`.
 
 
 ## License

--- a/api/chat.js
+++ b/api/chat.js
@@ -1,0 +1,37 @@
+const axios = require('axios');
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const apiKey = process.env.OPENAI_KEY;
+  if (!apiKey) {
+    res.status(500).json({ error: 'Missing OpenAI key' });
+    return;
+  }
+
+  const { messages } = req.body || {};
+  if (!messages) {
+    res.status(400).json({ error: 'Missing messages' });
+    return;
+  }
+
+  try {
+    const response = await axios.post(
+      'https://api.openai.com/v1/chat/completions',
+      {
+        model: 'gpt-3.5-turbo',
+        messages,
+      },
+      {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      }
+    );
+    res.status(200).json(response.data);
+  } catch (err) {
+    console.error(err.response?.data || err);
+    res.status(500).json({ error: 'Failed to contact OpenAI' });
+  }
+};

--- a/src/components/IntegrationBox.tsx
+++ b/src/components/IntegrationBox.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import axios from 'axios';
+import api from '../api/axios';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';
@@ -10,7 +10,6 @@ const IntegrationBox: React.FC = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
 
-  const apiKey = import.meta.env.VITE_OPENAI_KEY;
 
   const sendMessage = async () => {
     if (!input.trim()) return;
@@ -18,17 +17,10 @@ const IntegrationBox: React.FC = () => {
     setMessages(prev => [...prev, userMessage]);
     setInput('');
 
-    if (!apiKey) return;
-
     try {
-      const res = await axios.post(
-        'https://api.openai.com/v1/chat/completions',
-        {
-          model: 'gpt-3.5-turbo',
-          messages: [...messages, userMessage],
-        },
-        { headers: { Authorization: `Bearer ${apiKey}` } }
-      );
+      const res = await api.post('/chat', {
+        messages: [...messages, userMessage],
+      });
       const assistant = res.data.choices[0].message as Message;
       setMessages(prev => [...prev, assistant]);
     } catch (err) {


### PR DESCRIPTION
## Summary
- add `api/chat.js` serverless function to proxy messages to OpenAI using a secret key
- update `IntegrationBox.tsx` to call backend `/chat` endpoint
- remove `VITE_OPENAI_KEY` from environment configuration
- document new backend requirement for `OPENAI_KEY` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f13b047a08323baf92b44a0f515ff