### PR TITLE
Wrap pages with PageTemplate

### DIFF
--- a/src/components/PageTemplate.css
+++ b/src/components/PageTemplate.css
@@ -1,0 +1,4 @@
+.page-template {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import './PageTemplate.css';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const PageTemplate: React.FC<Props> = ({ children }) => (
+  <div className="page-template">{children}</div>
+);
+
+export default PageTemplate;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import useLocalStorage from '../hooks/useLocalStorage';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import IntegrationBox from '../components/IntegrationBox';
+import PageTemplate from '../components/PageTemplate';
 
 interface EventItem {
   id: string;
@@ -24,12 +25,13 @@ export default function Dashboard() {
   const upcomingTodos = todos.filter(t => differenceInCalendarDays(parseISO(t.due), today) <= 3);
 
   return (
-    <div className="dashboard">
-      <h1>Dashboard</h1>
-      <div className="top-wrapper">
-        <div className="calendar-container dashboard-section">
-          <iframe
-            title="calendar"
+    <PageTemplate>
+      <div className="dashboard">
+        <h1>Dashboard</h1>
+        <div className="top-wrapper">
+          <div className="calendar-container dashboard-section">
+            <iframe
+              title="calendar"
             src="https://calendar.google.com/calendar/embed?mode=AGENDA"
             style={{ border: 0 }}
             width="100%"
@@ -60,6 +62,7 @@ export default function Dashboard() {
           </ul>
         </div>
       </div>
-    </div>
+      </div>
+    </PageTemplate>
   );
 }

--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -7,6 +7,7 @@ import {
   Determination,
 } from '../api/determinations';
 import './ListPages.css';
+import PageTemplate from '../components/PageTemplate';
 
 const DeterminationsPage: React.FC = () => {
   const [items, setItems] = useState<Determination[]>([]);
@@ -148,9 +149,10 @@ const DeterminationsPage: React.FC = () => {
   };
 
   return (
-    <div className="list-page">
-      <h2>Determine</h2>
-      <form onSubmit={onSubmit} className="item-form">
+    <PageTemplate>
+      <div className="list-page">
+        <h2>Determine</h2>
+        <form onSubmit={onSubmit} className="item-form">
         <label htmlFor="det-capitolo">Capitolo</label>
         <input
           id="det-capitolo"
@@ -209,7 +211,8 @@ const DeterminationsPage: React.FC = () => {
           ))}
         </tbody>
       </table>
-    </div>
+      </div>
+    </PageTemplate>
   );
 };
 

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -14,6 +14,7 @@ import {
   DbEvent,
 } from '../api/events';
 import './ListPages.css';
+import PageTemplate from '../components/PageTemplate';
 
 interface UnifiedEvent {
   id: string;
@@ -223,9 +224,10 @@ export default function EventsPage() {
   };
 
   return (
-    <div className="list-page">
-      <h2>Eventi</h2>
-      <form onSubmit={onSubmit} className="item-form">
+    <PageTemplate>
+      <div className="list-page">
+        <h2>Eventi</h2>
+        <form onSubmit={onSubmit} className="item-form">
         <label htmlFor="ev-title">Titolo</label>
         <input
           id="ev-title"
@@ -286,6 +288,7 @@ export default function EventsPage() {
           ))}
         </tbody>
       </table>
-    </div>
+      </div>
+    </PageTemplate>
   );
 }

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -1,7 +1,3 @@
-.list-page {
-  max-width: 600px;
-  margin: 0 auto;
-}
 .item-form {
   display: flex;
   gap: 0.5rem;

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -6,6 +6,7 @@ import {
   deleteTodo,
 } from '../api/todos';
 import './ListPages.css';
+import PageTemplate from '../components/PageTemplate';
 
 interface TodoItem { id: string; text: string; due: string; }
 
@@ -103,9 +104,10 @@ export default function TodoPage() {
   };
 
   return (
-    <div className="list-page">
-      <h2>To-Do</h2>
-      <form onSubmit={onSubmit} className="item-form">
+    <PageTemplate>
+      <div className="list-page">
+        <h2>To-Do</h2>
+        <form onSubmit={onSubmit} className="item-form">
         <label htmlFor="todo-text">Attività</label>
         <input id="todo-text" placeholder="Attività" value={text} onChange={e => setText(e.target.value)} />
         <label htmlFor="todo-due">Scadenza</label>
@@ -134,6 +136,7 @@ export default function TodoPage() {
           ))}
         </tbody>
       </table>
-    </div>
+      </div>
+    </PageTemplate>
   );
 }


### PR DESCRIPTION
## Summary
- create a reusable `PageTemplate` component
- wrap Dashboard, EventsPage, TodoPage and DeterminationsPage with it
- clean up `ListPages.css`

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f118e614883238648df15a109583e