### PR TITLE
Update Footer year dynamically

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import './Footer.css';
 
-const Footer: React.FC = () => (
-  <footer className="site-footer">© M.Fenaroli 2k25</footer>
-);
+const Footer: React.FC = () => {
+  const year = new Date().getFullYear();
+  return <footer className="site-footer">© M.Fenaroli {year}</footer>;
+};
 
 export default Footer;

--- a/src/components/__tests__/ProtectedLayout.test.tsx
+++ b/src/components/__tests__/ProtectedLayout.test.tsx
@@ -23,6 +23,9 @@ describe('ProtectedLayout', () => {
     expect(screen.getByRole('button', { name: /esci/i })).toBeInTheDocument();
 
     // footer
-    expect(screen.getByText(/© M.Fenaroli 2k25/i)).toBeInTheDocument();
+    const currentYear = new Date().getFullYear();
+    expect(
+      screen.getByText(new RegExp(`© M.Fenaroli ${currentYear}`, 'i'))
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- compute the footer year with `new Date().getFullYear()`
- update test to expect dynamic year

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1688a0908323afe27c4ae1e4fd4b