### PR TITLE
Remove deprecated integration token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 VITE_API_URL=<backend-url>
 VITE_GAPI_CLIENT_ID=<google-client-id>
 VITE_GAPI_API_KEY=<google-api-key>
-VITE_INTEGRATION_TOKEN=<integration-token>

--- a/README.md
+++ b/README.md
@@ -17,11 +17,10 @@ npm install
 cp .env.example .env
 ```
 
-Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID`,
-`VITE_GAPI_API_KEY` and `VITE_INTEGRATION_TOKEN`.
-The integration token was originally used for a third-party widget.
-The chat box now sends prompts to a backend endpoint instead of directly to
-OpenAI, so no OpenAI key is needed in the client.
+Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID` and
+`VITE_GAPI_API_KEY`.
+The chat box sends prompts to a backend endpoint instead of directly to OpenAI,
+so no OpenAI key is needed in the client.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- remove `VITE_INTEGRATION_TOKEN` from example env file
- update README to drop mention of the integration token

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1684b64883239ec21285039c7b2a