### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This project contains the React front end of **Segretaria Digitale**, a simple a
 ## Setup
 
 1. Ensure [Node.js](https://nodejs.org/) and npm are installed.
-2. Install dependencies:
+2. Install dependencies (creates `node_modules/.bin/jest` used by the test suite):
 
 ```bash
 npm install
+# or run the helper script
+./scripts/setup.sh
 ```
 
 3. Copy `.env.example` to `.env` and replace the placeholder values:
@@ -55,6 +57,9 @@ Run the Jest test suite:
 ```bash
 npm test
 ```
+
+If Jest is missing, ensure dependencies are installed first using `npm install`
+or `./scripts/setup.sh`.
 
 The tests use Jest together with React Testing Library.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Install project dependencies
+npm install


### PR DESCRIPTION
## Summary
- add helper `scripts/setup.sh`
- clarify installation instructions for test dependencies

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f198b67a883239e59b42d06c3c4b5