### PR TITLE
Replace ProtectedLayout with PageTemplate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import {
   Navigate,
 } from "react-router-dom";
 
-import ProtectedLayout from "./components/ProtectedLayout";
+import PageTemplate from "./components/PageTemplate";
 import ProtectedRoute from "./components/ProtectedRoute";
 
 import LoginPage from "./pages/LoginPage";
@@ -28,7 +28,7 @@ const App: React.FC = () => {
         <Route
           element={
             <ProtectedRoute>
-              <ProtectedLayout />
+              <PageTemplate />
             </ProtectedRoute>
           }
         >

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Footer from './Footer';
 
-const ProtectedLayout: React.FC = () => (
+const PageTemplate: React.FC = () => (
   <>
     <Header />
     <main className="app-container">
@@ -13,4 +13,4 @@ const ProtectedLayout: React.FC = () => (
   </>
 );
 
-export default ProtectedLayout;
+export default PageTemplate;

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -1,17 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
-import ProtectedLayout from '../ProtectedLayout';
+import PageTemplate from '../PageTemplate';
 
 const Dummy: React.FC = () => <div>Dummy Page</div>;
 
-describe('ProtectedLayout', () => {
+describe('PageTemplate', () => {
   it('shows navigation, sidebar buttons and footer', () => {
     render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <Dummy />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DeterminationsPage from '../DeterminationsPage';
-import ProtectedLayout from '../../components/ProtectedLayout';
+import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter } from 'react-router-dom';
 
 beforeEach(() => {
@@ -12,9 +12,9 @@ describe('DeterminationsPage', () => {
   it('creates a new determination', async () => {
     const { container } = render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <DeterminationsPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 
@@ -35,9 +35,9 @@ describe('DeterminationsPage', () => {
 
     const { container } = render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <DeterminationsPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EventsPage from '../EventsPage';
 import api from '../../api/axios';
-import ProtectedLayout from '../../components/ProtectedLayout';
+import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../../api/axios', () => ({
@@ -39,9 +39,9 @@ describe('EventsPage', () => {
 
     render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <EventsPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 
@@ -53,9 +53,9 @@ describe('EventsPage', () => {
 
     const { container } = render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <EventsPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TodoPage from '../TodoPage';
 import * as todosApi from '../../api/todos';
-import ProtectedLayout from '../../components/ProtectedLayout';
+import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter } from 'react-router-dom';
 
 jest.mock('../../api/todos', () => ({
@@ -26,9 +26,9 @@ describe('TodoPage offline', () => {
 
     render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <TodoPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 
@@ -45,9 +45,9 @@ describe('TodoPage offline', () => {
 
     render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <TodoPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 
@@ -69,9 +69,9 @@ describe('TodoPage offline', () => {
 
     render(
       <MemoryRouter>
-        <ProtectedLayout>
+        <PageTemplate>
           <TodoPage />
-        </ProtectedLayout>
+        </PageTemplate>
       </MemoryRouter>
     );
 


### PR DESCRIPTION
## Summary
- swap `ProtectedLayout` for `PageTemplate`
- adjust imports and wrap protected routes with `PageTemplate`
- rename tests and update page tests
- delete obsolete layout component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1916b34883239177d0b2eab497de