### PR TITLE
Wrap template tests in router

### DIFF
--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import React from 'react';
 import PageTemplate from '../PageTemplate';
 
@@ -8,10 +8,12 @@ const Dummy: React.FC = () => <div>Dummy Page</div>;
 describe('PageTemplate', () => {
   it('shows navigation, sidebar buttons and footer', () => {
     render(
-      <MemoryRouter>
-        <PageTemplate>
-          <Dummy />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dummy />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DeterminationsPage from '../DeterminationsPage';
 import PageTemplate from '../../components/PageTemplate';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 beforeEach(() => {
   localStorage.clear();
@@ -11,10 +11,12 @@ beforeEach(() => {
 describe('DeterminationsPage', () => {
   it('creates a new determination', async () => {
     const { container } = render(
-      <MemoryRouter>
-        <PageTemplate>
-          <DeterminationsPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/determinazioni"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/determinazioni" element={<DeterminationsPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 
@@ -34,10 +36,12 @@ describe('DeterminationsPage', () => {
     );
 
     const { container } = render(
-      <MemoryRouter>
-        <PageTemplate>
-          <DeterminationsPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/determinazioni"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/determinazioni" element={<DeterminationsPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import EventsPage from '../EventsPage';
 import api from '../../api/axios';
 import PageTemplate from '../../components/PageTemplate';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 jest.mock('../../api/axios', () => ({
   __esModule: true,
@@ -38,10 +38,12 @@ describe('EventsPage', () => {
     );
 
     render(
-      <MemoryRouter>
-        <PageTemplate>
-          <EventsPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/events"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/events" element={<EventsPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 
@@ -52,10 +54,12 @@ describe('EventsPage', () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
     const { container } = render(
-      <MemoryRouter>
-        <PageTemplate>
-          <EventsPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/events"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/events" element={<EventsPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import TodoPage from '../TodoPage';
 import * as todosApi from '../../api/todos';
 import PageTemplate from '../../components/PageTemplate';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 jest.mock('../../api/todos', () => ({
   __esModule: true,
@@ -25,10 +25,12 @@ describe('TodoPage offline', () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
     render(
-      <MemoryRouter>
-        <PageTemplate>
-          <TodoPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/todo"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/todo" element={<TodoPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 
@@ -44,10 +46,12 @@ describe('TodoPage offline', () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
     render(
-      <MemoryRouter>
-        <PageTemplate>
-          <TodoPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/todo"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/todo" element={<TodoPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 
@@ -68,10 +72,12 @@ describe('TodoPage offline', () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
     render(
-      <MemoryRouter>
-        <PageTemplate>
-          <TodoPage />
-        </PageTemplate>
+      <MemoryRouter initialEntries={["/todo"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/todo" element={<TodoPage />} />
+          </Route>
+        </Routes>
       </MemoryRouter>
     );
 


### PR DESCRIPTION
## Summary
- update page tests to render using `<Routes>` and `<Route>`
- update page template test to use nested routes

## Testing
- `./scripts/setup.sh` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f92ef6b9883239ae35da6e4a85044