### PR TITLE
Move CALENDAR_ID inside Dashboard component

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,7 +3,6 @@ import useLocalStorage from '../hooks/useLocalStorage';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import IntegrationBox from '../components/IntegrationBox';
-const CALENDAR_ID = 'plcastionedellapresolana@gmail.com'; 
 interface EventItem {
   id: string;
   title: string;
@@ -16,6 +15,7 @@ interface TodoItem { id: string; text: string; due: string; }
 export default function Dashboard() {
   const [events] = useLocalStorage<EventItem[]>('events', []);
   const [todos] = useLocalStorage<TodoItem[]>('todos', []);
+  const CALENDAR_ID = 'plcastionedellapresolana@gmail.com';
 
   const today = new Date();
   const upcomingEvents = events.filter(


### PR DESCRIPTION
## Summary
- place CALENDAR_ID constant inside the Dashboard component

## Testing
- `npm run dev` *(fails: vite permission denied / missing rollup)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fac2cec9c832399c15d8e0cc60afd