### PR TITLE
Fix sticky footer layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  flex: 1;
   background: linear-gradient(135deg, #ffffff 0%, #e5e5e5 100%);
 }
 .login-page::before {
@@ -99,9 +99,12 @@ body {
 
 
 /* Layout di base */
-body, html, #root {
-  height: 100%;
+#root {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 .app-container {
+  flex: 1;
   padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- ensure pages use flex layout so footer stays at bottom
- let login page adapt to available height instead of forcing 100vh

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606c1498708323b6d6a4800efc18a2