### PR TITLE
Style headings and labels in red bold

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -105,3 +105,14 @@ body, html, #root {
 .app-container {
   padding: 1rem;
 }
+
+/* Red bold headings for boxes and form labels */
+h2 {
+  color: #A52019;
+  font-weight: 700;
+}
+
+label {
+  color: #A52019;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary
- apply red bold styling to all h2 headings and form labels

## Testing
- `npx jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68606cc13ee083238a4c27f563455b60