### PR TITLE
Update fonts to Poppins

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Segretaria Digitale</title>
 
-    <!-- Titillium Web font -->
+    <!-- Poppins font -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap"
       rel="stylesheet"
     />
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 /* Styles based on the "grafica istituzionale" guidelines
    https://designers.italia.it/kit/grafica/ */
-@import url('https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap');
 
 * {
   box-sizing: border-box;
@@ -8,7 +8,8 @@
 
 body {
   margin: 0;
-  font-family: 'Titillium Web', sans-serif;
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
   background: url('/background.png') no-repeat center/cover fixed;
   color: #333;
 }


### PR DESCRIPTION
## Summary
- replace Titillium font link in `index.html`
- load Poppins Semibold in `src/index.css`
- set default font-family to Poppins with weight 600

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606e42e5c8832394fbdf5041fb5f5e