### PR TITLE
Add black outline to form titles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -119,6 +119,8 @@ body {
 h2 {
   color: #A52019;
   font-weight: 700;
+  -webkit-text-stroke: 1px black;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
 
 label {


### PR DESCRIPTION
## Summary
- outline form titles with black stroke and shadow for better contrast

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608e8c88cc8323ac445c0f9724f2d1