### PR TITLE
Implement mobile dropdown lists

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -43,6 +43,7 @@ export default function EventsPage() {
     isPublic: false,
   });
   const [editing, setEditing] = useState<{ id: string; source: 'db' | 'gc' } | null>(null);
+  const isMobile = window.innerWidth <= 600;
 
   const resetForm = (): void => {
     setForm({ title: '', description: '', dateTime: '', endDateTime: '', isPublic: false });
@@ -261,6 +262,8 @@ export default function EventsPage() {
           </button>
         )}
       </form>
+      <details className="item-dropdown" open={!isMobile}>
+        <summary>Eventi salvati</summary>
       <table className="item-table">
         <thead>
           <tr>
@@ -286,6 +289,7 @@ export default function EventsPage() {
           ))}
         </tbody>
       </table>
+      </details>
       </div>
   );
 }

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -86,6 +86,28 @@
   background: #8B1B13;
 }
 
+.item-dropdown summary {
+  background: #A52019;
+  color: #fff;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  list-style: none;
+  margin-bottom: 0.5rem;
+}
+.item-dropdown summary::-webkit-details-marker {
+  display: none;
+}
+
+@media (min-width: 601px) {
+  .item-dropdown > summary {
+    display: none;
+  }
+  .item-dropdown {
+    display: block;
+  }
+}
+
 @media (max-width: 600px) {
   .item-form {
     flex-direction: column;

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -14,6 +14,7 @@ export default function TodoPage() {
   const [text, setText] = useState('');
   const [due, setDue] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
+  const isMobile = window.innerWidth <= 600;
 
   const reset = () => { setText(''); setDue(''); setEdit(null); };
 
@@ -113,6 +114,8 @@ export default function TodoPage() {
         <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>
+      <details className="item-dropdown" open={!isMobile}>
+        <summary>Todo salvati</summary>
       <table className="item-table">
         <thead>
           <tr>
@@ -134,6 +137,7 @@ export default function TodoPage() {
           ))}
         </tbody>
       </table>
+      </details>
       </div>
   );
 }


### PR DESCRIPTION
## Summary
- show saved todos/events in collapsible dropdowns on phones
- style dropdown summaries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608ef0098c8323bfdf42fc5a7e6c3a