### PR TITLE
Remove To-Do prefix and tweak fonts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -134,3 +134,8 @@ label {
   color: #A52019;
   font-weight: 700;
 }
+
+/* Slightly smaller font for div elements */
+div {
+  font-size: 0.9rem;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -30,7 +30,7 @@ export default function Dashboard() {
             <h2>Todo list 📝</h2>
             <ul>
               {upcomingTodos.map(t => (
-                <li key={t.id}>To-Do: {t.text} – {new Date(t.due).toLocaleDateString()}</li>
+                <li key={t.id}>{t.text} – {new Date(t.due).toLocaleDateString()}</li>
               ))}
               {!upcomingTodos.length && <li>Nessun todo imminente.</li>}
             </ul>


### PR DESCRIPTION
## Summary
- show todo titles without the `To-Do:` prefix on Dashboard
- reduce font size of all `div` elements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860a576345083239b39c84d0ec78a5e