### PR TITLE
Store todos per user

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
+import { useAuthStore } from '../store/auth';
+import { getUserStorageKey } from '../utils/auth';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 interface EventItem {
@@ -12,8 +14,13 @@ interface EventItem {
 interface TodoItem { id: string; text: string; due: string; }
 
 export default function Dashboard() {
+  const token = useAuthStore(s => s.token);
+  const todoKey = useMemo(
+    () => getUserStorageKey('todos', token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)),
+    [token]
+  );
   const [events] = useLocalStorage<EventItem[]>('events', []);
-  const [todos] = useLocalStorage<TodoItem[]>('todos', []);
+  const [todos] = useLocalStorage<TodoItem[]>(todoKey, []);
   const CALENDAR_ID = 'plcastionedellapresolana@gmail.com';
 
   const today = new Date();

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import {
   listTodos,
   createTodo,
@@ -6,6 +6,8 @@ import {
   deleteTodo,
 } from '../api/todos';
 import './ListPages.css';
+import { useAuthStore } from '../store/auth';
+import { getUserStorageKey } from '../utils/auth';
 
 interface TodoItem { id: string; text: string; due: string; }
 
@@ -15,11 +17,16 @@ export default function TodoPage() {
   const [due, setDue] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
   const isMobile = window.innerWidth <= 600;
+  const token = useAuthStore(s => s.token);
+  const storageKey = useMemo(
+    () => getUserStorageKey('todos', token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)),
+    [token]
+  );
 
   const reset = () => { setText(''); setDue(''); setEdit(null); };
 
   const saveLocal = (data: TodoItem[]) => {
-    localStorage.setItem('todos', JSON.stringify(data));
+    localStorage.setItem(storageKey, JSON.stringify(data));
   };
 
   useEffect(() => {
@@ -39,11 +46,11 @@ export default function TodoPage() {
           // use fallback
         }
       }
-      const stored = localStorage.getItem('todos');
+      const stored = localStorage.getItem(storageKey);
       if (stored) setTodos(JSON.parse(stored));
     };
     fetchTodos();
-  }, []);
+  }, [storageKey]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/utils/__tests__/auth.test.ts
+++ b/src/utils/__tests__/auth.test.ts
@@ -1,0 +1,14 @@
+import { getUserStorageKey } from '../auth';
+
+describe('getUserStorageKey', () => {
+  it('returns prefix when token missing', () => {
+    expect(getUserStorageKey('todos', null)).toBe('todos');
+  });
+
+  it('adds user id from token', () => {
+    const header = Buffer.from('{}').toString('base64');
+    const payload = Buffer.from(JSON.stringify({ sub: '123' })).toString('base64');
+    const token = `${header}.${payload}.sig`;
+    expect(getUserStorageKey('todos', token)).toBe('todos_123');
+  });
+});

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,16 @@
+export function decodeToken(token: string): any | null {
+  try {
+    const payload = token.split('.')[1];
+    const json = Buffer.from(payload, 'base64').toString('utf8');
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export function getUserStorageKey(prefix: string, token: string | null): string {
+  if (!token) return prefix;
+  const decoded = decodeToken(token);
+  const id = decoded?.sub || decoded?.user_id || decoded?.id || decoded?.email;
+  return id ? `${prefix}_${id}` : prefix;
+}


### PR DESCRIPTION
## Summary
- decode JWT tokens to extract user ID
- save todos under user-specific localStorage keys
- show upcoming todos per account on the dashboard
- test helper for user storage keys

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686185ec31848323b795731fe5c3441d