### PR TITLE
Add dropdown labels for mobile view

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -263,7 +263,7 @@ export default function EventsPage() {
         )}
       </form>
       <details className="item-dropdown" open={!isMobile}>
-        <summary>Eventi salvati</summary>
+        <summary>{isMobile ? 'Lista Eventi Salvati' : 'Eventi salvati'}</summary>
       <table className="item-table">
         <thead>
           <tr>

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -95,6 +95,13 @@
   list-style: none;
   margin-bottom: 0.5rem;
 }
+.item-dropdown summary::after {
+  content: ' \25BC';
+  float: right;
+}
+.item-dropdown[open] > summary::after {
+  content: ' \25B2';
+}
 .item-dropdown summary::-webkit-details-marker {
   display: none;
 }

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -133,7 +133,7 @@ export default function TodoPage() {
         {edit && <button type="button" onClick={reset}>Annulla</button>}
       </form>
       <details className="item-dropdown" open={!isMobile}>
-        <summary>Todo salvati</summary>
+        <summary>{isMobile ? 'Lista to-do salvati' : 'Todo salvati'}</summary>
       <table className="item-table">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- rename saved lists on mobile
- add dropdown arrow for mobile menus

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861867d31f483238320332c6d20fdef