### PR TITLE
Aggiunge saluto utente

### DIFF
--- a/src/components/Greeting.css
+++ b/src/components/Greeting.css
@@ -1,0 +1,5 @@
+.user-greeting {
+  text-align: left;
+  padding: 0.5rem 1rem;
+  font-size: 1.1rem;
+}

--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useAuthStore } from '../store/auth';
+import { decodeToken } from '../utils/auth';
+import './Greeting.css';
+
+const Greeting: React.FC = () => {
+  const token = useAuthStore(s => s.token) || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null);
+  if (!token) return null;
+
+  const decoded = decodeToken(token);
+  const email: string | undefined = decoded?.email || decoded?.sub || decoded?.user_id || decoded?.id;
+  if (!email) return null;
+
+  const username = email.endsWith('@comune.castione.bg.it') ? email.split('@')[0] : email;
+  return <div className="user-greeting">Ciao {username}</div>;
+};
+
+export default Greeting;

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Footer from './Footer';
+import Greeting from './Greeting';
 
 const PageTemplate: React.FC = () => (
   <>
     <Header />
+    <Greeting />
     <main className="app-container">
       <Outlet />
     </main>


### PR DESCRIPTION
## Summary
- mostra un saluto con il nome dell'utente dopo l'header

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run build --silent` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686187e25ce083238864279d07544717