### PR TITLE
Refine login background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,10 @@ body {
   color: #333;
 }
 
+body.login-only {
+  background: none;
+}
+
 
 /* LOGIN */
 .login-page {
@@ -21,9 +25,9 @@ body {
   justify-content: flex-start;
   align-items: center;
   flex: 1;
-  background: url('/Login.png') no-repeat center/90% fixed;
+  background: url('/Login.png') no-repeat center/cover fixed;
   position: relative;
-  padding-left: 2rem;
+  padding-left: 4rem;
 }
 .login-page::before {
   content: "";

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { useAuthStore } from "../store/auth";
@@ -9,6 +9,13 @@ const LoginPage: React.FC = () => {
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
   const setToken = useAuthStore(s => s.setToken);
+
+  useEffect(() => {
+    document.body.classList.add('login-only');
+    return () => {
+      document.body.classList.remove('login-only');
+    };
+  }, []);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- ensure only `Login.png` shows on login page
- shift login form slightly right on desktop

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686195a2ec588323a9cd4d4f984a9287