### PR TITLE
Change Home link label to Dashboard

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ const Header: React.FC = () => {
         <h1>Polizia Locale - Castione della Presolana</h1>
       </div>
       <nav>
-        <Link to="/">🏠 Home</Link>
+        <Link to="/">🏠 Dashboard</Link>
         <Link to="/events">📅 Eventi</Link>
         <Link to="/todo">📝 To-Do</Link>
         <Link to="/determinazioni">📄 Determine</Link>

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -18,7 +18,7 @@ describe('PageTemplate', () => {
     );
 
     // navigation links
-    expect(screen.getByText('🏠 Home')).toBeInTheDocument();
+    expect(screen.getByText('🏠 Dashboard')).toBeInTheDocument();
     expect(screen.getByText('📅 Eventi')).toBeInTheDocument();
     expect(screen.getByText('📝 To-Do')).toBeInTheDocument();
     expect(screen.getByText('📄 Determine')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update the Home link text to `Dashboard` in `Header`
- adjust test expectation accordingly

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619cddb4ec8323a2db78c7511f1a81