### PR TITLE
Center Dashboard title

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -4,6 +4,14 @@
   gap: 2rem;
   padding: 1rem;
 }
+
+.dashboard h1 {
+  text-align: center;
+  color: #000;
+  -webkit-text-stroke: 1px #A52019;
+  text-shadow: -1px -1px 0 #A52019, 1px -1px 0 #A52019,
+               -1px 1px 0 #A52019, 1px 1px 0 #A52019;
+}
 .dashboard-section {
   border: 1px solid #A52019;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- center the Dashboard heading
- give the title a black font color with a red border

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619e033fdc8323b89ed423f57dbc1f