### PR TITLE
Move greeting to dashboard

### DIFF
--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Footer from './Footer';
-import Greeting from './Greeting';
 
 const PageTemplate: React.FC = () => (
   <>
     <Header />
-    <Greeting />
     <main className="app-container">
       <Outlet />
     </main>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import useLocalStorage from '../hooks/useLocalStorage';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import './Dashboard.css';
+import Greeting from '../components/Greeting';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 interface EventItem {
   id: string;
@@ -31,6 +32,7 @@ export default function Dashboard() {
 
   return (
     <div className="dashboard">
+        <Greeting />
         <h1>Dashboard</h1>
         <div className="upcoming-wrapper">
           <div className="notifications dashboard-section">


### PR DESCRIPTION
## Summary
- remove greeting from PageTemplate
- show greeting at the top of the Dashboard page

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619eea913883238268d71ec7d32734