### PR TITLE
Use Login.png as full-page background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,13 +10,10 @@ body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
   font-weight: 600;
-  background: url('/background.png') no-repeat center/contain fixed;
+  background: url('/Login.png') no-repeat center/contain fixed;
   color: #333;
 }
 
-body.login-only {
-  background: none;
-}
 
 
 /* LOGIN */
@@ -25,7 +22,7 @@ body.login-only {
   justify-content: flex-start;
   align-items: center;
   flex: 1;
-  background: url('/Login.png') no-repeat center/cover fixed;
+  background: url('/Login.png') no-repeat center/contain fixed;
   position: relative;
   padding-left: 4rem;
 }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { useAuthStore } from "../store/auth";
@@ -10,12 +10,6 @@ const LoginPage: React.FC = () => {
   const navigate = useNavigate();
   const setToken = useAuthStore(s => s.setToken);
 
-  useEffect(() => {
-    document.body.classList.add('login-only');
-    return () => {
-      document.body.classList.remove('login-only');
-    };
-  }, []);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- set `Login.png` as the default background image for all pages
- remove special body class from `LoginPage`
- ensure login page uses `contain` instead of `cover` for background so the image is fully visible

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619fbcf5088323a1da2b1647270a45