### PR TITLE
Adjust public events checkbox size

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -3,13 +3,20 @@
   gap: 0.5rem;
   margin-bottom: 1rem;
 }
-.item-form input,
+.item-form input:not([type="checkbox"]),
 .item-form textarea {
   flex: 1;
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
   font-size: 1rem;
+}
+
+.item-form input[type="checkbox"] {
+  flex: 0;
+  width: 1rem;
+  height: 1rem;
+  align-self: center;
 }
 .item-form button {
   padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- narrow styling for .item-form inputs to exclude checkboxes
- size down the public events checkbox

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4606bec83238dd4fd476b5e8ef0