### PR TITLE
Make login background not cropped

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,6 @@ body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
   font-weight: 600;
-  background: url('/Login.png') no-repeat center/cover fixed;
   color: #333;
 }
 
@@ -22,7 +21,7 @@ body {
   justify-content: flex-start;
   align-items: center;
   flex: 1;
-  background: url('/Login.png') no-repeat center/cover fixed;
+  background: url('/Login.png') no-repeat center/contain fixed;
   position: relative;
   padding-left: 12rem;
 }
@@ -30,7 +29,7 @@ body {
   content: "";
   position: fixed;
   inset: 0;
-  background: inherit;
+  background: url('/Login.png') no-repeat center/cover fixed;
   filter: blur(16px);
   z-index: -1;
 }
@@ -108,7 +107,7 @@ body {
   body,
   .login-page {
     background-attachment: scroll;
-    background-size: cover;
+    background-size: contain;
     justify-content: center;
     padding-left: 0;
   }


### PR DESCRIPTION
## Summary
- show entire background image on login page
- remove global background image

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a84fa4448323a60fdf20784e1e35