### PR TITLE
Load Almendra SC globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Segretaria Digitale</title>
 
-    <!-- Poppins font -->
+    <!-- Almendra SC font -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap"
       rel="stylesheet"
     />
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 /* Styles based on the "grafica istituzionale" guidelines
    https://designers.italia.it/kit/grafica/ */
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap');
 
 * {
   box-sizing: border-box;
@@ -8,7 +8,7 @@
 
 body {
   margin: 0;
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Almendra SC', serif;
   font-weight: 600;
   color: #333;
 }


### PR DESCRIPTION
## Summary
- use Almendra SC font from Google Fonts
- apply Almendra SC font as the global body font

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b47051c483238c8b9a668b04d21d