### PR TITLE
Apply Imperial Script font to headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap"
       rel="stylesheet"
     />
+    <!-- Imperial Script font -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Imperial+Script&display=swap"
+      rel="stylesheet"
+    />
 
 
   </head>

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -24,6 +24,7 @@
 .site-header h1 {
   font-size: 2rem;
   margin: 0;
+  font-family: 'Imperial Script', cursive;
 }
 .small-logo {
   height: 90px;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 /* Styles based on the "grafica istituzionale" guidelines
    https://designers.italia.it/kit/grafica/ */
 @import url('https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Imperial+Script&display=swap');
 
 * {
   box-sizing: border-box;
@@ -55,6 +56,7 @@ body {
   font-size: 1.4rem;
   margin-bottom: 1.5rem;
   color: #A52019;
+  font-family: 'Imperial Script', cursive;
   font-weight: 700;
   -webkit-text-stroke: 1px black;
   text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;


### PR DESCRIPTION
## Summary
- load Imperial Script font
- use Imperial Script for the login page heading
- use Imperial Script for the header title

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b67bf69483239c2bb48beb2d0c2c