### PR TITLE
Use Login.png across pages

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,10 @@ body {
   font-family: 'Almendra SC', serif;
   font-weight: 600;
   color: #333;
+  background: url('/Login.png') no-repeat center/cover fixed;
+}
+body.login-bg {
+  background-size: contain;
 }
 
 
@@ -22,17 +26,8 @@ body {
   justify-content: flex-start;
   align-items: center;
   flex: 1;
-  background: url('/Login.png') no-repeat center/contain fixed;
   position: relative;
   padding-left: 17rem;
-}
-.login-page::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: url('/Login.png') no-repeat center/cover fixed;
-  filter: blur(16px);
-  z-index: -1;
 }
 
 .login-card {
@@ -106,10 +101,11 @@ body {
   }
 
   /* Allow the background to scroll on mobile devices */
-  body,
-  .login-page {
+  body.login-bg {
     background-attachment: scroll;
     background-size: contain;
+  }
+  .login-page {
     justify-content: center;
     padding-left: 0;
   }

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import api from "../api/axios";
 import { useAuthStore } from "../store/auth";
@@ -9,6 +9,13 @@ const LoginPage: React.FC = () => {
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
   const setToken = useAuthStore(s => s.setToken);
+
+  useEffect(() => {
+    document.body.classList.add("login-bg");
+    return () => {
+      document.body.classList.remove("login-bg");
+    };
+  }, []);
 
 
   const onSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- set default background to Login.png on body
- toggle body class for login page to display the entire image
- update responsive rules for the login page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c16eaa7083238456b99ed68eeb52