### PR TITLE
Adjust login layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,7 @@ body.login-bg {
   margin-bottom: 1rem;
 }
 
+.login-title,
 .login-card h1 {
   font-size: 1.4rem;
   margin-bottom: 1.5rem;
@@ -55,6 +56,14 @@ body.login-bg {
   font-weight: 700;
   -webkit-text-stroke: 1px black;
   text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}
+.login-title {
+  position: absolute;
+  top: 1rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  margin-bottom: 0;
 }
 
 .login-form input {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -32,11 +32,10 @@ const LoginPage: React.FC = () => {
   return (
     <>
       <div className="login-page">
+        <h1 className="login-title">Segretaria digitale Polizia Locale Castione della Presolana</h1>
         <div className="login-card">
           <img src="/logo.png" alt="Logo" className="login-logo" />
           <form className="login-form" onSubmit={onSubmit}>
-          <h1>Segretaria digitale Polizia Locale Castione della Presolana</h1>
-          <label htmlFor="login-email">email istituzionale</label>
           <input
             id="login-email"
             type="email"
@@ -45,7 +44,6 @@ const LoginPage: React.FC = () => {
             onChange={e => setEmail(e.target.value)}
             required
           />
-          <label htmlFor="login-password">Password</label>
           <input
             id="login-password"
             type="password"


### PR DESCRIPTION
## Summary
- move application title to the top of the login page
- remove email/password labels
- add `login-title` style to keep appearance

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c5efeee48323b48a0f1b5a3c1584