### PR TITLE
Remove dashboard heading outline

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -61,3 +61,9 @@
     flex-direction: column;
   }
 }
+
+/* Remove black outline from dashboard section headings */
+.dashboard-section h2 {
+  -webkit-text-stroke: 0;
+  text-shadow: none;
+}


### PR DESCRIPTION
## Summary
- remove black text outline from "Todo list" and upcoming events headers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c67031988323ab33f5704a77f307