### PR TITLE
Remove determination field labels

### DIFF
--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -172,21 +172,18 @@ const DeterminationsPage: React.FC = () => {
     <div className="list-page">
         <h2>Determine</h2>
         <form onSubmit={onSubmit} className="item-form">
-        <label htmlFor="det-capitolo">Capitolo</label>
         <input
           id="det-capitolo"
           placeholder="Capitolo"
           value={capitolo}
           onChange={e => setCapitolo(e.target.value)}
         />
-        <label htmlFor="det-numero">Numero</label>
         <input
           id="det-numero"
           placeholder="Numero"
           value={numero}
           onChange={e => setNumero(e.target.value)}
         />
-        <label htmlFor="det-somma">Somma</label>
         <input
           id="det-somma"
           type="number"
@@ -195,7 +192,6 @@ const DeterminationsPage: React.FC = () => {
           value={somma}
           onChange={e => setSomma(e.target.value)}
         />
-        <label htmlFor="det-descrizione">Descrizione</label>
         <textarea
           id="det-descrizione"
           placeholder="Descrizione"

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -20,10 +20,10 @@ describe('DeterminationsPage', () => {
       </MemoryRouter>
     );
 
-    await userEvent.type(screen.getByLabelText('Capitolo'), 'C1');
-    await userEvent.type(screen.getByLabelText('Numero'), '001');
-    await userEvent.type(screen.getByLabelText('Somma'), '10');
-    await userEvent.type(screen.getByLabelText('Descrizione'), 'desc');
+    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'C1');
+    await userEvent.type(screen.getByPlaceholderText('Numero'), '001');
+    await userEvent.type(screen.getByPlaceholderText('Somma'), '10');
+    await userEvent.type(screen.getByPlaceholderText('Descrizione'), 'desc');
     await userEvent.type(screen.getByLabelText('Scadenza'), '2023-06-10');
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 
@@ -48,14 +48,14 @@ describe('DeterminationsPage', () => {
 
     await screen.findByText(/A/);
     await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
-    await userEvent.clear(screen.getByLabelText('Capitolo'));
-    await userEvent.type(screen.getByLabelText('Capitolo'), 'B');
-    await userEvent.clear(screen.getByLabelText('Numero'));
-    await userEvent.type(screen.getByLabelText('Numero'), '2');
-    await userEvent.clear(screen.getByLabelText('Somma'));
-    await userEvent.type(screen.getByLabelText('Somma'), '6');
-    await userEvent.clear(screen.getByLabelText('Descrizione'));
-    await userEvent.type(screen.getByLabelText('Descrizione'), 'new');
+    await userEvent.clear(screen.getByPlaceholderText('Capitolo'));
+    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'B');
+    await userEvent.clear(screen.getByPlaceholderText('Numero'));
+    await userEvent.type(screen.getByPlaceholderText('Numero'), '2');
+    await userEvent.clear(screen.getByPlaceholderText('Somma'));
+    await userEvent.type(screen.getByPlaceholderText('Somma'), '6');
+    await userEvent.clear(screen.getByPlaceholderText('Descrizione'));
+    await userEvent.type(screen.getByPlaceholderText('Descrizione'), 'new');
     await userEvent.clear(screen.getByLabelText('Scadenza'));
     await userEvent.type(screen.getByLabelText('Scadenza'), '2023-02-02');
     await userEvent.click(screen.getByRole('button', { name: /salva/i }));


### PR DESCRIPTION
## Summary
- drop label elements for `capitolo`, `numero`, `somma` and `descrizione` inputs
- update determination tests to query inputs via placeholder text

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c71a582c83239f2dbb2affe2c4eb