### PR TITLE
Remove activity label from todo page

### DIFF
--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -171,7 +171,6 @@ export default function TodoPage() {
     <div className="list-page">
         <h2>To-Do</h2>
         <form onSubmit={onSubmit} className="item-form">
-        <label htmlFor="todo-text">Attività</label>
         <input id="todo-text" placeholder="Attività" value={text} onChange={e => setText(e.target.value)} />
         <label htmlFor="todo-due">Scadenza</label>
         <input id="todo-due" type="date" value={due} onChange={e => setDue(e.target.value)} />

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -42,7 +42,7 @@ describe('TodoPage offline', () => {
       </MemoryRouter>
     );
 
-    await userEvent.type(screen.getByLabelText('Attività'), 'Task 1');
+    await userEvent.type(screen.getByPlaceholderText('Attività'), 'Task 1');
     await userEvent.type(screen.getByLabelText('Scadenza'), '2023-06-01');
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 
@@ -66,8 +66,8 @@ describe('TodoPage offline', () => {
     await screen.findByText('Task');
     await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
 
-    await userEvent.clear(screen.getByLabelText('Attività'));
-    await userEvent.type(screen.getByLabelText('Attività'), 'Task edited');
+    await userEvent.clear(screen.getByPlaceholderText('Attività'));
+    await userEvent.type(screen.getByPlaceholderText('Attività'), 'Task edited');
     await userEvent.clear(screen.getByLabelText('Scadenza'));
     await userEvent.type(screen.getByLabelText('Scadenza'), '2023-02-02');
     await userEvent.click(screen.getByRole('button', { name: /salva/i }));


### PR DESCRIPTION
## Summary
- drop the `Attività` label from the todo form
- adjust tests to target the placeholder instead of the removed label

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c73ab81c832382942292e3789420