### PR TITLE
Remove labels and adjust events test

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -227,23 +227,23 @@ export default function EventsPage() {
     <div className="list-page">
         <h2>Eventi</h2>
         <form onSubmit={onSubmit} className="item-form">
-        <label htmlFor="ev-title">Titolo</label>
         <input
           id="ev-title"
+          data-testid="title-input"
           placeholder="Titolo"
           value={form.title}
           onChange={e => setForm({ ...form, title: e.target.value })}
         />
-        <label htmlFor="ev-description">Descrizione</label>
         <textarea
           id="ev-description"
+          data-testid="description-input"
           placeholder="Descrizione"
           value={form.description}
           onChange={e => setForm({ ...form, description: e.target.value })}
         />
-        <label htmlFor="ev-date">Data e ora</label>
         <input
           id="ev-date"
+          data-testid="date-input"
           type="datetime-local"
           value={form.dateTime}
           onChange={e => setForm({ ...form, dateTime: e.target.value })}
@@ -267,9 +267,9 @@ export default function EventsPage() {
       <table className="item-table">
         <thead>
           <tr>
-            <th>Titolo</th>
-            <th>Data</th>
-            <th>Descrizione</th>
+            <th></th>
+            <th></th>
+            <th></th>
             <th>Pubblico?</th>
             <th></th>
           </tr>

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -53,7 +53,7 @@ describe('EventsPage', () => {
   it('adds new event offline', async () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
-    const { container } = render(
+    render(
       <MemoryRouter initialEntries={["/events"]}>
         <Routes>
           <Route element={<PageTemplate />}>
@@ -63,10 +63,9 @@ describe('EventsPage', () => {
       </MemoryRouter>
     );
 
-    await userEvent.type(screen.getByLabelText('Titolo'), 'My Event');
-    await userEvent.type(screen.getByLabelText('Descrizione'), 'Desc');
-    const dateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
-    await userEvent.type(dateInput, '2023-05-01T12:00');
+    await userEvent.type(screen.getByTestId('title-input'), 'My Event');
+    await userEvent.type(screen.getByTestId('description-input'), 'Desc');
+    await userEvent.type(screen.getByTestId('date-input'), '2023-05-01T12:00');
     await userEvent.click(screen.getByLabelText(/pubblico/i));
     await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
 


### PR DESCRIPTION
## Summary
- remove title/description/date labels in EventsPage
- add test ids for event inputs
- blank out table headers for title, date and description
- update events tests to use new test ids

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c816fe748323a4c0b76be1b1885e