### PR TITLE
Center list page headings on mobile

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -127,4 +127,7 @@
     flex-direction: column;
     gap: 0.75rem;
   }
+  .list-page h2 {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
## Summary
- center Determine, To-Do and Eventi headings when screen width is 600px or less

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861caf3fec88323bc7b22df3b0649ac