### PR TITLE
Add data-testid attributes and update tests

### DIFF
--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -174,18 +174,21 @@ const DeterminationsPage: React.FC = () => {
         <form onSubmit={onSubmit} className="item-form">
         <input
           id="det-capitolo"
+          data-testid="det-capitolo"
           placeholder="Capitolo"
           value={capitolo}
           onChange={e => setCapitolo(e.target.value)}
         />
         <input
           id="det-numero"
+          data-testid="det-numero"
           placeholder="Numero"
           value={numero}
           onChange={e => setNumero(e.target.value)}
         />
         <input
           id="det-somma"
+          data-testid="det-somma"
           type="number"
           step="0.01"
           placeholder="Somma"
@@ -194,6 +197,7 @@ const DeterminationsPage: React.FC = () => {
         />
         <textarea
           id="det-descrizione"
+          data-testid="det-descrizione"
           placeholder="Descrizione"
           value={descrizione}
           onChange={e => setDescrizione(e.target.value)}
@@ -201,12 +205,13 @@ const DeterminationsPage: React.FC = () => {
         <label htmlFor="det-scadenza">Scadenza</label>
         <input
           id="det-scadenza"
+          data-testid="det-scadenza"
           type="date"
           value={scadenza}
           onChange={e => setScadenza(e.target.value)}
         />
-        <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
-        {edit && <button type="button" onClick={reset}>Annulla</button>}
+        <button data-testid="det-submit" type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
+        {edit && <button data-testid="det-cancel" type="button" onClick={reset}>Annulla</button>}
       </form>
       <table className="item-table">
         <thead>
@@ -228,8 +233,12 @@ const DeterminationsPage: React.FC = () => {
               <td>{d.descrizione}</td>
               <td>{new Date(d.scadenza).toLocaleDateString()}</td>
               <td>
-                <button onClick={() => onEdit(d)}>Modifica</button>
-                <button onClick={() => onDelete(d.id)}>Elimina</button>
+                <button data-testid="det-edit" onClick={() => onEdit(d)}>
+                  Modifica
+                </button>
+                <button data-testid="det-delete" onClick={() => onDelete(d.id)}>
+                  Elimina
+                </button>
               </td>
             </tr>
           ))}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -171,11 +171,11 @@ export default function TodoPage() {
     <div className="list-page">
         <h2>To-Do</h2>
         <form onSubmit={onSubmit} className="item-form">
-        <input id="todo-text" placeholder="Attività" value={text} onChange={e => setText(e.target.value)} />
+        <input id="todo-text" data-testid="todo-text" placeholder="Attività" value={text} onChange={e => setText(e.target.value)} />
         <label htmlFor="todo-due">Scadenza</label>
-        <input id="todo-due" type="date" value={due} onChange={e => setDue(e.target.value)} />
-        <button type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
-        {edit && <button type="button" onClick={reset}>Annulla</button>}
+        <input id="todo-due" data-testid="todo-due" type="date" value={due} onChange={e => setDue(e.target.value)} />
+        <button data-testid="todo-submit" type="submit">{edit ? 'Salva' : 'Aggiungi'}</button>
+        {edit && <button data-testid="todo-cancel" type="button" onClick={reset}>Annulla</button>}
       </form>
       <details className="item-dropdown" open={!isMobile}>
         <summary>{isMobile ? 'Lista to-do salvati' : 'Todo salvati'}</summary>
@@ -195,8 +195,12 @@ export default function TodoPage() {
               <td>
                 {!t.readonly && (
                   <>
-                    <button onClick={() => onEdit(t)}>Modifica</button>
-                    <button onClick={() => onDelete(t.id)}>Elimina</button>
+                    <button data-testid="todo-edit" onClick={() => onEdit(t)}>
+                      Modifica
+                    </button>
+                    <button data-testid="todo-delete" onClick={() => onDelete(t.id)}>
+                      Elimina
+                    </button>
                   </>
                 )}
               </td>

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -20,12 +20,12 @@ describe('DeterminationsPage', () => {
       </MemoryRouter>
     );
 
-    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'C1');
-    await userEvent.type(screen.getByPlaceholderText('Numero'), '001');
-    await userEvent.type(screen.getByPlaceholderText('Somma'), '10');
-    await userEvent.type(screen.getByPlaceholderText('Descrizione'), 'desc');
-    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-06-10');
-    await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
+    await userEvent.type(screen.getByTestId('det-capitolo'), 'C1');
+    await userEvent.type(screen.getByTestId('det-numero'), '001');
+    await userEvent.type(screen.getByTestId('det-somma'), '10');
+    await userEvent.type(screen.getByTestId('det-descrizione'), 'desc');
+    await userEvent.type(screen.getByTestId('det-scadenza'), '2023-06-10');
+    await userEvent.click(screen.getByTestId('det-submit'));
 
     expect(await screen.findByText(/C1/)).toBeInTheDocument();
   });
@@ -47,18 +47,18 @@ describe('DeterminationsPage', () => {
     );
 
     await screen.findByText(/A/);
-    await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
-    await userEvent.clear(screen.getByPlaceholderText('Capitolo'));
-    await userEvent.type(screen.getByPlaceholderText('Capitolo'), 'B');
-    await userEvent.clear(screen.getByPlaceholderText('Numero'));
-    await userEvent.type(screen.getByPlaceholderText('Numero'), '2');
-    await userEvent.clear(screen.getByPlaceholderText('Somma'));
-    await userEvent.type(screen.getByPlaceholderText('Somma'), '6');
-    await userEvent.clear(screen.getByPlaceholderText('Descrizione'));
-    await userEvent.type(screen.getByPlaceholderText('Descrizione'), 'new');
-    await userEvent.clear(screen.getByLabelText('Scadenza'));
-    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-02-02');
-    await userEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await userEvent.click(screen.getByTestId('det-edit'));
+    await userEvent.clear(screen.getByTestId('det-capitolo'));
+    await userEvent.type(screen.getByTestId('det-capitolo'), 'B');
+    await userEvent.clear(screen.getByTestId('det-numero'));
+    await userEvent.type(screen.getByTestId('det-numero'), '2');
+    await userEvent.clear(screen.getByTestId('det-somma'));
+    await userEvent.type(screen.getByTestId('det-somma'), '6');
+    await userEvent.clear(screen.getByTestId('det-descrizione'));
+    await userEvent.type(screen.getByTestId('det-descrizione'), 'new');
+    await userEvent.clear(screen.getByTestId('det-scadenza'));
+    await userEvent.type(screen.getByTestId('det-scadenza'), '2023-02-02');
+    await userEvent.click(screen.getByTestId('det-submit'));
 
     expect(await screen.findByText(/B/)).toBeInTheDocument();
   });

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -42,9 +42,9 @@ describe('TodoPage offline', () => {
       </MemoryRouter>
     );
 
-    await userEvent.type(screen.getByPlaceholderText('Attività'), 'Task 1');
-    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-06-01');
-    await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
+    await userEvent.type(screen.getByTestId('todo-text'), 'Task 1');
+    await userEvent.type(screen.getByTestId('todo-due'), '2023-06-01');
+    await userEvent.click(screen.getByTestId('todo-submit'));
 
     expect(await screen.findByText('Task 1')).toBeInTheDocument();
   });
@@ -64,13 +64,13 @@ describe('TodoPage offline', () => {
     );
 
     await screen.findByText('Task');
-    await userEvent.click(screen.getByRole('button', { name: /modifica/i }));
+    await userEvent.click(screen.getByTestId('todo-edit'));
 
-    await userEvent.clear(screen.getByPlaceholderText('Attività'));
-    await userEvent.type(screen.getByPlaceholderText('Attività'), 'Task edited');
-    await userEvent.clear(screen.getByLabelText('Scadenza'));
-    await userEvent.type(screen.getByLabelText('Scadenza'), '2023-02-02');
-    await userEvent.click(screen.getByRole('button', { name: /salva/i }));
+    await userEvent.clear(screen.getByTestId('todo-text'));
+    await userEvent.type(screen.getByTestId('todo-text'), 'Task edited');
+    await userEvent.clear(screen.getByTestId('todo-due'));
+    await userEvent.type(screen.getByTestId('todo-due'), '2023-02-02');
+    await userEvent.click(screen.getByTestId('todo-submit'));
 
     expect(await screen.findByText('Task edited')).toBeInTheDocument();
   });
@@ -90,7 +90,7 @@ describe('TodoPage offline', () => {
     );
 
     await screen.findByText('Task');
-    await userEvent.click(screen.getByRole('button', { name: /elimina/i }));
+    await userEvent.click(screen.getByTestId('todo-delete'));
 
     expect(screen.queryByText('Task')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- add `data-testid` attributes to determination inputs and buttons
- add `data-testid` attributes to todo inputs and buttons
- update tests for determinations and todo pages to use `getByTestId`
- keep EventsPage tests unchanged

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861caf8ab0c8323afa76810d5b727e7