### PR TITLE
Update tests to use data-testid

### DIFF
--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -63,8 +63,8 @@ describe('EventsPage', () => {
       </MemoryRouter>
     );
 
-    await userEvent.type(screen.getByLabelText('Titolo'), 'My Event');
-    await userEvent.type(screen.getByLabelText('Descrizione'), 'Desc');
+    await userEvent.type(screen.getByTestId('event-title'), 'My Event');
+    await userEvent.type(screen.getByTestId('event-description'), 'Desc');
     const dateInput = container.querySelector('input[type="datetime-local"]') as HTMLInputElement;
     await userEvent.type(dateInput, '2023-05-01T12:00');
     await userEvent.click(screen.getByLabelText(/pubblico/i));


### PR DESCRIPTION
## Summary
- use new data-testid attributes in EventsPage tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c82a33488323af8bc984d3505e3b