### PR TITLE
Show all todos in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -28,7 +28,7 @@ export default function Dashboard() {
   const upcomingEvents = events.filter(
     e => differenceInCalendarDays(parseISO(e.dateTime), today) <= 3
   );
-  const upcomingTodos = todos.filter(t => differenceInCalendarDays(parseISO(t.due), today) <= 3);
+  const dashboardTodos = todos;
 
   return (
     <div className="dashboard">
@@ -38,10 +38,10 @@ export default function Dashboard() {
           <div className="notifications dashboard-section">
             <h2>Todo list 📝</h2>
             <ul>
-              {upcomingTodos.map(t => (
+              {dashboardTodos.map(t => (
                 <li key={t.id}>{t.text} – {new Date(t.due).toLocaleDateString()}</li>
               ))}
-              {!upcomingTodos.length && <li>Nessun todo imminente.</li>}
+              {!dashboardTodos.length && <li>Nessun todo.</li>}
             </ul>
           </div>
           <div className="notifications dashboard-section">


### PR DESCRIPTION
## Summary
- display all todos in the dashboard instead of only upcoming ones

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861cd8465908323a9c5f4e12b3a6e8e