### PR TITLE
Add PDF API support

### DIFF
--- a/src/api/pdfs.ts
+++ b/src/api/pdfs.ts
@@ -1,0 +1,13 @@
+import api from './axios'
+import type { PDFFile } from './types'
+
+export const listPDFs = (): Promise<PDFFile[]> =>
+  api.get<PDFFile[]>('/pdfs').then(r => r.data)
+
+export const uploadPDF = (file: File): Promise<PDFFile> => {
+  const data = new FormData()
+  data.append('file', file)
+  return api.post<PDFFile>('/pdfs', data, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  }).then(r => r.data)
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -12,3 +12,9 @@ export interface GcEvent {
   }
   visibility?: string
 }
+
+export interface PDFFile {
+  id: string
+  name: string
+  url: string
+}


### PR DESCRIPTION
## Summary
- add `PDFFile` interface for PDF management
- implement `listPDFs()` and `uploadPDF()` API helpers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862561179e88323ac020ad2d62807e9