### PR TITLE
Add Utilita page for PDF management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Dashboard from "./pages/Dashboard";
 import EventsPage from "./pages/EventsPage";
 import TodoPage from "./pages/TodoPage";
 import DeterminationsPage from "./pages/DeterminationsPage";
+import UtilitaPage from "./pages/UtilitaPage";
 
 
 const App: React.FC = () => {
@@ -36,6 +37,7 @@ const App: React.FC = () => {
           <Route path="/events" element={<EventsPage />} />
           <Route path="/todo" element={<TodoPage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
+          <Route path="/utilita" element={<UtilitaPage />} />
         </Route>
 
         {/* Qualunque altra rotta redirige alla dashboard */}

--- a/src/api/utilita.ts
+++ b/src/api/utilita.ts
@@ -1,0 +1,24 @@
+import api from './axios'
+
+export interface PdfFile {
+  id: string
+  titolo: string
+  url: string
+}
+
+export const listPdfs = (): Promise<PdfFile[]> =>
+  api.get<PdfFile[]>('/utilita').then(r => r.data)
+
+export const uploadPdf = (
+  file: File,
+  titolo: string
+): Promise<PdfFile> => {
+  const data = new FormData()
+  data.append('file', file)
+  data.append('titolo', titolo)
+  return api
+    .post<PdfFile>('/utilita', data, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    })
+    .then(r => r.data)
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -23,6 +23,7 @@ const Header: React.FC = () => {
         <Link to="/events">📅 Eventi</Link>
         <Link to="/todo">📝 To-Do</Link>
         <Link to="/determinazioni">📄 Determine</Link>
+        <Link to="/utilita">📁 Utilità</Link>
         <button onClick={logout}>Esci</button>
       </nav>
     </header>

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useState } from 'react'
+import { listPdfs, uploadPdf, PdfFile } from '../api/utilita'
+import './ListPages.css'
+
+export default function UtilitaPage() {
+  const [items, setItems] = useState<PdfFile[]>([])
+  const [file, setFile] = useState<File | null>(null)
+  const [title, setTitle] = useState('')
+  const isMobile = window.innerWidth <= 600
+
+  const saveLocal = (data: PdfFile[]) => {
+    localStorage.setItem('pdfs', JSON.stringify(data))
+  }
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (navigator.onLine) {
+        try {
+          const data = await listPdfs()
+          setItems(data)
+          saveLocal(data)
+          return
+        } catch {
+          // ignore and try local storage
+        }
+      }
+      const stored = localStorage.getItem('pdfs')
+      if (stored) {
+        try {
+          setItems(JSON.parse(stored) as PdfFile[])
+        } catch {
+          // ignore
+        }
+      }
+    }
+    fetchData()
+  }, [])
+
+  const reset = () => {
+    setFile(null)
+    setTitle('')
+  }
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!file || !title) return
+
+    let newItem: PdfFile | null = null
+    if (navigator.onLine) {
+      try {
+        newItem = await uploadPdf(file, title)
+      } catch {
+        // ignore
+      }
+    }
+    if (!newItem) {
+      newItem = {
+        id: Date.now().toString(),
+        titolo: title,
+        url: URL.createObjectURL(file),
+      }
+    }
+    const updated = [...items, newItem]
+    setItems(updated)
+    saveLocal(updated)
+    reset()
+  }
+
+  return (
+    <div className="list-page">
+      <h2>Utilità</h2>
+      <form onSubmit={onSubmit} className="item-form">
+        <input
+          id="util-title"
+          placeholder="Titolo"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <input
+          id="util-file"
+          type="file"
+          accept="application/pdf"
+          onChange={e => setFile(e.target.files ? e.target.files[0] : null)}
+        />
+        <button type="submit">Carica</button>
+      </form>
+      <details className="item-dropdown" open={!isMobile}>
+        <summary>{isMobile ? 'Lista PDF caricati' : 'PDF caricati'}</summary>
+        <table className="item-table">
+          <thead>
+            <tr>
+              <th>Titolo</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map(p => (
+              <tr key={p.id}>
+                <td>
+                  <a href={p.url} target="_blank" rel="noopener noreferrer">
+                    {p.titolo}
+                  </a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create API helpers for pdf utilities
- add UtilitaPage with upload form and table
- wire UtilitaPage into routes and navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862561474988323b91f9a7d6de2377c