### PR TITLE
Add .env.example and stop tracking secrets

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VITE_API_URL="https://segretaria-digitale-backend.onrender.com"
-VITE_GAPI_CLIENT_ID="915439779647-54l80fl9mdsu71j6lsn8n1ggao2p5br6.apps.googleusercontent.com"
-VITE_GAPI_API_KEY="AIzaSyAxum50Fxrntu2tewEsDCFOQbE3ortfaMc"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VITE_API_URL="https://your-backend-url"
+VITE_GAPI_CLIENT_ID="your-google-client-id"
+VITE_GAPI_API_KEY="your-google-api-key"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 ./scripts/setup.sh
 ```
 
-3. Copy `.env.example` to `.env` and replace the placeholder values:
+3. Copy the sample `.env.example` to `.env` and replace the placeholder values:
 
 ```
 cp .env.example .env


### PR DESCRIPTION
## Summary
- stop tracking `.env`
- add `.env.example` placeholders
- mention `.env.example` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625a4abdb48323b4e6ad451f95b3f7