### PR TITLE
Implement UtilitaPage uploads

### DIFF
--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,5 +1,56 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { listPDFs, uploadPDF } from '../api/pdfs';
+import type { PDFFile } from '../api/types';
+import './ListPages.css';
 
 export default function UtilitaPage() {
-  return <div>Utilita</div>;
+  const [pdfs, setPdfs] = useState<PDFFile[]>([]);
+
+  useEffect(() => {
+    const fetchPdfs = async () => {
+      try {
+        const data = await listPDFs();
+        setPdfs(data);
+      } catch {
+        // ignore errors fetching PDFs
+      }
+    };
+    fetchPdfs();
+  }, []);
+
+  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const uploaded = await uploadPDF(file);
+      setPdfs(p => [...p, uploaded]);
+    } catch {
+      // ignore upload errors
+    } finally {
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <div className="list-page">
+      <h2>Utilità</h2>
+      <form className="item-form">
+        <input
+          data-testid="pdf-input"
+          type="file"
+          accept="application/pdf"
+          onChange={onChange}
+        />
+      </form>
+      <ul className="item-list">
+        {pdfs.map(p => (
+          <li key={p.id}>
+            <a href={p.url} target="_blank" rel="noopener noreferrer">
+              {p.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UtilitaPage from '../UtilitaPage';
+import PageTemplate from '../../components/PageTemplate';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import * as pdfApi from '../../api/pdfs';
+
+jest.mock('../../api/pdfs', () => ({
+  __esModule: true,
+  listPDFs: jest.fn(),
+  uploadPDF: jest.fn(),
+}));
+
+const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
+
+beforeEach(() => {
+  mockedApi.listPDFs.mockResolvedValue([]);
+  mockedApi.uploadPDF.mockImplementation(async file => ({
+    id: '1',
+    name: file.name,
+    url: '/'+file.name,
+  }));
+});
+
+describe('UtilitaPage', () => {
+  it('shows PDFs from API', async () => {
+    mockedApi.listPDFs.mockResolvedValue([{ id: '1', name: 'doc.pdf', url: '/doc.pdf' }]);
+
+    render(
+      <MemoryRouter initialEntries={["/utilita"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/utilita" element={<UtilitaPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('doc.pdf')).toBeInTheDocument();
+  });
+
+  it('uploads new PDF', async () => {
+    render(
+      <MemoryRouter initialEntries={["/utilita"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/utilita" element={<UtilitaPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const file = new File(['a'], 'new.pdf', { type: 'application/pdf' });
+    await userEvent.upload(screen.getByTestId('pdf-input'), file);
+
+    expect(mockedApi.uploadPDF).toHaveBeenCalledWith(file);
+    expect(await screen.findByText('new.pdf')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- expand `UtilitaPage` to list PDFs and allow uploading new ones
- add tests for the new Utilità page behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625a4c70f08323910b3d37db916f9c