### PR TITLE
Add rewrite rule for SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "buildCommand": "npm run build",
   "outputDirectory": "dist"
 }
+


### PR DESCRIPTION
## Summary
- configure Vercel rewrites so sub routes resolve to `index.html`

## Testing
- `npm test` *(fails: jest not found)*
- `npx vercel deploy --prod` *(fails: network access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68625f468cb08323a6ed375dbd05c46a