### PR TITLE
Document test setup and add pretest hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,19 @@ export.
 
 ## Testing
 
-Run the Jest test suite:
+Before running tests, install dependencies if you haven't already:
+
+```bash
+npm install
+# or run the helper script
+./scripts/setup.sh
+```
+
+Then run the Jest test suite:
 
 ```bash
 npm test
 ```
-
-If Jest is missing, ensure dependencies are installed first using `npm install`
-or `./scripts/setup.sh`.
 
 The tests use Jest together with React Testing Library.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite --host --port 3000",
     "build": "vite build",
     "serve": "vite preview",
+    "pretest": "test -x node_modules/.bin/jest || npm install",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- highlight that dependencies must be installed before running tests
- add a `pretest` script to install missing Jest automatically

## Testing
- `npm test` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68626608b08483239b774df82c05190d