### PR TITLE
Use atob for token decoding

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,7 @@
 export function decodeToken(token: string): any | null {
   try {
     const payload = token.split('.')[1];
-    const json = Buffer.from(payload, 'base64').toString('utf8');
+    const json = atob(payload);
     return JSON.parse(json);
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- replace Buffer usage with `atob` in `decodeToken`

## Testing
- `npx tsc src/utils/auth.ts --noEmit --lib ESNext,DOM`
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862660952ec8323b267698334f498e7