### PR TITLE
Apply Cormorant Garamond font

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,11 @@
       href="https://fonts.googleapis.com/css2?family=Imperial+Script&display=swap"
       rel="stylesheet"
     />
+    <!-- Cormorant Garamond font -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap"
+      rel="stylesheet"
+    />
 
 
   </head>

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -6,6 +6,7 @@
   background-color: #001f3f;
   color: #fff;
   padding: 1.5rem 1.5rem;
+  font-family: 'Almendra SC', serif;
 }
 .site-header nav a {
   color: #fff;

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
    https://designers.italia.it/kit/grafica/ */
 @import url('https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Imperial+Script&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap');
 
 * {
   box-sizing: border-box;
@@ -9,13 +10,14 @@
 
 body {
   margin: 0;
-  font-family: 'Almendra SC', serif;
+  font-family: 'Cormorant Garamond', serif;
   font-weight: 600;
   color: #333;
   background: url('/Login.png') no-repeat center/cover fixed;
 }
 body.login-bg {
   background-size: contain;
+  font-family: 'Almendra SC', serif;
 }
 
 


### PR DESCRIPTION
## Summary
- load Cormorant Garamond from Google Fonts
- make Cormorant Garamond the default font
- keep header and login page styled with Almendra SC

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68626cebfa2083239d11828a5b115a93