### PR TITLE
Add delete option for Dashboard todos

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -41,6 +41,23 @@
   border: 1px solid #ddd;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.notifications li button {
+  margin-left: 0.5rem;
+  background: #A52019;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.notifications li button:hover {
+  background: #8B1B13;
 }
 
 .upcoming-wrapper {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
+import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
 import Greeting from '../components/Greeting';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
@@ -21,7 +22,7 @@ export default function Dashboard() {
     [token]
   );
   const [events] = useLocalStorage<EventItem[]>('events', []);
-  const [todos] = useLocalStorage<TodoItem[]>(todoKey, []);
+  const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
   const CALENDAR_ID = 'plcastionedellapresolana@gmail.com';
 
   const today = new Date();
@@ -29,6 +30,18 @@ export default function Dashboard() {
     e => differenceInCalendarDays(parseISO(e.dateTime), today) <= 3
   );
   const dashboardTodos = todos;
+
+  const onDelete = async (id: string): Promise<void> => {
+    if (navigator.onLine) {
+      try {
+        await deleteTodo(id);
+      } catch {
+        // ignore
+      }
+    }
+    const updated = todos.filter(t => t.id !== id);
+    setTodos(updated);
+  };
 
   return (
     <div className="dashboard">
@@ -39,7 +52,15 @@ export default function Dashboard() {
             <h2>Todo list 📝</h2>
             <ul>
               {dashboardTodos.map(t => (
-                <li key={t.id}>{t.text} – {new Date(t.due).toLocaleDateString()}</li>
+                <li key={t.id}>
+                  <span>{t.text} – {new Date(t.due).toLocaleDateString()}</span>
+                  <button
+                    data-testid="dashboard-delete"
+                    onClick={() => onDelete(t.id)}
+                  >
+                    ×
+                  </button>
+                </li>
               ))}
               {!dashboardTodos.length && <li>Nessun todo.</li>}
             </ul>

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Dashboard from '../Dashboard';
+import PageTemplate from '../../components/PageTemplate';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('Dashboard', () => {
+  it('deletes todo from dashboard', async () => {
+    localStorage.setItem(
+      'todos',
+      JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01' }])
+    );
+    Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>            
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Task');
+    await userEvent.click(screen.getByTestId('dashboard-delete'));
+
+    expect(screen.queryByText('Task')).not.toBeInTheDocument();
+  });
+});
+


### PR DESCRIPTION
## Summary
- allow deleting todos directly on the dashboard
- style delete button and list items
- add regression test for dashboard todo removal

## Testing
- `npm test` *(fails: 403 Forbidden when trying to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68626e14b100832383ece1411974c0cd