### PR TITLE
Fix duplicated determina todos

### DIFF
--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -84,9 +84,15 @@ export default function TodoPage() {
           readonly: true,
         }));
 
+      // remove previous determina reminders to avoid duplicates
+      all = all.filter(t => !t.id.startsWith('det-'));
       all = [...all, ...detTodos];
-      setTodos(all);
-      saveLocal(all);
+
+      // ensure unique ids (in case of duplicates from storage)
+      const map = new Map(all.map(t => [t.id, t]));
+      const unique = Array.from(map.values());
+      setTodos(unique);
+      saveLocal(unique);
     };
     fetchTodos();
   }, [storageKey]);


### PR DESCRIPTION
## Summary
- prevent repeated determina reminders by filtering and deduplicating before saving todos

## Testing
- `npm test` *(fails: 403 Forbidden when trying to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68626ebdafa483238b85df244766456e