### PR TITLE
Add cross-tab sync to useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -10,5 +10,17 @@ export default function useLocalStorage<T>(key: string, initial: T) {
     localStorage.setItem(key, JSON.stringify(value));
   }, [key, value]);
 
+  useEffect(() => {
+    const handler = (e: StorageEvent) => {
+      if (e.key === key) {
+        setValue(e.newValue ? JSON.parse(e.newValue) : initial);
+      }
+    };
+    window.addEventListener('storage', handler);
+    return () => {
+      window.removeEventListener('storage', handler);
+    };
+  }, [key, initial]);
+
   return [value, setValue] as const;
 }


### PR DESCRIPTION
## Summary
- update `useLocalStorage` hook to listen for `storage` events
- refresh stored value when another tab updates localStorage

## Testing
- `npm test` *(fails: E403 Forbidden while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68626ebed0008323b4a7fb0a4a39cb27