### PR TITLE
Remove @imported fonts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,5 @@
 /* Styles based on the "grafica istituzionale" guidelines
    https://designers.italia.it/kit/grafica/ */
-@import url('https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Imperial+Script&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap');
 
 * {
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- avoid importing Google fonts twice by removing @import

## Testing
- `npm test` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862c8296ba88323b79d001cbbd65046