### PR TITLE
Move Greeting next to Dashboard title

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -5,6 +5,13 @@
   padding: 1rem;
 }
 
+.dashboard-header {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+
 .dashboard h1 {
   text-align: center;
   color: red;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -45,8 +45,10 @@ export default function Dashboard() {
 
   return (
     <div className="dashboard">
-        <Greeting />
+      <div className="dashboard-header">
         <h1>Dashboard</h1>
+        <Greeting />
+      </div>
         <div className="upcoming-wrapper">
           <div className="notifications dashboard-section">
             <h2>Todo list 📝</h2>


### PR DESCRIPTION
## Summary
- keep greeting visible but move it right next to the Dashboard heading
- add a small flex container for the heading and greeting

## Testing
- `npm test` *(fails: E403 Forbidden while fetching from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6862f103589083239e481e0ae7bba32b