### PR TITLE
Remove PDF upload feature

### DIFF
--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { listPDFs, uploadPDF } from '../api/pdfs';
+import { listPDFs } from '../api/pdfs';
 import type { PDFFile } from '../api/types';
 import './ListPages.css';
 
@@ -18,30 +18,10 @@ export default function UtilitaPage() {
     fetchPdfs();
   }, []);
 
-  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    try {
-      const uploaded = await uploadPDF(file);
-      setPdfs(p => [...p, uploaded]);
-    } catch {
-      // ignore upload errors
-    } finally {
-      e.target.value = '';
-    }
-  };
 
   return (
     <div className="list-page">
       <h2>Utilità</h2>
-      <form className="item-form">
-        <input
-          data-testid="pdf-input"
-          type="file"
-          accept="application/pdf"
-          onChange={onChange}
-        />
-      </form>
       <ul className="item-list">
         {pdfs.map(p => (
           <li key={p.id}>

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import UtilitaPage from '../UtilitaPage';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
@@ -8,18 +7,12 @@ import * as pdfApi from '../../api/pdfs';
 jest.mock('../../api/pdfs', () => ({
   __esModule: true,
   listPDFs: jest.fn(),
-  uploadPDF: jest.fn(),
 }));
 
 const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
 
 beforeEach(() => {
   mockedApi.listPDFs.mockResolvedValue([]);
-  mockedApi.uploadPDF.mockImplementation(async file => ({
-    id: '1',
-    name: file.name,
-    url: '/'+file.name,
-  }));
 });
 
 describe('UtilitaPage', () => {
@@ -39,21 +32,4 @@ describe('UtilitaPage', () => {
     expect(await screen.findByText('doc.pdf')).toBeInTheDocument();
   });
 
-  it('uploads new PDF', async () => {
-    render(
-      <MemoryRouter initialEntries={["/utilita"]}>
-        <Routes>
-          <Route element={<PageTemplate />}>
-            <Route path="/utilita" element={<UtilitaPage />} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
-
-    const file = new File(['a'], 'new.pdf', { type: 'application/pdf' });
-    await userEvent.upload(screen.getByTestId('pdf-input'), file);
-
-    expect(mockedApi.uploadPDF).toHaveBeenCalledWith(file);
-    expect(await screen.findByText('new.pdf')).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
## Summary
- disable PDF uploads on Utilità page
- drop upload PDF tests

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `npx jest --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_6862f3abfce88323b50a620275f1efc8