### PR TITLE
Remove PDF upload

### DIFF
--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { listPDFs, uploadPDF } from '../api/pdfs';
+import { listPDFs } from '../api/pdfs';
 import type { PDFFile } from '../api/types';
 import './ListPages.css';
 
@@ -18,30 +18,12 @@ export default function UtilitaPage() {
     fetchPdfs();
   }, []);
 
-  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    try {
-      const uploaded = await uploadPDF(file);
-      setPdfs(p => [...p, uploaded]);
-    } catch {
-      // ignore upload errors
-    } finally {
-      e.target.value = '';
-    }
-  };
+  // Upload functionality removed
 
   return (
     <div className="list-page">
       <h2>Utilità</h2>
-      <form className="item-form">
-        <input
-          data-testid="pdf-input"
-          type="file"
-          accept="application/pdf"
-          onChange={onChange}
-        />
-      </form>
+      {/* Upload form removed */}
       <ul className="item-list">
         {pdfs.map(p => (
           <li key={p.id}>

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import UtilitaPage from '../UtilitaPage';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
@@ -8,18 +7,12 @@ import * as pdfApi from '../../api/pdfs';
 jest.mock('../../api/pdfs', () => ({
   __esModule: true,
   listPDFs: jest.fn(),
-  uploadPDF: jest.fn(),
 }));
 
 const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
 
 beforeEach(() => {
   mockedApi.listPDFs.mockResolvedValue([]);
-  mockedApi.uploadPDF.mockImplementation(async file => ({
-    id: '1',
-    name: file.name,
-    url: '/'+file.name,
-  }));
 });
 
 describe('UtilitaPage', () => {
@@ -39,21 +32,4 @@ describe('UtilitaPage', () => {
     expect(await screen.findByText('doc.pdf')).toBeInTheDocument();
   });
 
-  it('uploads new PDF', async () => {
-    render(
-      <MemoryRouter initialEntries={["/utilita"]}>
-        <Routes>
-          <Route element={<PageTemplate />}>
-            <Route path="/utilita" element={<UtilitaPage />} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
-
-    const file = new File(['a'], 'new.pdf', { type: 'application/pdf' });
-    await userEvent.upload(screen.getByTestId('pdf-input'), file);
-
-    expect(mockedApi.uploadPDF).toHaveBeenCalledWith(file);
-    expect(await screen.findByText('new.pdf')).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
## Summary
- remove PDF upload logic from utilities page
- drop upload form and adjust tests accordingly

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6862f3c05df883238491d0dccce814c4