### PR TITLE
Move greeting to header with time-aware message

### DIFF
--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -12,7 +12,11 @@ const Greeting: React.FC = () => {
   if (!email) return null;
 
   const username = email.endsWith('@comune.castione.bg.it') ? email.split('@')[0] : email;
-  return <div className="user-greeting">Ciao {username}</div>;
+
+  const hours = new Date().getHours();
+  const saluto = hours < 17 ? 'Buongiorno' : 'Buonasera';
+
+  return <div className="user-greeting">{saluto} {username}</div>;
 };
 
 export default Greeting;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -22,6 +22,10 @@
   display: flex;
   align-items: center;
 }
+.title-greeting {
+  display: flex;
+  flex-direction: column;
+}
 .site-header h1 {
   font-size: 2rem;
   margin: 0;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../store/auth";
+import Greeting from "./Greeting";
 import "./Header.css";
 
 const Header: React.FC = () => {
@@ -16,7 +17,10 @@ const Header: React.FC = () => {
     <header className="site-header">
       <div className="logo-title">
         <img src="/logo.png" alt="Logo" className="small-logo" />
-        <h1>Polizia Locale - Castione della Presolana</h1>
+        <div className="title-greeting">
+          <h1>Polizia Locale - Castione della Presolana</h1>
+          <Greeting />
+        </div>
       </div>
       <nav>
         <Link to="/">🏠 Dashboard</Link>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
-import Greeting from '../components/Greeting';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 interface EventItem {
   id: string;
@@ -47,7 +46,6 @@ export default function Dashboard() {
     <div className="dashboard">
       <div className="dashboard-header">
         <h1>Dashboard</h1>
-        <Greeting />
       </div>
         <div className="upcoming-wrapper">
           <div className="notifications dashboard-section">


### PR DESCRIPTION
## Summary
- show Greeting component inside the header
- greet users with "Buongiorno" or "Buonasera" based on time of day
- remove greeting from dashboard

## Testing
- `npm test` *(fails: npm cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_6862f47df9e483239140b131629c0c8e