### PR TITLE
Ensure npm test runs offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This project contains the React front end of **Segretaria Digitale**, a simple a
 2. Install dependencies (creates `node_modules/.bin/jest` used by the test suite):
 
 ```bash
-npm install
+# Use a clean, reproducible install
+npm ci
 # or run the helper script
 ./scripts/setup.sh
 ```
@@ -68,12 +69,13 @@ export.
 Before running tests, install dependencies if you haven't already:
 
 ```bash
-npm install
+# Perform a clean install using the lockfile
+npm ci
 # or run the helper script
 ./scripts/setup.sh
 ```
 
-Then run the Jest test suite:
+Then run the Jest test suite (dependencies will be installed from the lockfile in offline mode if missing):
 
 ```bash
 npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "vite --host --port 3000",
     "build": "vite build",
     "serve": "vite preview",
-    "pretest": "test -x node_modules/.bin/jest || npm install",
+    "pretest": "test -x node_modules/.bin/jest || npm ci --offline",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- install dependencies in pretest using `npm ci --offline`
- document using `npm ci` and offline behavior in README

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_6862f610db3483238591d07c80dea0ef