### PR TITLE
Fix empty headers in events table

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -267,9 +267,9 @@ export default function EventsPage() {
       <table className="item-table">
         <thead>
           <tr>
-            <th></th>
-            <th></th>
-            <th></th>
+            <th>Titolo</th>
+            <th>Data e ora</th>
+            <th>Descrizione</th>
             <th>Pubblico?</th>
             <th></th>
           </tr>


### PR DESCRIPTION
## Summary
- fill in the headers for the events table

## Testing
- `npm test` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862f66d41e8832384eae409bf4334af