### PR TITLE
Move greeting to header

### DIFF
--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -12,7 +12,11 @@ const Greeting: React.FC = () => {
   if (!email) return null;
 
   const username = email.endsWith('@comune.castione.bg.it') ? email.split('@')[0] : email;
-  return <div className="user-greeting">Ciao {username}</div>;
+  const hour = new Date().getHours();
+  let salutation = 'Buonasera';
+  if (hour < 12) salutation = 'Buongiorno';
+  else if (hour < 18) salutation = 'Buon pomeriggio';
+  return <div className="user-greeting">{salutation} {username}</div>;
 };
 
 export default Greeting;

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -31,6 +31,14 @@
   height: 90px;
   margin-right: 0.5rem;
 }
+.header-right {
+  display: flex;
+  align-items: center;
+}
+.header-right .user-greeting {
+  margin-right: 1rem;
+  font-size: 1.1rem;
+}
 .site-header button {
   background: #001f3f;
   color: #fff;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../store/auth";
+import Greeting from "./Greeting";
 import "./Header.css";
 
 const Header: React.FC = () => {
@@ -18,14 +19,17 @@ const Header: React.FC = () => {
         <img src="/logo.png" alt="Logo" className="small-logo" />
         <h1>Polizia Locale - Castione della Presolana</h1>
       </div>
-      <nav>
-        <Link to="/">🏠 Dashboard</Link>
-        <Link to="/events">📅 Eventi</Link>
-        <Link to="/todo">📝 To-Do</Link>
-        <Link to="/determinazioni">📄 Determine</Link>
-        <Link to="/utilita">⚙️ Utilità</Link>
-        <button onClick={logout}>Esci</button>
-      </nav>
+      <div className="header-right">
+        <Greeting />
+        <nav>
+          <Link to="/">🏠 Dashboard</Link>
+          <Link to="/events">📅 Eventi</Link>
+          <Link to="/todo">📝 To-Do</Link>
+          <Link to="/determinazioni">📄 Determine</Link>
+          <Link to="/utilita">⚙️ Utilità</Link>
+          <button onClick={logout}>Esci</button>
+        </nav>
+      </div>
     </header>
   );
 };

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -6,6 +6,10 @@ import PageTemplate from '../PageTemplate';
 const Dummy: React.FC = () => <div>Dummy Page</div>;
 
 describe('PageTemplate', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it('shows navigation, sidebar buttons and footer', () => {
     render(
       <MemoryRouter initialEntries={["/"]}>
@@ -29,5 +33,24 @@ describe('PageTemplate', () => {
     expect(
       screen.getByText(new RegExp(`© M.Fenaroli ${currentYear}`, 'i'))
     ).toBeInTheDocument();
+  });
+
+  it('displays greeting when user token exists', () => {
+    const payload = btoa(JSON.stringify({ email: 'test@comune.castione.bg.it' }));
+    localStorage.setItem('token', `xx.${payload}.yy`);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dummy />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const hour = new Date().getHours();
+    const salutation = hour < 12 ? 'Buongiorno' : hour < 18 ? 'Buon pomeriggio' : 'Buonasera';
+    expect(screen.getByText(new RegExp(`${salutation} test`, 'i'))).toBeInTheDocument();
   });
 });

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -5,17 +5,6 @@
   padding: 1rem;
 }
 
-.dashboard-header {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-}
-
-.dashboard h1 {
-  text-align: center;
-  color: red;
-}
 .dashboard-section {
   border: 1px solid #ddd;
   border-radius: 4px;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,6 @@ import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
-import Greeting from '../components/Greeting';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 interface EventItem {
   id: string;
@@ -45,9 +44,6 @@ export default function Dashboard() {
 
   return (
     <div className="dashboard">
-      <div className="dashboard-header">
-        <Greeting />
-      </div>
         <div className="upcoming-wrapper">
           <div className="notifications dashboard-section">
             <h2>Todo list 📝</h2>


### PR DESCRIPTION
## Summary
- add time-aware Greeting
- show the new greeting in Header
- remove Dashboard header container and styling
- test that greeting renders when logged in

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6862f5c490d48323bf1ef78ef461c5ce