### PR TITLE
Add Google Drive listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Edit `.env` to configure values for `VITE_API_URL`, `VITE_GAPI_CLIENT_ID` and
 `VITE_GAPI_API_KEY`. Make sure to supply your own Google credentials for the
 `VITE_GAPI_CLIENT_ID` and `VITE_GAPI_API_KEY` variables.
 
+The same credentials are used for both the Google Calendar and Google Drive
+integrations.
+
 The variables are:
 
 - `VITE_API_URL` – https://segretaria-digitale-backend.onrender.com.
@@ -61,7 +64,8 @@ This serves the `dist` directory using Vite's preview mode.
 When the development server is running you can visit `/utilita` for assorted
 administrative tools. The page is available at
 `http://localhost:3000/utilita` and provides quick links to actions such as PDF
-export.
+export. If you sign in with Google, the page also lists files from your Drive
+in addition to the PDFs served by the backend.
 
 ## Testing
 

--- a/src/api/googleDrive.ts
+++ b/src/api/googleDrive.ts
@@ -1,0 +1,26 @@
+import type { DriveFile } from './types'
+
+export const loadClient = async (): Promise<void> => {
+  const gapi = (window as any).gapi
+  await gapi.load('client:auth2')
+  await gapi.client.init({
+    apiKey: import.meta.env.VITE_GAPI_API_KEY,
+    clientId: import.meta.env.VITE_GAPI_CLIENT_ID,
+    discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
+    scope: 'https://www.googleapis.com/auth/drive.readonly',
+  })
+}
+
+export const signIn = async (): Promise<void> => {
+  const gapi = (window as any).gapi
+  if (!gapi.auth2 || !gapi.auth2.getAuthInstance()) {
+    await loadClient()
+  }
+  await gapi.auth2.getAuthInstance().signIn()
+}
+
+export const listDriveFiles = async (): Promise<DriveFile[]> => {
+  const gapi = (window as any).gapi
+  const res = await gapi.client.drive.files.list()
+  return res.result.files || []
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -18,3 +18,9 @@ export interface PDFFile {
   name: string
   url: string
 }
+
+export interface DriveFile {
+  id?: string
+  name?: string
+  mimeType?: string
+}

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { listPDFs } from '../api/pdfs';
-import type { PDFFile } from '../api/types';
+import { signIn as driveSignIn, listDriveFiles } from '../api/googleDrive';
+import type { PDFFile, DriveFile } from '../api/types';
 import './ListPages.css';
 
 export default function UtilitaPage() {
   const [pdfs, setPdfs] = useState<PDFFile[]>([]);
+  const [driveFiles, setDriveFiles] = useState<DriveFile[]>([]);
 
   useEffect(() => {
     const fetchPdfs = async () => {
@@ -15,7 +17,17 @@ export default function UtilitaPage() {
         // ignore errors fetching PDFs
       }
     };
+    const fetchDrive = async () => {
+      try {
+        await driveSignIn();
+        const data = await listDriveFiles();
+        setDriveFiles(data);
+      } catch {
+        // ignore errors fetching Drive files
+      }
+    };
     fetchPdfs();
+    fetchDrive();
   }, []);
 
 
@@ -23,6 +35,9 @@ export default function UtilitaPage() {
     <div className="list-page">
       <h2>Utilità</h2>
       <ul className="item-list">
+        {driveFiles.map(f => (
+          <li key={`drive-${f.id}`}>{f.name}</li>
+        ))}
         {pdfs.map(p => (
           <li key={p.id}>
             <a href={p.url} target="_blank" rel="noopener noreferrer">

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -3,16 +3,26 @@ import UtilitaPage from '../UtilitaPage';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import * as pdfApi from '../../api/pdfs';
+import * as driveApi from '../../api/googleDrive';
 
 jest.mock('../../api/pdfs', () => ({
   __esModule: true,
   listPDFs: jest.fn(),
 }));
 
+jest.mock('../../api/googleDrive', () => ({
+  __esModule: true,
+  signIn: jest.fn(),
+  listDriveFiles: jest.fn(),
+}));
+
 const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
+const mockedDriveApi = driveApi as jest.Mocked<typeof driveApi>;
 
 beforeEach(() => {
   mockedApi.listPDFs.mockResolvedValue([]);
+  mockedDriveApi.signIn.mockResolvedValue();
+  mockedDriveApi.listDriveFiles.mockResolvedValue([]);
 });
 
 describe('UtilitaPage', () => {
@@ -30,6 +40,22 @@ describe('UtilitaPage', () => {
     );
 
     expect(await screen.findByText('doc.pdf')).toBeInTheDocument();
+  });
+
+  it('shows files from Drive', async () => {
+    mockedDriveApi.listDriveFiles.mockResolvedValue([{ id: 'd1', name: 'drive.pdf' } as any]);
+
+    render(
+      <MemoryRouter initialEntries={["/utilita"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/utilita" element={<UtilitaPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('drive.pdf')).toBeInTheDocument();
   });
 
 });


### PR DESCRIPTION
## Summary
- add `googleDrive` API helper
- extend API types with `DriveFile`
- list Google Drive files in Utilità page
- update tests for the new API
- document the Google Drive integration

## Testing
- `npm test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6862f60e54e883239e0afac349d2f37e