### PR TITLE
Handle description field for determinations

### DIFF
--- a/src/api/determinations.ts
+++ b/src/api/determinations.ts
@@ -10,18 +10,35 @@ export interface Determination {
 }
 
 export const listDeterminations = (): Promise<Determination[]> =>
-  api.get<Determination[]>('/determinazioni').then(r => r.data)
+  api
+    .get<Determination[]>('/determinazioni')
+    .then(r =>
+      r.data.map(d => ({
+        ...d,
+        descrizione: (d as any).descrizione ?? (d as any).description ?? ''
+      }))
+    )
 
 export const createDetermination = (
   data: Omit<Determination, 'id'>
 ): Promise<Determination> =>
-  api.post<Determination>('/determinazioni', data).then(r => r.data)
+  api
+    .post<Determination>('/determinazioni', data)
+    .then(r => ({
+      ...r.data,
+      descrizione: (r.data as any).descrizione ?? (r.data as any).description ?? ''
+    }))
 
 export const updateDetermination = (
   id: string,
   data: Partial<Omit<Determination, 'id'>>
 ): Promise<Determination> =>
-  api.put<Determination>(`/determinazioni/${id}`, data).then(r => r.data)
+  api
+    .put<Determination>(`/determinazioni/${id}`, data)
+    .then(r => ({
+      ...r.data,
+      descrizione: (r.data as any).descrizione ?? (r.data as any).description ?? ''
+    }))
 
 export const deleteDetermination = (id: string): Promise<void> =>
   api.delete(`/determinazioni/${id}`).then(() => undefined)


### PR DESCRIPTION
## Summary
- map `description` field to `descrizione` in determination API calls

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa5dd91c8323afc8c75b68e035c7