### PR TITLE
Add description assertion in Determinations tests

### DIFF
--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -28,6 +28,7 @@ describe('DeterminationsPage', () => {
     await userEvent.click(screen.getByTestId('det-submit'));
 
     expect(await screen.findByText(/C1/)).toBeInTheDocument();
+    expect(await screen.findByText(/desc/)).toBeInTheDocument();
   });
 
   it('edits an existing determination', async () => {
@@ -61,5 +62,6 @@ describe('DeterminationsPage', () => {
     await userEvent.click(screen.getByTestId('det-submit'));
 
     expect(await screen.findByText(/B/)).toBeInTheDocument();
+    expect(await screen.findByText(/new/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- extend DeterminationsPage tests to verify description field is shown after creation and editing

## Testing
- `npm test` *(fails: ENOTCACHED, cannot download packages offline)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa5f64e08323a5db48116e96cc0f