### PR TITLE
Center greeting in header

### DIFF
--- a/src/components/Greeting.css
+++ b/src/components/Greeting.css
@@ -1,5 +1,5 @@
 .user-greeting {
-  text-align: left;
+  text-align: center;
   padding: 0.5rem 1rem;
   font-size: 1.1rem;
 }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -31,13 +31,13 @@
   height: 90px;
   margin-right: 0.5rem;
 }
+.header-center {
+  flex: 1;
+  text-align: center;
+}
 .header-right {
   display: flex;
   align-items: center;
-}
-.header-right .user-greeting {
-  margin-right: 1rem;
-  font-size: 1.1rem;
 }
 .site-header button {
   background: #001f3f;
@@ -59,6 +59,11 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-around;
+  }
+  .header-center {
+    width: 100%;
+    margin: 0.5rem 0;
+    text-align: center;
   }
   .site-header nav a,
   .site-header button {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,8 +19,10 @@ const Header: React.FC = () => {
         <img src="/logo.png" alt="Logo" className="small-logo" />
         <h1>Polizia Locale - Castione della Presolana</h1>
       </div>
-      <div className="header-right">
+      <div className="header-center">
         <Greeting />
+      </div>
+      <div className="header-right">
         <nav>
           <Link to="/">🏠 Dashboard</Link>
           <Link to="/events">📅 Eventi</Link>


### PR DESCRIPTION
## Summary
- center the greeting using a new `header-center` container
- update CSS to make the greeting text centered

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached')*

------
https://chatgpt.com/codex/tasks/task_e_6862fb096b1c832394a9a0acef976e07