### PR TITLE
Add login hint for Google Drive sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ When the development server is running you can visit `/utilita` for assorted
 administrative tools. The page is available at
 `http://localhost:3000/utilita` and provides quick links to actions such as PDF
 export. If you sign in with Google, the page also lists files from your Drive
-in addition to the PDFs served by the backend.
+in addition to the PDFs served by the backend. The Google Drive integration
+uses an optional login hint to suggest an account when opening the sign in
+dialog.
 
 ## Testing
 

--- a/src/api/googleDrive.ts
+++ b/src/api/googleDrive.ts
@@ -11,12 +11,14 @@ export const loadClient = async (): Promise<void> => {
   })
 }
 
-export const signIn = async (): Promise<void> => {
+export const signIn = async (loginHint?: string): Promise<void> => {
   const gapi = (window as any).gapi
   if (!gapi.auth2 || !gapi.auth2.getAuthInstance()) {
     await loadClient()
   }
-  await gapi.auth2.getAuthInstance().signIn()
+  await gapi.auth2
+    .getAuthInstance()
+    .signIn({ prompt: 'select_account', login_hint: loginHint })
 }
 
 export const listDriveFiles = async (): Promise<DriveFile[]> => {

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -19,7 +19,7 @@ export default function UtilitaPage() {
     };
     const fetchDrive = async () => {
       try {
-        await driveSignIn();
+        await driveSignIn('plcastionedellapresolana@gmail.com');
         const data = await listDriveFiles();
         setDriveFiles(data);
       } catch {


### PR DESCRIPTION
## Summary
- allow passing a login hint to `signIn` in `googleDrive.ts`
- pass the association email when authenticating from `UtilitaPage`
- note the optional login hint in the Utilità page section of the README

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_6862fcc553a083238614149f41561829