### PR TITLE
Add meeting links icons

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -138,3 +138,16 @@
     gap: 0.75rem;
   }
 }
+
+/* Links to videoconference platforms on the Utilità page */
+.meeting-links {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.meeting-links img {
+  max-width: 120px;
+  height: auto;
+}

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -22,6 +22,29 @@ export default function UtilitaPage() {
   return (
     <div className="list-page">
       <h2>Utilità</h2>
+      <div className="meeting-links">
+        <a
+          href="https://meet.google.com/landing?pli=1"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img src="/meet.png" alt="Google Meet" />
+        </a>
+        <a
+          href="https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=5e3ce6c0-2b1f-4285-8d4b-75ee78787346&scope=openId%20profile%20openid%20offline_access&redirect_uri=https%3A%2F%2Fteams.microsoft.com%2Fv2&client-request-id=0197c2c9-22ca-7789-a2e1-6168143993df&response_mode=fragment&response_type=code&x-client-SKU=msal.js.browser&x-client-VER=3.28.1&client_info=1&code_challenge=OEznWaAeaUqI6XVtFii8r0yzDNev1PjfzNRaqzUKTcw&code_challenge_method=S256&nonce=0197c2c9-22cb-7ad6-ae27-1b8f6901ff0b&state=eyJpZCI6IjAxOTdjMmM5LTIyY2ItN2U3MC1iYTUyLWI0OGVmNmE1Y2UxNyIsIm1ldGEiOnsiaW50ZXJhY3Rpb25UeXBlIjoicmVkaXJlY3QifX0%3D%7Chttps%3A%2F%2Fteams.microsoft.com%2Fv2%2F%3Fenablemcasfort21%3Dtrue&sso_reload=true"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img src="/teams.png" alt="Microsoft Teams" />
+        </a>
+        <a
+          href="https://zoom.us/it/signin#/login"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img src="/zoom.png" alt="Zoom" />
+        </a>
+      </div>
       <ul className="item-list">
         {pdfs.map(p => (
           <li key={p.id}>


### PR DESCRIPTION
## Summary
- show Google Meet, Teams and Zoom icons with links on the Utilità page
- style the meeting icons section

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_686306c383b083238cfc4b478b24627c