### PR TITLE
Improve meeting links responsiveness

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -151,3 +151,10 @@
   max-width: 120px;
   height: auto;
 }
+
+@media (max-width: 600px) {
+  .meeting-links {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- handle meeting links flex layout for small screens

## Testing
- `npm test` *(fails: ENOTCACHED because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68630783c0348323aa3777f7b8f8faf9