### PR TITLE
Add LoginPage test

### DIFF
--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoginPage from '../LoginPage';
+import api from '../../api/axios';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+
+jest.mock('../../api/axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  localStorage.clear();
+});
+
+describe('LoginPage', () => {
+  it('navigates to dashboard on valid credentials', async () => {
+    mockedApi.post.mockResolvedValue({ data: { access_token: 'tok' } });
+
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/email/i), 'u@e');
+    await userEvent.type(screen.getByPlaceholderText(/password/i), 'pass');
+    await userEvent.click(screen.getByRole('button', { name: /accedi/i }));
+
+    expect(await screen.findByText('Home')).toBeInTheDocument();
+  });
+
+  it('shows alert on invalid credentials', async () => {
+    mockedApi.post.mockRejectedValue(new Error('invalid'));
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByPlaceholderText(/email/i), 'u@e');
+    await userEvent.type(screen.getByPlaceholderText(/password/i), 'bad');
+    await userEvent.click(screen.getByRole('button', { name: /accedi/i }));
+
+    expect(alertSpy).toHaveBeenCalledWith('Credenziali errate');
+    alertSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add LoginPage.test to cover navigation and error cases

## Testing
- `npm test` *(fails: ENOTCACHED -- no cached dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68630a88c1a08323a3463a40c0334d29