### PR TITLE
Fix mobile login logo size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -117,6 +117,10 @@ body.login-bg {
     justify-content: center;
     padding-left: 0;
   }
+  .login-logo {
+    width: 140px;
+    margin-top: -0.5rem;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- keep login logo from blocking mobile background

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_68630c0bd844832396cad5acd3e3aeb3