### PR TITLE
Fix description field for determinations

### DIFF
--- a/src/api/determinations.ts
+++ b/src/api/determinations.ts
@@ -23,7 +23,10 @@ export const createDetermination = (
   data: Omit<Determination, 'id'>
 ): Promise<Determination> =>
   api
-    .post<Determination>('/determinazioni', data)
+    .post<Determination>('/determinazioni', {
+      ...data,
+      description: data.descrizione
+    })
     .then(r => ({
       ...r.data,
       descrizione: (r.data as any).descrizione ?? (r.data as any).description ?? ''
@@ -34,7 +37,10 @@ export const updateDetermination = (
   data: Partial<Omit<Determination, 'id'>>
 ): Promise<Determination> =>
   api
-    .put<Determination>(`/determinazioni/${id}`, data)
+    .put<Determination>(`/determinazioni/${id}`, {
+      ...data,
+      description: data.descrizione
+    })
     .then(r => ({
       ...r.data,
       descrizione: (r.data as any).descrizione ?? (r.data as any).description ?? ''

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -27,6 +27,9 @@ describe('DeterminationsPage', () => {
     await userEvent.type(screen.getByTestId('det-scadenza'), '2023-06-10');
     await userEvent.click(screen.getByTestId('det-submit'));
 
+    const storedCreate = JSON.parse(localStorage.getItem('determinations') || '[]');
+    expect(storedCreate[0].descrizione).toBe('desc');
+
     expect(await screen.findByText(/C1/)).toBeInTheDocument();
     expect(await screen.findByText(/desc/)).toBeInTheDocument();
   });
@@ -60,6 +63,9 @@ describe('DeterminationsPage', () => {
     await userEvent.clear(screen.getByTestId('det-scadenza'));
     await userEvent.type(screen.getByTestId('det-scadenza'), '2023-02-02');
     await userEvent.click(screen.getByTestId('det-submit'));
+
+    const storedEdit = JSON.parse(localStorage.getItem('determinations') || '[]');
+    expect(storedEdit[0].descrizione).toBe('new');
 
     expect(await screen.findByText(/B/)).toBeInTheDocument();
     expect(await screen.findByText(/new/)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- send `descrizione` as the English `description` in determination APIs
- ensure localStorage keeps the description when creating or editing
- test localStorage persistence of the description

## Testing
- `npm test` *(fails: ENOTCACHED - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6863109574d083238d712c463a6d09f4