### PR TITLE
Remove unused uploadPDF API function

### DIFF
--- a/src/api/pdfs.ts
+++ b/src/api/pdfs.ts
@@ -4,10 +4,3 @@ import type { PDFFile } from './types'
 export const listPDFs = (): Promise<PDFFile[]> =>
   api.get<PDFFile[]>('/pdfs').then(r => r.data)
 
-export const uploadPDF = (file: File): Promise<PDFFile> => {
-  const data = new FormData()
-  data.append('file', file)
-  return api.post<PDFFile>('/pdfs', data, {
-    headers: { 'Content-Type': 'multipart/form-data' }
-  }).then(r => r.data)
-}


### PR DESCRIPTION
## Summary
- delete the unused `uploadPDF` function from the PDF API module

## Testing
- `npm test` *(fails: ENOTCACHED due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_686314bb14888323b69158a5d6c99048