### PR TITLE
Remove global div font size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -168,7 +168,3 @@ label {
   border: 2px solid #A52019;
 }
 
-/* Slightly smaller font for div elements */
-div {
-  font-size: 0.9rem;
-}


### PR DESCRIPTION
## Summary
- remove the CSS rule that globally set a 0.9rem font size for all divs

## Testing
- `npm test` *(fails: ENOTCACHED for @testing-library/jest-dom)*
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686314bfc10c83238c80192af6ce38bc