### PR TITLE
Remove unused container destructuring

### DIFF
--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 describe('DeterminationsPage', () => {
   it('creates a new determination', async () => {
-    const { container } = render(
+    render(
       <MemoryRouter initialEntries={["/determinazioni"]}>
         <Routes>
           <Route element={<PageTemplate />}>
@@ -40,7 +40,7 @@ describe('DeterminationsPage', () => {
       JSON.stringify([{ id: '1', capitolo: 'A', numero: '1', somma: 5, scadenza: '2023-01-01', descrizione: 'old' }])
     );
 
-    const { container } = render(
+    render(
       <MemoryRouter initialEntries={["/determinazioni"]}>
         <Routes>
           <Route element={<PageTemplate />}>


### PR DESCRIPTION
## Summary
- clean up `DeterminationsPage` tests by removing unused `container` destructuring

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686314e1d0348323814fe4c12be20b9a