### PR TITLE
Remove unused container from render calls

### DIFF
--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 describe('DeterminationsPage', () => {
   it('creates a new determination', async () => {
-    const { container } = render(
+    render(
       <MemoryRouter initialEntries={["/determinazioni"]}>
         <Routes>
           <Route element={<PageTemplate />}>
@@ -40,7 +40,7 @@ describe('DeterminationsPage', () => {
       JSON.stringify([{ id: '1', capitolo: 'A', numero: '1', somma: 5, scadenza: '2023-01-01', descrizione: 'old' }])
     );
 
-    const { container } = render(
+    render(
       <MemoryRouter initialEntries={["/determinazioni"]}>
         <Routes>
           <Route element={<PageTemplate />}>


### PR DESCRIPTION
## Summary
- cleanup DeterminationsPage tests by removing unused destructured `container`

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached')*

------
https://chatgpt.com/codex/tasks/task_e_686314e56f088323ab1be242ec02ac9b