### PR TITLE
Refactor offline CRUD helpers

### DIFF
--- a/src/utils/offline.ts
+++ b/src/utils/offline.ts
@@ -1,0 +1,20 @@
+export async function withOffline<T>(online: () => Promise<T>, offline: () => T | Promise<T>): Promise<T> {
+  if (navigator.onLine) {
+    try {
+      return await online();
+    } catch {
+      // ignore and fall back
+    }
+  }
+  return await offline();
+}
+
+export async function withoutResult(online: () => Promise<void>): Promise<void> {
+  if (navigator.onLine) {
+    try {
+      await online();
+    } catch {
+      // ignore when offline
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `withOffline` and `withoutResult` utilities
- streamline create/update/delete logic in todo and determinations pages

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_686314d2fd4083238882533268b4cd3c