### PR TITLE
Fix login logo mobile size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,8 +118,8 @@ body.login-bg {
     padding-left: 0;
   }
   .login-logo {
-    width: 100px;
-    margin-top: -1.5rem;
+    width: 80px;
+    margin-top: -2rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak mobile login logo styling

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm test` *(fails: no cached response available)*

------
https://chatgpt.com/codex/tasks/task_e_68631743fd048323b4d09c2210561c6b