### PR TITLE
Handle description field from localStorage

### DIFF
--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -19,7 +19,15 @@ const DeterminationsPage: React.FC = () => {
   const [edit, setEdit] = useState<string | null>(null);
 
   const saveLocal = (data: Determination[]): void => {
-    localStorage.setItem('determinations', JSON.stringify(data));
+    const trimmed = data.map(d => ({
+      id: d.id,
+      capitolo: d.capitolo,
+      numero: d.numero,
+      somma: d.somma,
+      scadenza: d.scadenza,
+      descrizione: d.descrizione,
+    }));
+    localStorage.setItem('determinations', JSON.stringify(trimmed));
   };
 
   useEffect(() => {
@@ -37,7 +45,12 @@ const DeterminationsPage: React.FC = () => {
       const stored = localStorage.getItem('determinations');
       if (stored) {
         try {
-          setItems(JSON.parse(stored) as Determination[]);
+          const parsed = JSON.parse(stored);
+          const mapped = parsed.map((d: any) => ({
+            ...d,
+            descrizione: d.descrizione ?? d.description ?? '',
+          }));
+          setItems(mapped as Determination[]);
         } catch {
           // ignore
         }

--- a/src/pages/__tests__/DeterminationsPage.test.tsx
+++ b/src/pages/__tests__/DeterminationsPage.test.tsx
@@ -70,4 +70,32 @@ describe('DeterminationsPage', () => {
     expect(await screen.findByText(/B/)).toBeInTheDocument();
     expect(await screen.findByText(/new/)).toBeInTheDocument();
   });
+
+  it('loads items with description property', async () => {
+    localStorage.setItem(
+      'determinations',
+      JSON.stringify([
+        {
+          id: '1',
+          capitolo: 'A',
+          numero: '1',
+          somma: 5,
+          scadenza: '2023-01-01',
+          description: 'other',
+        },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/determinazioni"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/determinazioni" element={<DeterminationsPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/other/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- map `description` to `descrizione` when loading determinations from localStorage
- trim fields when storing determinations locally
- test rendering of items that use the `description` field

## Testing
- `npm test` *(fails: request to registry.npmjs.org because dependencies not cached)*

------
https://chatgpt.com/codex/tasks/task_e_68637aeeceac8323a93be248b19d6247