### PR TITLE
Adjust meeting link images for desktop

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -147,9 +147,18 @@
   margin-bottom: 1rem;
 }
 
+
 .meeting-links img {
   max-width: 120px;
   height: auto;
+}
+
+@media (min-width: 601px) {
+  .meeting-links img {
+    width: 15cm;
+    height: 8cm;
+    object-fit: contain;
+  }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- tweak layout of meeting links on Utilità page
  - keep the small size on mobile
  - add a desktop-only rule to display images in a 15cm by 8cm area

## Testing
- `npm test` *(fails: ENOTCACHED for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_6863dd45315c8323ad95e8c8335c83ad