### PR TITLE
Use per-user key for events

### DIFF
--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -4,6 +4,7 @@ import EventsPage from '../EventsPage';
 import api from '../../api/axios';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { getUserStorageKey } from '../../utils/auth';
 
 jest.mock('../../api/axios', () => ({
   __esModule: true,
@@ -25,7 +26,7 @@ beforeEach(() => {
 describe('EventsPage', () => {
   it('loads events from localStorage', async () => {
     localStorage.setItem(
-      'events',
+      getUserStorageKey('events', null),
       JSON.stringify([
         {
           id: '1',


### PR DESCRIPTION
## Summary
- scope EventsPage storage by user token
- retrieve events using the computed key
- update EventsPage tests to use `getUserStorageKey`

## Testing
- `npm ci --offline` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_6863e09076648323b740eb2891d6556f