### PR TITLE
Filter private events by owner

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -7,6 +7,7 @@ export interface DbEvent {
   descrizione?: string
   data_ora: string
   is_public?: boolean
+  owner_id?: string
 }
 
 export const listDbEvents = (): Promise<DbEvent[]> =>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -20,7 +20,12 @@ export default function Dashboard() {
     () => getUserStorageKey('todos', token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)),
     [token]
   );
-  const [events] = useLocalStorage<EventItem[]>('events', []);
+  const eventsKey = useMemo(
+    () =>
+      getUserStorageKey('events', token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)),
+    [token]
+  );
+  const [events] = useLocalStorage<EventItem[]>(eventsKey, []);
   const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
   const CALENDAR_ID = 'plcastionedellapresolana@gmail.com';
 


### PR DESCRIPTION
## Summary
- add `owner_id` field to `DbEvent`
- filter fetched events using JWT owner id and store them under a user-specific key
- keep owner id when editing events and store it when creating
- load events from the user-specific key in Dashboard
- adjust tests and add one to ensure other users' private events are hidden

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_6863e08ec6c88323a3c47eb2ffab225b