### PR TITLE
Filter offline events by user

### DIFF
--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -33,7 +33,7 @@ describe('EventsPage', () => {
           title: 'Test',
           description: 'desc',
           dateTime: '2023-01-01T10:00',
-          isPublic: false,
+          isPublic: true,
         },
       ])
     );
@@ -49,6 +49,35 @@ describe('EventsPage', () => {
     );
 
     expect(await screen.findByText('Test')).toBeInTheDocument();
+  });
+
+  it('filters events by owner and visibility from localStorage', async () => {
+    const header = Buffer.from('{}').toString('base64');
+    const payload = Buffer.from(JSON.stringify({ sub: '123' })).toString('base64');
+    const token = `${header}.${payload}.sig`;
+    localStorage.setItem('token', token);
+    localStorage.setItem(
+      getUserStorageKey('events', token),
+      JSON.stringify([
+        { id: '1', title: 'Mine', description: '', dateTime: '2023-01-01T10:00', isPublic: false, owner_id: '123' },
+        { id: '2', title: 'Other', description: '', dateTime: '2023-01-02T10:00', isPublic: false, owner_id: '456' },
+        { id: '3', title: 'Public', description: '', dateTime: '2023-01-03T10:00', isPublic: true, owner_id: '456' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/events"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/events" element={<EventsPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Mine')).toBeInTheDocument();
+    expect(await screen.findByText('Public')).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
 
   it('adds new event offline', async () => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -8,6 +8,13 @@ export function decodeToken(token: string): any | null {
   }
 }
 
+export function getUserId(token: string | null): string | null {
+  if (!token) return null;
+  const decoded = decodeToken(token);
+  const id = decoded?.sub || decoded?.user_id || decoded?.id || decoded?.email;
+  return id || null;
+}
+
 export function getUserStorageKey(prefix: string, token: string | null): string {
   if (!token) return prefix;
   const decoded = decodeToken(token);


### PR DESCRIPTION
## Summary
- add `getUserId` helper
- store user id on new events
- filter stored events by owner and public visibility
- test events filtering
- tweak localStorage test fixture

## Testing
- `npm test` *(fails: cache mode only-if-cached)*

------
https://chatgpt.com/codex/tasks/task_e_6863e65c7cc883238c946eed3b48a9e5