### PR TITLE
Extend DbEvent with owner_id

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -7,6 +7,7 @@ export interface DbEvent {
   descrizione?: string
   data_ora: string
   is_public?: boolean
+  owner_id: string | null
 }
 
 export const listDbEvents = (): Promise<DbEvent[]> =>


### PR DESCRIPTION
## Summary
- include `owner_id` on `DbEvent`

## Testing
- `npm test` *(fails: ENOTCACHED dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6863e659d8988323b3f2f41689525dbb