### PR TITLE
Filter DB events by user

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -7,6 +7,7 @@ export interface DbEvent {
   descrizione?: string
   data_ora: string
   is_public?: boolean
+  owner_id?: string
 }
 
 export const listDbEvents = (): Promise<DbEvent[]> =>


### PR DESCRIPTION
## Summary
- decode current user ID from token in `EventsPage`
- filter DB events so only public or owned events load
- type `owner_id` for `DbEvent`

## Testing
- `npm run -s pretest` *(fails: ENOTCACHED due to network restrictions)*
- `npm test` *(fails: ENOTCACHED due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6863e65c2c388323b838b170d36e4f21