### PR TITLE
Resolve descrizione field mismatch

### DIFF
--- a/src/api/determinations.ts
+++ b/src/api/determinations.ts
@@ -25,7 +25,7 @@ export const createDetermination = (
   api
     .post<Determination>('/determinazioni', {
       ...data,
-      description: data.descrizione
+      descrizione: data.descrizione
     })
     .then(r => ({
       ...r.data,
@@ -39,7 +39,7 @@ export const updateDetermination = (
   api
     .put<Determination>(`/determinazioni/${id}`, {
       ...data,
-      description: data.descrizione
+      descrizione: data.descrizione
     })
     .then(r => ({
       ...r.data,


### PR DESCRIPTION
## Summary
- use `descrizione` when creating or updating Determinazione records

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached')*

------
https://chatgpt.com/codex/tasks/task_e_6863eca48ee883239c3a508fd59ebe9d