### PR TITLE
Fix timers in TodoPage tests

### DIFF
--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -28,6 +28,10 @@ beforeEach(() => {
   mockedDetApi.listDeterminations.mockResolvedValue([] as any);
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe('TodoPage offline', () => {
   it('adds new todo offline', async () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });


### PR DESCRIPTION
## Summary
- ensure tests in `TodoPage.test.tsx` reset to real timers after each run

## Testing
- `npm test` *(fails: request to registry.npmjs.org:443 because cache mode is only-if-cached)*

------
https://chatgpt.com/codex/tasks/task_e_6863feb96fac8323b54fe35d43236d56