### PR TITLE
Bold description columns and numeric font

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
       href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap"
       rel="stylesheet"
     />
+    <!-- Roboto Mono font for numbers -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap"
+      rel="stylesheet"
+    />
 
 
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -168,3 +168,15 @@ label {
   border: 2px solid #A52019;
 }
 
+/* Special font for numeric content */
+.digit-font,
+input[type="number"],
+input[type="date"],
+input[type="datetime-local"] {
+  font-family: 'Roboto Mono', monospace;
+}
+
+.desc-cell {
+  font-weight: bold;
+}
+

--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -195,11 +195,11 @@ const DeterminationsPage: React.FC = () => {
         <tbody>
           {items.map(d => (
             <tr key={d.id}>
-              <td>{d.capitolo}</td>
-              <td>{d.numero}</td>
-              <td>€{d.somma}</td>
-              <td>{d.descrizione}</td>
-              <td>{new Date(d.scadenza).toLocaleDateString()}</td>
+              <td className="digit-font">{d.capitolo}</td>
+              <td className="digit-font">{d.numero}</td>
+              <td className="digit-font">€{d.somma}</td>
+              <td className="desc-cell">{d.descrizione}</td>
+              <td className="digit-font">{new Date(d.scadenza).toLocaleDateString()}</td>
               <td>
                 <button data-testid="det-edit" onClick={() => onEdit(d)}>
                   Modifica

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -312,8 +312,8 @@ export default function EventsPage() {
           {events.map(ev => (
             <tr key={`${ev.source}-${ev.id}`}>
               <td>{ev.title}</td>
-              <td>{new Date(ev.dateTime).toLocaleString()}</td>
-              <td>{ev.description}</td>
+              <td className="digit-font">{new Date(ev.dateTime).toLocaleString()}</td>
+              <td className="desc-cell">{ev.description}</td>
               <td>{ev.isPublic ? 'Sì' : 'No'}</td>
               <td>
                 <button onClick={() => onEdit(ev)}>Modifica</button>

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -75,6 +75,7 @@
 .item-table th {
   background: #a8a3a3;
   text-align: left;
+  font-weight: bold;
 }
 .item-table td:last-child {
   white-space: nowrap;

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -161,8 +161,8 @@ export default function TodoPage() {
         <tbody>
           {todos.map(t => (
             <tr key={t.id}>
-              <td>{t.text}</td>
-              <td>{new Date(t.due).toLocaleDateString()}</td>
+              <td className="desc-cell">{t.text}</td>
+              <td className="digit-font">{new Date(t.due).toLocaleDateString()}</td>
               <td>
                 {!t.readonly && (
                   <>


### PR DESCRIPTION
## Summary
- add Roboto Mono font for digits
- emphasize table headers and description cells
- style numeric data cells with a monospace font

## Testing
- `npm test` *(fails: ENOTCACHED during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_686400a8c24483238ec9d1fe5bba6bc2