### PR TITLE
Update env example with schedule variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 VITE_API_URL="https://your-backend-url"
 VITE_GAPI_CLIENT_ID="your-google-client-id"
 VITE_GAPI_API_KEY="your-google-api-key"
+
+# Schedule page configuration
+# Comma-separated IDs of the Google Calendars displayed on the schedule page
+VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
+# API key used for public read-only access to those calendars
+VITE_SCHEDULE_PUBLIC_API_KEY="your-public-api-key"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The variables are:
 - `VITE_API_URL` – https://segretaria-digitale-backend.onrender.com.
 - `VITE_GAPI_CLIENT_ID` – `your-google-client-id`.
 - `VITE_GAPI_API_KEY` – `your-google-api-key`.
+- `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs used by the schedule page.
+- `VITE_SCHEDULE_PUBLIC_API_KEY` – public API key for retrieving events from those calendars.
 
 
 ## Development


### PR DESCRIPTION
## Summary
- document Google Calendar IDs and public API key for the schedule page
- describe the same variables in the README

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_68644873dc248323bd67e9a2bdc9514c