### PR TITLE
Configure Vite and Jest alias

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,10 @@ const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  testMatch: ['**/?(*.)+(test).[tj]s?(x)']
+  testMatch: ['**/?(*.)+(test).[tj]s?(x)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  }
 };
 
 export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,11 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["vite/client", "jest"]
+    "types": ["vite/client", "jest"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'url';
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
   server: { port: 3000, host: true }
 });
 


### PR DESCRIPTION
## Summary
- set up `@` alias to reference the `src` directory
- resolve the same alias in TypeScript and Jest configs

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_6864489a31848323a0703a62eb271243