### PR TITLE
Add React Query setup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import App from './App';
 import './index.css';
+
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode><App/></React.StrictMode>
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+      {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- configure `QueryClient` and wrap app in `QueryClientProvider`
- show `ReactQueryDevtools` when running in development

## Testing
- `npm test` *(fails: ENOTCACHED due to offline install)*

------
https://chatgpt.com/codex/tasks/task_e_68644898637883238a8d532c76befe1a