### PR TITLE
Add Orari link

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,6 +27,7 @@ const Header: React.FC = () => {
           <Link to="/">🏠 Dashboard</Link>
           <Link to="/events">📅 Eventi</Link>
           <Link to="/todo">📝 To-Do</Link>
+          <Link to="/orari">🕑 Orari</Link>
           <Link to="/determinazioni">📄 Determine</Link>
           <Link to="/utilita">🤝 Riunioni</Link>
           <button onClick={logout}>Esci</button>

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -25,6 +25,7 @@ describe('PageTemplate', () => {
     expect(screen.getByText('🏠 Dashboard')).toBeInTheDocument();
     expect(screen.getByText('📅 Eventi')).toBeInTheDocument();
     expect(screen.getByText('📝 To-Do')).toBeInTheDocument();
+    expect(screen.getByText('🕑 Orari')).toBeInTheDocument();
     expect(screen.getByText('📄 Determine')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /esci/i })).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- add an "Orari" link in the navigation header
- expect the new link in PageTemplate tests

## Testing
- `npm test` *(fails: request to registry.npmjs.org denied)*

------
https://chatgpt.com/codex/tasks/task_e_6864488f604c83238ce197c72107730d