### PR TITLE
Add lazy-loaded schedule page route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const EventsPage = React.lazy(() => import("./pages/EventsPage"));
 const TodoPage = React.lazy(() => import("./pages/TodoPage"));
 const DeterminationsPage = React.lazy(() => import("./pages/DeterminationsPage"));
 const UtilitaPage = React.lazy(() => import("./pages/UtilitaPage"));
+const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
 
 
 const App: React.FC = () => {
@@ -40,6 +41,7 @@ const App: React.FC = () => {
           <Route path="/events" element={<EventsPage />} />
           <Route path="/todo" element={<TodoPage />} />
           <Route path="/utilita" element={<UtilitaPage />} />
+          <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
         </Route>
 


### PR DESCRIPTION
## Summary
- lazy load `SchedulePage`
- route `/orari` behind protected routes

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_68644891a79c832392f722a6e7bae871