### PR TITLE
Add react-calendar dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "axios": "^1.3.4",
     "date-fns": "^4.1.0",
     "react": "^18.2.0",
+    "react-calendar": "^6.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
     "vite": "^4.5.14",


### PR DESCRIPTION
## Summary
- include `react-calendar` as a dependency

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm test` *(fails: ENOTCACHED request to https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68644895c8d483238eddb8840ac23025