### PR TITLE
Update PageTemplate test for new nav link

### DIFF
--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -26,6 +26,9 @@ describe('PageTemplate', () => {
     expect(screen.getByText('📅 Eventi')).toBeInTheDocument();
     expect(screen.getByText('📝 To-Do')).toBeInTheDocument();
     expect(screen.getByText('📄 Determine')).toBeInTheDocument();
+    expect(
+      screen.getByText(/🕑\s*Orari/i)
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /esci/i })).toBeInTheDocument();
 
     // footer


### PR DESCRIPTION
## Summary
- ensure new "🕑 Orari" navigation link is present in `PageTemplate.test.tsx`

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_686448941fdc832388ca0e986a5fe4d3