### PR TITLE
Fix React Query dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "react-calendar": "^6.0.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.0",
-        "@tanstack/react-query": "^4.29.0",
-        "@tanstack/react-query-devtools": "^4.29.0",
+        "@tanstack/react-query": "^4.35.3",
+        "@tanstack/react-query-devtools": "^4.35.3",
         "vite": "^7.0.0",
         "zustand": "^5.0.5"
       },
@@ -2284,14 +2284,14 @@
       "license": "ISC"
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.0.tgz",
+      "version": "4.35.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.3.tgz",
       "integrity": "",
       "license": "MIT"
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.0.tgz",
+      "version": "4.35.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.35.3.tgz",
       "integrity": "",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "react-calendar": "^6.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
-    "@tanstack/react-query": "^4.29.0",
-    "@tanstack/react-query-devtools": "^4.29.0",
+    "@tanstack/react-query": "^4.35.3",
+    "@tanstack/react-query-devtools": "^4.35.3",
     "vite": "^4.5.14",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
## Summary
- bump `@tanstack/react-query` and devtools to 4.35.3

## Testing
- `npm ci --offline` *(fails: request to https://registry.npmjs.org/@testing-library%2fjest-dom failed: cache mode is 'only-if-cached' but no cached response is available)*
- `npm test` *(fails: request to https://registry.npmjs.org/@testing-library%2fjest-dom failed: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_68645a18cc3483238a02aaf26fea0406