### PR TITLE
Update React Query version to 4.36.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "react-calendar": "^6.0.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.0",
-        "@tanstack/react-query": "^4.35.3",
-        "@tanstack/react-query-devtools": "^4.35.3",
+        "@tanstack/react-query": "^4.36.0",
+        "@tanstack/react-query-devtools": "^4.36.0",
         "vite": "^7.0.0",
         "zustand": "^5.0.5"
       },
@@ -2284,14 +2284,14 @@
       "license": "ISC"
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.3.tgz",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.0.tgz",
       "integrity": "",
       "license": "MIT"
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "4.35.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.35.3.tgz",
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.36.0.tgz",
       "integrity": "",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "react-calendar": "^6.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
-    "@tanstack/react-query": "^4.35.3",
-    "@tanstack/react-query-devtools": "^4.35.3",
+    "@tanstack/react-query": "^4.36.0",
+    "@tanstack/react-query-devtools": "^4.36.0",
     "vite": "^4.5.14",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
## Summary
- bump `@tanstack/react-query` and devtools to v4.36.0

## Testing
- `npm test` *(fails: ENOTCACHED for @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68645bd6b34c83239f1ce78ab2dfeb94