### PR TITLE
Fix React Query version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "react-calendar": "^6.0.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.0",
-        "@tanstack/react-query": "^4.36.0",
-        "@tanstack/react-query-devtools": "^4.36.0",
+        "@tanstack/react-query": "^4.36.1",
+        "@tanstack/react-query-devtools": "^4.36.1",
         "vite": "^7.0.0",
         "zustand": "^5.0.5"
       },
@@ -2284,14 +2284,14 @@
       "license": "ISC"
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.0.tgz",
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
       "integrity": "",
       "license": "MIT"
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "4.36.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.36.0.tgz",
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.36.1.tgz",
       "integrity": "",
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "react-calendar": "^6.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
-    "@tanstack/react-query": "^4.36.0",
-    "@tanstack/react-query-devtools": "^4.36.0",
+    "@tanstack/react-query": "^4.36.1",
+    "@tanstack/react-query-devtools": "^4.36.1",
     "vite": "^4.5.14",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
## Summary
- bump React Query to 4.36.1

## Testing
- `npm test` *(fails: request to registry.npmjs.org denied)*

------
https://chatgpt.com/codex/tasks/task_e_68645f11dc1c8323a67ca7d8fa56036d