### PR TITLE
Fix login page error message test

### DIFF
--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -38,9 +38,8 @@ describe('LoginPage', () => {
     expect(await screen.findByText('Home')).toBeInTheDocument();
   });
 
-  it('shows alert on invalid credentials', async () => {
+  it('shows an error message on invalid credentials', async () => {
     mockedApi.post.mockRejectedValue(new Error('invalid'));
-    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
 
     render(
       <MemoryRouter initialEntries={["/login"]}>
@@ -55,7 +54,6 @@ describe('LoginPage', () => {
     await userEvent.type(screen.getByPlaceholderText(/password/i), 'bad');
     await userEvent.click(screen.getByRole('button', { name: /accedi/i }));
 
-    expect(alertSpy).toHaveBeenCalledWith('Credenziali errate');
-    alertSpy.mockRestore();
+    expect(await screen.findByText('Credenziali errate')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- update invalid credentials test in LoginPage to look for the rendered error message instead of spying on `window.alert`

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_68646d6a27548323bbb71c6e93209975