### PR TITLE
Make schedule calendar configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ VITE_GAPI_API_KEY="your-google-api-key"
 
 # Schedule page configuration
 # Comma-separated IDs of the Google Calendars displayed on the schedule page
+# The first ID controls the calendar iframe (defaults to plcastionedellapresolana@gmail.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
 # API key used for public read-only access to those calendars
 VITE_SCHEDULE_PUBLIC_API_KEY="your-public-api-key"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The variables are:
 - `VITE_API_URL` – https://segretaria-digitale-backend.onrender.com.
 - `VITE_GAPI_CLIENT_ID` – `your-google-client-id`.
 - `VITE_GAPI_API_KEY` – `your-google-api-key`.
-- `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs used by the schedule page.
+- `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs.
+  The schedule page shows the first ID and falls back to
+  `plcastionedellapresolana@gmail.com` when unset.
 - `VITE_SCHEDULE_PUBLIC_API_KEY` – public API key for retrieving events from those calendars.
 
 4. Start the development server:

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -58,7 +58,9 @@ export default function SchedulePage() {
     saveLocal(updated);
   };
 
-  const CALENDAR_ID = 'plcastionedellapresolana@gmail.com';
+  const CALENDAR_ID =
+    import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
+    'plcastionedellapresolana@gmail.com';
 
   return (
     <div className="list-page">


### PR DESCRIPTION
## Summary
- configure schedule calendar via `VITE_SCHEDULE_CALENDAR_IDS`
- document new behavior in README and `.env.example`

## Testing
- `npm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864d99542b08323a56a868ad50f4bcf