### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ This project contains the React front end of **Segretaria Digitale**, a simple a
 2. Install dependencies (creates `node_modules/.bin/jest` used by the test suite):
 
 ```bash
-# Use a clean, reproducible install
-npm ci
+npm install
+# This repository doesn't include a lockfile
 # If you see 404 errors for `@tanstack/react-query`,
-# update the dependency to a recent release (>=4.36.1)
-# and regenerate the lockfile with `npm install`.
-# or run the helper script
+# update the dependency to a recent release (>=4.36.1).
+# You can also run the helper script
 ./scripts/setup.sh
 ```
 
@@ -82,13 +81,12 @@ export.
 Before running tests, install dependencies if you haven't already:
 
 ```bash
-# Perform a clean install using the lockfile
-npm ci
+npm install
 # or run the helper script
 ./scripts/setup.sh
 ```
 
-Then run the Jest test suite (dependencies will be installed from the lockfile in offline mode if missing):
+Then run the Jest test suite:
 
 ```bash
 npm test


### PR DESCRIPTION
## Summary
- fix install instructions to recommend `npm install`
- update testing section accordingly

## Testing
- `npm test` *(fails: npm ci requires lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6864e149c3248323a41adf1c0eff67c1