### PR TITLE
Update default schedule calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ VITE_GAPI_API_KEY="your-google-api-key"
 
 # Schedule page configuration
 # Comma-separated IDs of the Google Calendars displayed on the schedule page
-# The first ID controls the calendar iframe (defaults to plcastionedellapresolana@gmail.com)
+# The first ID controls the calendar iframe (defaults to 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
 # API key used for public read-only access to those calendars
 VITE_SCHEDULE_PUBLIC_API_KEY="your-public-api-key"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The variables are:
 - `VITE_GAPI_API_KEY` – `your-google-api-key`.
 - `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs.
   The schedule page shows the first ID and falls back to
-  `plcastionedellapresolana@gmail.com` when unset.
+`9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com` when unset.
 - `VITE_SCHEDULE_PUBLIC_API_KEY` – public API key for retrieving events from those calendars.
 
 4. Start the development server:

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -60,7 +60,7 @@ export default function SchedulePage() {
 
   const CALENDAR_ID =
     import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
-    'plcastionedellapresolana@gmail.com';
+    '9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com';
 
   return (
     <div className="list-page">


### PR DESCRIPTION
## Summary
- update the fallback calendar ID in `SchedulePage.tsx`
- document the new default in `.env.example`
- update README to mention the new fallback ID

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6864e5daf7248323908f1345315bc65a