### PR TITLE
Use environment calendar ID in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -22,7 +22,9 @@ export default function Dashboard() {
   );
   const [events] = useLocalStorage<EventItem[]>('events', []);
   const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
-  const CALENDAR_ID = 'plcastionedellapresolana@gmail.com';
+  const CALENDAR_ID =
+    import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
+    'plcastionedellapresolana@gmail.com';
 
   const today = new Date();
   const upcomingEvents = events.filter(


### PR DESCRIPTION
## Summary
- rely on `VITE_SCHEDULE_CALENDAR_IDS` for the dashboard calendar like the schedule page

## Testing
- `npm test` *(fails: npm cannot run without a lockfile and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6864e5dd659c8323869971ea50df6fa3