### PR TITLE
Remove invalid match-sorter-utils package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@tanstack/query-core": "^4.36.1",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",
-    "@tanstack/match-sorter-utils": "^4.36.1",
     "vite": "^4.5.14",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
## Summary
- remove `@tanstack/match-sorter-utils` from dependencies

## Testing
- `npm install` *(fails: 403 Forbidden when reaching registry)*
- `npm test` *(fails: npm ci requires package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864e897ab708323949a668a3ddabcae