### PR TITLE
Update schedule page to use API

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -1,0 +1,20 @@
+import api from './axios'
+
+export interface Turno {
+  id: string
+  user_id: string
+  slot1: string
+  slot2?: string | null
+  slot3?: string | null
+}
+
+export const listTurni = (): Promise<Turno[]> =>
+  api.get<Turno[]>('/orari/').then(r => r.data)
+
+export const createTurno = (
+  data: Omit<Turno, 'id'>
+): Promise<Turno> =>
+  api.post<Turno>('/orari/', data).then(r => r.data)
+
+export const deleteTurno = (id: string): Promise<void> =>
+  api.delete(`/orari/${id}`).then(() => undefined)

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -1,55 +1,84 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import SchedulePage from '../SchedulePage';
-import PageTemplate from '../../components/PageTemplate';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SchedulePage from '../SchedulePage'
+import PageTemplate from '../../components/PageTemplate'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import * as api from '../../api/schedule'
+
+jest.mock('../../api/schedule', () => ({
+  __esModule: true,
+  listTurni: jest.fn(),
+  createTurno: jest.fn(),
+  deleteTurno: jest.fn(),
+}))
+
+const mockedApi = api as jest.Mocked<typeof api>
 
 beforeEach(() => {
-  localStorage.clear();
-});
+  jest.resetAllMocks()
+  localStorage.clear()
+  mockedApi.listTurni.mockResolvedValue([])
+})
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/orari"]}>
+      <Routes>
+        <Route element={<PageTemplate />}>
+          <Route path="/orari" element={<SchedulePage />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  )
 
 describe('SchedulePage', () => {
-  it('loads shifts from localStorage', async () => {
-    localStorage.setItem(
-      'shifts',
-      JSON.stringify([
-        { id: '1', date: '2023-01-01', start: '08:00', end: '10:00', note: '' },
-      ])
-    );
+  it('loads turni from API', async () => {
+    mockedApi.listTurni.mockResolvedValue([
+      { id: '1', slot1: '08-10', user_id: 'u' },
+    ] as any)
 
-    render(
-      <MemoryRouter initialEntries={["/orari"]}>
-        <Routes>
-          <Route element={<PageTemplate />}>
-            <Route path="/orari" element={<SchedulePage />} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
+    renderPage()
 
-    expect(await screen.findByText('08:00')).toBeInTheDocument();
-  });
+    expect(await screen.findByText('08-10')).toBeInTheDocument()
+  })
 
-  it('adds a new shift', async () => {
-    render(
-      <MemoryRouter initialEntries={["/orari"]}>
-        <Routes>
-          <Route element={<PageTemplate />}>
-            <Route path="/orari" element={<SchedulePage />} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
+  it('adds a new turno', async () => {
+    mockedApi.createTurno.mockResolvedValue({
+      id: '2',
+      slot1: '09-11',
+      user_id: '123',
+    } as any)
 
-    await userEvent.type(screen.getByLabelText(/data/i), '2023-06-01');
-    await userEvent.type(screen.getByLabelText(/inizio/i), '09:00');
-    await userEvent.type(screen.getByLabelText(/fine/i), '10:00');
-    await userEvent.type(screen.getByPlaceholderText(/note/i), 'test');
-    await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }));
+    const header = Buffer.from('{}').toString('base64')
+    const payload = Buffer.from(JSON.stringify({ sub: '123' })).toString('base64')
+    const token = `${header}.${payload}.sig`
+    localStorage.setItem('token', token)
 
-    expect(await screen.findByText('09:00')).toBeInTheDocument();
+    renderPage()
+    await screen.findByRole('button', { name: /aggiungi/i })
 
-    const stored = JSON.parse(localStorage.getItem('shifts') || '[]');
-    expect(stored[0].start).toBe('09:00');
-  });
-});
+    await userEvent.type(screen.getByPlaceholderText(/slot 1/i), '09-11')
+    await userEvent.click(screen.getByRole('button', { name: /aggiungi/i }))
+
+    expect(await screen.findByText('09-11')).toBeInTheDocument()
+    expect(mockedApi.createTurno).toHaveBeenCalled()
+    expect(
+      (screen.getByPlaceholderText(/slot 1/i) as HTMLInputElement).value
+    ).toBe('')
+  })
+
+  it('deletes a turno', async () => {
+    mockedApi.listTurni.mockResolvedValue([
+      { id: '1', slot1: '07-09', user_id: 'u' },
+    ] as any)
+    mockedApi.deleteTurno.mockResolvedValue()
+
+    renderPage()
+
+    await screen.findByText('07-09')
+    await userEvent.click(screen.getByRole('button', { name: /elimina/i }))
+
+    expect(screen.queryByText('07-09')).not.toBeInTheDocument()
+    expect(mockedApi.deleteTurno).toHaveBeenCalledWith('1')
+  })
+})


### PR DESCRIPTION
## Summary
- implement API methods for schedule (turni)
- rework SchedulePage to use backend API and embed calendar
- update SchedulePage tests for new behavior

## Testing
- `npm test` *(fails: `npm ci` requires lockfile and registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68651d582d188323acc48a1855668d89