### PR TITLE
Fix API URL placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-VITE_API_URL="https://your-backend-url"
+VITE_API_URL="https://<your-backend>.onrender.com"
 VITE_GAPI_CLIENT_ID="your-google-client-id"
 VITE_GAPI_API_KEY="your-google-api-key"
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Google Calendar integration.
 
 The variables are:
 
-- `VITE_API_URL` – https://segretaria-digitale-backend.onrender.com.
+- `VITE_API_URL` – https://<your-backend>.onrender.com.
 - `VITE_GAPI_CLIENT_ID` – `your-google-client-id`.
 - `VITE_GAPI_API_KEY` – `your-google-api-key`.
 - `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs.


### PR DESCRIPTION
## Summary
- keep VITE_API_URL placeholder consistent across docs

## Testing
- `npm test` *(fails: npm ci requires lockfile and internet)*

------
https://chatgpt.com/codex/tasks/task_e_68651edd07908323984de6c19d385878