### PR TITLE
Remove VITE_SCHEDULE_PUBLIC_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,3 @@ VITE_GAPI_API_KEY="your-google-api-key"
 # The first ID controls the calendar iframe (defaults to 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
 # API key used for public read-only access to those calendars
-VITE_SCHEDULE_PUBLIC_API_KEY="your-public-api-key"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ The variables are:
 - `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs.
   The schedule page shows the first ID and falls back to
 `9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com` when unset.
-- `VITE_SCHEDULE_PUBLIC_API_KEY` – public API key for retrieving events from those calendars.
 
 4. Start the development server:
 


### PR DESCRIPTION
## Summary
- delete VITE_SCHEDULE_PUBLIC_API_KEY from `.env.example`
- remove documentation of VITE_SCHEDULE_PUBLIC_API_KEY in README

## Testing
- `npm test` *(fails: npm cannot install packages without network access)*

------
https://chatgpt.com/codex/tasks/task_e_686523b316088323b8fdc74b9cb01432