### PR TITLE
Centralize default calendar ID

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_CALENDAR_ID = '9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com';
+

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { getUserStorageKey } from '../utils/auth';
 import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
+import { DEFAULT_CALENDAR_ID } from '../constants';
 interface EventItem {
   id: string;
   title: string;
@@ -24,7 +25,7 @@ export default function Dashboard() {
   const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
   const CALENDAR_ID =
     import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
-    'plcastionedellapresolana@gmail.com';
+    DEFAULT_CALENDAR_ID;
 
   const today = new Date();
   const upcomingEvents = events.filter(

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import api from '../api/axios';
 import { listUtenti, Utente } from '../api/users';
+import { DEFAULT_CALENDAR_ID } from '../constants';
 import './ListPages.css';
 
 /* ---------- TIPI ---------- */
@@ -19,7 +20,7 @@ interface Turno {
 /* ---------- COSTANTI ---------- */
 const CALENDAR_ID =
   import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
-  '9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com';
+  DEFAULT_CALENDAR_ID;
 
 /* ---------- HELPER ---------- */
 const stripDomain = (email: string) =>


### PR DESCRIPTION
## Summary
- add `DEFAULT_CALENDAR_ID` constant
- reuse shared constant in Dashboard and SchedulePage

## Testing
- `npm test` *(fails: npm ci requires lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686523b64ab48323bce11b97b641b772