### PR TITLE
Add ImportExcel component

### DIFF
--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -1,0 +1,43 @@
+import React, { useRef, useState } from 'react';
+import api from '../api/axios';
+
+export default function ImportExcel() {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+
+  const onChoose = () => fileInput.current?.click();
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setBusy(true);
+    const form = new FormData();
+    form.append('file', file);
+
+    try {
+      const res = await api.post('/import/xlsx', form, {
+        responseType: 'blob',
+      });
+      const url = URL.createObjectURL(res.data);
+      window.open(url, '_blank');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <button type="button" onClick={onChoose} disabled={busy} style={{ marginBottom: '1rem' }}>
+        {busy ? 'Caricamento…' : 'Importa Excel'}
+      </button>
+      <input
+        ref={fileInput}
+        type="file"
+        accept=".xlsx,.xls"
+        style={{ display: 'none' }}
+        onChange={onFile}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `ImportExcel` component for importing Excel files via API

## Testing
- `npm test` *(fails: missing package-lock)*

------
https://chatgpt.com/codex/tasks/task_e_68652b1c0930832391a754cd220b9b5c