### PR TITLE
Add ImportExcel to SchedulePage

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import api from '../api/axios';
 import { listUtenti, Utente } from '../api/users';
 import { DEFAULT_CALENDAR_ID } from '../constants';
+import ImportExcel from '../components/ImportExcel';
 import './ListPages.css';
 
 /* ---------- TIPI ---------- */
@@ -95,6 +96,8 @@ export default function SchedulePage() {
   return (
     <div className="list-page">
       <h2>Turni di servizio</h2>
+
+      <ImportExcel />
 
       {/* -------- FORM -------- */}
       <form className="item-form" onSubmit={handleAdd}>


### PR DESCRIPTION
## Summary
- import the ImportExcel component in SchedulePage
- render `<ImportExcel />` just above the schedule form

## Testing
- `npm test` *(fails: npm ci requires lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68652b2a0f988323851146b9c8ace8a2