### PR TITLE
Update ImportExcel success handling

### DIFF
--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -1,9 +1,14 @@
 import React, { useRef, useState } from 'react';
 import api from '../api/axios';
 
-export default function ImportExcel() {
+export default function ImportExcel({
+  onComplete,
+}: {
+  onComplete?: (success: boolean) => void;
+}) {
   const fileInput = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
 
   const onChoose = () => fileInput.current?.click();
 
@@ -12,6 +17,7 @@ export default function ImportExcel() {
     if (!file) return;
 
     setBusy(true);
+    setMessage('');
     const form = new FormData();
     form.append('file', file);
 
@@ -21,6 +27,12 @@ export default function ImportExcel() {
       });
       const url = URL.createObjectURL(res.data);
       window.open(url, '_blank');
+      setMessage('File importato correttamente');
+      onComplete?.(true);
+    } catch (err) {
+      console.error(err);
+      setMessage('Errore durante l\'import');
+      onComplete?.(false);
     } finally {
       setBusy(false);
     }
@@ -31,6 +43,11 @@ export default function ImportExcel() {
       <button type="button" onClick={onChoose} disabled={busy} style={{ marginBottom: '1rem' }}>
         {busy ? 'Caricamento…' : 'Importa Excel'}
       </button>
+      {message && (
+        <p className={message.startsWith('Errore') ? 'error' : 'success-message'}>
+          {message}
+        </p>
+      )}
       <input
         ref={fileInput}
         type="file"

--- a/src/index.css
+++ b/src/index.css
@@ -180,3 +180,8 @@ input[type="datetime-local"] {
   font-weight: bold;
 }
 
+.success-message {
+  color: #00703c;
+  margin-bottom: 1rem;
+}
+

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -46,13 +46,25 @@ export default function SchedulePage() {
   const [turni, setTurni] = useState<Turno[]>([]);
   const [refreshCal, setRefreshCal] = useState(false);
 
+  const fetchTurni = async () => {
+    const { data } = await api.get<Turno[]>('/orari/');
+    setTurni(data);
+  };
+
+  const handleImportComplete = async (success: boolean) => {
+    if (success) {
+      await fetchTurni();
+      setRefreshCal(prev => !prev);
+    }
+  };
+
   /* --- caricamento iniziale --- */
   useEffect(() => {
     listUtenti().then(r => {
       setUtenti(r.data);
       setUtenteSel(r.data[0]?.id ?? '');
     });
-    api.get<Turno[]>('/orari/').then(r => setTurni(r.data));
+    fetchTurni();
   }, []);
 
   /* --- helper --- */
@@ -97,7 +109,7 @@ export default function SchedulePage() {
     <div className="list-page">
       <h2>Turni di servizio</h2>
 
-      <ImportExcel />
+      <ImportExcel onComplete={handleImportComplete} />
 
       {/* -------- FORM -------- */}
       <form className="item-form" onSubmit={handleAdd}>


### PR DESCRIPTION
## Summary
- handle success/failure in `ImportExcel`
- refresh calendar and shift list after importing
- display a success message

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find jest types)*
- `npx jest --runInBand` *(fails: forbidden to fetch jest package)*

------
https://chatgpt.com/codex/tasks/task_e_6865385a6f0483239b1061ada933923f