### PR TITLE
Apply bold style to body text

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
 body {
   margin: 0;
   font-family: 'Cormorant Garamond', serif;
-  font-weight: 600;
+  font-weight: bold;
   color: #333;
   background: url('/Login.png') no-repeat center/cover fixed;
 }
@@ -142,7 +142,7 @@ main.app-container {
 
 .site-header * {
   text-transform: none;
-  font-weight: normal;
+  font-weight: bold;
 }
 
 /* Red bold headings for boxes and form labels */


### PR DESCRIPTION
## Summary
- emphasize all body text by changing the base style to `font-weight: bold`
- ensure header text inherits bold weight

## Testing
- `npm test` *(fails: no lockfile, offline install)*

------
https://chatgpt.com/codex/tasks/task_e_68653880e2a8832384500fb858bd142c