### PR TITLE
Add Google Calendar integration for shifts

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -1,0 +1,32 @@
+import { createShiftEvent } from '../googleCalendar'
+
+const insertMock = jest.fn()
+
+beforeEach(() => {
+  insertMock.mockReset()
+  ;(window as any).gapi = {
+    client: { calendar: { events: { insert: insertMock } } },
+  } as any
+  insertMock.mockResolvedValue({ result: { id: '1' } })
+})
+
+test('creates calendar events for each slot', async () => {
+  await createShiftEvent({
+    calendarId: 'cal',
+    summary: 'User',
+    date: '2023-05-01',
+    slot1: { inizio: '08:00', fine: '10:00' },
+    slot2: { inizio: '11:00', fine: '12:00' },
+  })
+
+  expect(insertMock).toHaveBeenCalledTimes(2)
+  expect(insertMock).toHaveBeenCalledWith({
+    calendarId: 'cal',
+    resource: {
+      summary: 'User',
+      description: undefined,
+      start: { dateTime: '2023-05-01T08:00' },
+      end: { dateTime: '2023-05-01T10:00' },
+    },
+  })
+})

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -68,3 +68,41 @@ export const deleteEvent = async (id: string): Promise<void> => {
   })
 }
 
+export interface ShiftSlot {
+  inizio: string
+  fine: string
+}
+
+export interface ShiftEventData {
+  calendarId: string
+  summary: string
+  date: string
+  note?: string
+  slot1: ShiftSlot
+  slot2?: ShiftSlot
+  slot3?: ShiftSlot
+}
+
+export const createShiftEvent = async (
+  data: ShiftEventData
+): Promise<GcEvent[]> => {
+  const gapi = (window as any).gapi
+  const slots = [data.slot1, data.slot2, data.slot3].filter(
+    Boolean
+  ) as ShiftSlot[]
+  const results: GcEvent[] = []
+  for (const slot of slots) {
+    const res = await gapi.client.calendar.events.insert({
+      calendarId: data.calendarId,
+      resource: {
+        summary: data.summary,
+        description: data.note,
+        start: { dateTime: `${data.date}T${slot.inizio}` },
+        end: { dateTime: `${data.date}T${slot.fine}` },
+      },
+    })
+    results.push(res.result)
+  }
+  return results
+}
+

--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -1,7 +1,11 @@
-import React, { useRef, useState } from 'react';
-import api from '../api/axios';
+import React, { useRef, useState } from 'react'
+import api from '../api/axios'
 
-export default function ImportExcel() {
+interface Props {
+  onImported?: (turni: any[]) => void
+}
+
+export default function ImportExcel({ onImported }: Props) {
   const fileInput = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
 
@@ -18,9 +22,15 @@ export default function ImportExcel() {
     try {
       const res = await api.post('/import/xlsx', form, {
         responseType: 'blob',
-      });
-      const url = URL.createObjectURL(res.data);
-      window.open(url, '_blank');
+      })
+      const url = URL.createObjectURL(res.data)
+      window.open(url, '_blank')
+      try {
+        const list = await api.get('/orari/')
+        onImported?.(list.data)
+      } catch {
+        // ignore errors
+      }
     } finally {
       setBusy(false);
     }

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -4,6 +4,7 @@ import SchedulePage from '../SchedulePage'
 import PageTemplate from '../../components/PageTemplate'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import api from '../../api/axios'
+import * as gc from '../../api/googleCalendar'
 
 jest.mock('../../api/axios', () => ({
   __esModule: true,
@@ -14,11 +15,21 @@ jest.mock('../../api/axios', () => ({
   },
 }))
 
+jest.mock('../../api/googleCalendar', () => ({
+  __esModule: true,
+  signIn: jest.fn(),
+  createShiftEvent: jest.fn(),
+}))
+
+const mockedGc = gc as jest.Mocked<typeof gc>
+
 const mockedApi = api as jest.Mocked<typeof api>
 
 beforeEach(() => {
   jest.resetAllMocks()
   mockedApi.get.mockResolvedValue({ data: [] })
+  mockedGc.signIn.mockResolvedValue()
+  mockedGc.createShiftEvent.mockResolvedValue([] as any)
 })
 
 const renderPage = () =>
@@ -78,6 +89,7 @@ describe('SchedulePage', () => {
       note: undefined,
     })
     expect((inputs[0] as HTMLInputElement).value).toBe('')
+    expect(mockedGc.createShiftEvent).toHaveBeenCalled()
   })
 
   it('deletes a turno', async () => {


### PR DESCRIPTION
## Summary
- add `createShiftEvent` API to push shift slots to Google Calendar
- expand `ImportExcel` to refresh turns after upload
- update `SchedulePage` with calendar selection and event creation
- test SchedulePage calls calendar API
- unit test calendar event creation

## Testing
- `npm test` *(fails: The `npm ci` command can only install with an existing package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_68653857c7a483239c1c7f596a726690