### PR TITLE
Integrate schedule page with Google Calendar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ VITE_GAPI_API_KEY="your-google-api-key"
 
 # Schedule page configuration
 # Comma-separated IDs of the Google Calendars displayed on the schedule page
-# The first ID controls the calendar iframe (defaults to 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
+# The first ID is selected by default (defaults to 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
 # API key used for public read-only access to those calendars

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ The variables are:
 - `VITE_GAPI_CLIENT_ID` – `your-google-client-id`.
 - `VITE_GAPI_API_KEY` – `your-google-api-key`.
 - `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs.
-  The schedule page shows the first ID and falls back to
-`9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com` when unset.
+  The schedule page lets you choose among these calendars, defaults to the first,
+  and falls back to
+  `9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com` when unset.
 
 4. Start the development server:
 

--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -1,0 +1,32 @@
+import { createShiftEvents } from '../googleCalendar'
+
+describe('createShiftEvents', () => {
+  const insert = jest.fn().mockResolvedValue({})
+  beforeEach(() => {
+    ;(window as any).gapi = {
+      client: { calendar: { events: { insert } } },
+    }
+    insert.mockClear()
+  })
+
+  it('creates an event for each slot', async () => {
+    await createShiftEvents('cal', {
+      userEmail: 'u@e',
+      giorno: '2023-05-01',
+      slot1: { inizio: '08:00', fine: '09:00' },
+      slot2: { inizio: '10:00', fine: '11:00' },
+      note: 'note',
+    })
+
+    expect(insert).toHaveBeenCalledTimes(2)
+    expect(insert).toHaveBeenCalledWith({
+      calendarId: 'cal',
+      resource: {
+        summary: 'u@e',
+        description: 'note',
+        start: { dateTime: '2023-05-01T08:00' },
+        end: { dateTime: '2023-05-01T09:00' },
+      },
+    })
+  })
+})

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -68,3 +68,35 @@ export const deleteEvent = async (id: string): Promise<void> => {
   })
 }
 
+export interface ShiftData {
+  userEmail: string
+  giorno: string
+  slot1: { inizio: string; fine: string }
+  slot2?: { inizio: string; fine: string }
+  slot3?: { inizio: string; fine: string }
+  note?: string
+}
+
+export const createShiftEvents = async (
+  calendarId: string,
+  turno: ShiftData
+): Promise<void> => {
+  const gapi = (window as any).gapi
+  const slots = [turno.slot1, turno.slot2, turno.slot3].filter(Boolean) as {
+    inizio: string
+    fine: string
+  }[]
+
+  for (const slot of slots) {
+    await gapi.client.calendar.events.insert({
+      calendarId,
+      resource: {
+        summary: turno.userEmail,
+        description: turno.note,
+        start: { dateTime: `${turno.giorno}T${slot.inizio}` },
+        end: { dateTime: `${turno.giorno}T${slot.fine}` },
+      },
+    })
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `createShiftEvents` helper to googleCalendar API
- allow choosing among configured calendars on SchedulePage
- create calendar events when adding or importing shifts
- update env sample and README with calendar info
- add unit tests for calendar integration

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_68653aade9e883238231d97ba71574db