### PR TITLE
Implement floating ImportExcel button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -185,3 +185,8 @@ input[type="datetime-local"] {
   margin-bottom: 1rem;
 }
 
+.error {
+  color: #d4351c; /* Red Italia */
+  margin-bottom: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- overhaul `ImportExcel` component with floating button and clearer feedback
- add global `.error` style for messages

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_686577843ff88323b18d5dab35b3c1db