### PR TITLE
Fix PDF import cleanup

### DIFF
--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -30,6 +30,7 @@ export default function ImportExcel({ onComplete }: ImportExcelProps) {
       const pdfBlob: Blob = response.data;
       const pdfURL = URL.createObjectURL(pdfBlob);
       window.open(pdfURL, '_blank');
+      URL.revokeObjectURL(pdfURL);
       setMessage('File importato correttamente.');
       onComplete?.(true);
     } catch (error) {

--- a/src/components/__tests__/ImportExcel.test.tsx
+++ b/src/components/__tests__/ImportExcel.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ImportExcel from '../ImportExcel'
+import api from '../../api/axios'
+
+jest.mock('../../api/axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}))
+
+const mockedApi = api as jest.Mocked<typeof api>
+
+describe('ImportExcel', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('revokes object URL after successful import', async () => {
+    mockedApi.post.mockResolvedValueOnce({ data: new Blob() })
+
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+    const createSpy = jest
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:1')
+    const revokeSpy = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    const { container } = render(<ImportExcel />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['1'], 'test.xlsx')
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank')
+    })
+    expect(revokeSpy).toHaveBeenCalledWith('blob:1')
+
+    openSpy.mockRestore()
+    createSpy.mockRestore()
+    revokeSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- revoke created object URLs when importing Excel files
- add ImportExcel unit test

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_686579cacdac8323afbe87a5b46611d6