### PR TITLE
Allow more turno types

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -16,7 +16,7 @@ interface Turno {
   slot1: Slot;
   slot2?: Slot;
   slot3?: Slot;
-  tipo: 'NORMALE' | 'STRAORD' | 'FERIE';
+  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO';
   note?: string;
   user_id: string;
 }
@@ -40,7 +40,7 @@ export default function SchedulePage() {
   const [s2End,   setS2End]   = useState('');
   const [s3Start, setS3Start] = useState('');
   const [s3End,   setS3End]   = useState('');
-  const [tipo, setTipo] = useState<'NORMALE' | 'STRAORD' | 'FERIE'>('NORMALE');
+  const [tipo, setTipo] = useState<'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'>('NORMALE');
   const [note, setNote] = useState('');
 
   const [calendarId, setCalendarId] = useState<string>(CALENDAR_IDS[0]);
@@ -211,6 +211,8 @@ export default function SchedulePage() {
           <option value="NORMALE">Normale</option>
           <option value="STRAORD">Straordinario</option>
           <option value="FERIE">Ferie</option>
+          <option value="RIPOSO">Riposo</option>
+          <option value="FESTIVO">Festivo</option>
         </select>
 
         <input placeholder="Note" value={note} onChange={e => setNote(e.target.value)} />

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -107,6 +107,78 @@ describe('SchedulePage', () => {
     }))
   })
 
+  it('adds a new turno with tipo RIPOSO', async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [] })
+    mockedApi.post.mockResolvedValueOnce({
+      data: {
+        id: '3',
+        giorno: '2023-05-03',
+        slot1: { inizio: '10:00', fine: '12:00' },
+        tipo: 'RIPOSO',
+        user_id: 'u',
+      },
+    })
+
+    renderPage()
+    await screen.findByRole('button', { name: /salva turno/i })
+
+    const inputs = screen.getAllByRole('textbox')
+    await userEvent.type(inputs[0], '2023-05-03')
+    await userEvent.type(inputs[1], '10:00')
+    await userEvent.type(inputs[2], '12:00')
+
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[2], 'RIPOSO')
+
+    await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
+
+    expect(await screen.findByText('RIPOSO')).toBeInTheDocument()
+    expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
+      user_id: 'u',
+      giorno: '2023-05-03',
+      slot1: { inizio: '10:00', fine: '12:00' },
+      tipo: 'RIPOSO',
+      note: undefined,
+    })
+  })
+
+  it('adds a new turno with tipo FESTIVO', async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [] })
+    mockedApi.post.mockResolvedValueOnce({
+      data: {
+        id: '4',
+        giorno: '2023-05-04',
+        slot1: { inizio: '11:00', fine: '13:00' },
+        tipo: 'FESTIVO',
+        user_id: 'u',
+      },
+    })
+
+    renderPage()
+    await screen.findByRole('button', { name: /salva turno/i })
+
+    const inputs = screen.getAllByRole('textbox')
+    await userEvent.type(inputs[0], '2023-05-04')
+    await userEvent.type(inputs[1], '11:00')
+    await userEvent.type(inputs[2], '13:00')
+
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[2], 'FESTIVO')
+
+    await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
+
+    expect(await screen.findByText('FESTIVO')).toBeInTheDocument()
+    expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
+      user_id: 'u',
+      giorno: '2023-05-04',
+      slot1: { inizio: '11:00', fine: '13:00' },
+      tipo: 'FESTIVO',
+      note: undefined,
+    })
+  })
+
   it('deletes a turno', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '07:00', fine: '09:00' }, tipo: 'NORMALE', user_id: 'u' }] })


### PR DESCRIPTION
## Summary
- extend allowed `Turno` types
- update state and select controls in SchedulePage
- test new `RIPOSO` and `FESTIVO` types

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_686579c6da988323802a7c0c3e31003d