### PR TITLE
Clarify schedule calendar env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ VITE_GAPI_API_KEY="your-google-api-key"
 
 # Schedule page configuration
 # Comma-separated IDs of the Google Calendars displayed on the schedule page
-# The first ID is selected by default (defaults to 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
+# The first ID is selected by default (defaults to
+# 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
 # API key used for public read-only access to those calendars

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ The variables are:
 - `VITE_API_URL` – https://<your-backend>.onrender.com.
 - `VITE_GAPI_CLIENT_ID` – `your-google-client-id`.
 - `VITE_GAPI_API_KEY` – `your-google-api-key`.
-- `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs.
-  The schedule page lets you choose among these calendars, defaults to the first,
-  and falls back to
-  `9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com` when unset.
+- `VITE_SCHEDULE_CALENDAR_IDS` – comma-separated list of Google Calendar IDs used
+  by the schedule page. The first ID is selected by default and it falls back to
+  `9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com`
+  when unset.
 
 4. Start the development server:
 

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -22,7 +22,7 @@ interface Turno {
 }
 
 /* ---------- COSTANTI ---------- */
-const CALENDAR_IDS =
+const SCHEDULE_CALENDAR_IDS =
   import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',') || [DEFAULT_CALENDAR_ID];
 
 /* ---------- HELPER ---------- */
@@ -43,7 +43,7 @@ export default function SchedulePage() {
   const [tipo, setTipo] = useState<'NORMALE' | 'STRAORD' | 'FERIE'>('NORMALE');
   const [note, setNote] = useState('');
 
-  const [calendarId, setCalendarId] = useState<string>(CALENDAR_IDS[0]);
+  const [calendarId, setCalendarId] = useState<string>(SCHEDULE_CALENDAR_IDS[0]);
 
   /* -- stato dati -- */
   const [utenti, setUtenti] = useState<Utente[]>([]);
@@ -161,7 +161,7 @@ export default function SchedulePage() {
           onChange={e => setCalendarId(e.target.value)}
           style={{ marginLeft: '0.5rem' }}
         >
-          {CALENDAR_IDS.map(id => (
+          {SCHEDULE_CALENDAR_IDS.map(id => (
             <option key={id} value={id}>{id}</option>
           ))}
         </select>


### PR DESCRIPTION
## Summary
- document schedule calendar variable consistently
- rename schedule calendar constant for clarity

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_686579c94f70832398d0f45a6e8a1af8