### PR TITLE
Add Excel import API

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -18,3 +18,9 @@ export const createTurno = (
 
 export const deleteTurno = (id: string): Promise<void> =>
   api.delete(`/orari/${id}`).then(() => undefined)
+
+export const importTurniExcel = (file: File): Promise<Blob> => {
+  const form = new FormData()
+  form.append('file', file)
+  return api.post('/import/xlsx', form, { responseType: 'blob' }).then(res => res.data)
+}


### PR DESCRIPTION
## Summary
- add `importTurniExcel` helper in the schedule API

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_68657da6e14483239820e3733f2d341d