### PR TITLE
Update README lockfile note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project contains the React front end of **Segretaria Digitale**, a simple a
 
 ```bash
 npm install
-# This repository doesn't include a lockfile
+# Dependencies are locked via `package-lock.json`
 # If you see 404 errors for `@tanstack/react-query`,
 # update the dependency to a recent release (>=4.36.1).
 # You can also run the helper script


### PR DESCRIPTION
## Summary
- note `package-lock.json` locks dependencies

## Testing
- `npm test` *(fails: cache mode only-if-cached)*

------
https://chatgpt.com/codex/tasks/task_e_68657dbce2d88323a56e9330dea4eaea