### PR TITLE
Add styling for imported shifts section

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -190,3 +190,9 @@ input[type="datetime-local"] {
   margin-bottom: 1rem;
 }
 
+/* Imported shifts section */
+.imported-turni-section h3 {
+  color: #A52019;
+  font-weight: bold;
+}
+

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -278,22 +278,24 @@ export default function SchedulePage() {
       </div>
 
       {importedTurni.length > 0 && (
-        <table className="item-table" style={{ marginTop: '1rem' }}>
-          <thead>
-            <tr>
-              <th>Nome agente</th>
-              <th>Giorno</th>
-              <th>Tipo</th>
-              <th>Slot 1</th>
-              <th>Slot 2</th>
-              <th>Slot 3</th>
-            </tr>
-          </thead>
-          <tbody>
-            {importedTurni.map(t => {
-              const nome = stripDomain(
-                utenti.find(u => u.id === t.user_id)?.email || ''
-              );
+        <section className="imported-turni-section">
+          <h3>Turni importati</h3>
+          <table className="item-table" style={{ marginTop: '1rem' }}>
+            <thead>
+              <tr>
+                <th>Nome agente</th>
+                <th>Giorno</th>
+                <th>Tipo</th>
+                <th>Slot 1</th>
+                <th>Slot 2</th>
+                <th>Slot 3</th>
+              </tr>
+            </thead>
+            <tbody>
+              {importedTurni.map(t => {
+                const nome = stripDomain(
+                  utenti.find(u => u.id === t.user_id)?.email || ''
+                );
               const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
               const slot1 = ferieLike
                 ? t.tipo
@@ -318,9 +320,10 @@ export default function SchedulePage() {
                   <td style={{ color: 'red' }}>{slot3Text}</td>
                 </tr>
               );
-            })}
-          </tbody>
-        </table>
+              })}
+            </tbody>
+          </table>
+        </section>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- style headers inside `.imported-turni-section`
- wrap imported shift table in the new section and add a heading

## Testing
- `npm test` *(fails: ENOTCACHED no cached response)*

------
https://chatgpt.com/codex/tasks/task_e_68657db978808323bf9a42630e63b1b8