### PR TITLE
Update Utente with name field

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -3,6 +3,7 @@ import api from './axios'
 export interface Utente {
   id: string
   email: string
+  nome: string
 }
 
 export const listUtenti = () => api.get<Utente[]>('/users/')

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -58,7 +58,7 @@ const renderPage = () =>
 describe('SchedulePage', () => {
   it('loads turni from API', async () => {
     mockedApi.get.mockImplementation(url => {
-      if (url === '/users/') return Promise.resolve({ data: [{ id: 'u', email: 'u@e' }] })
+      if (url === '/users/') return Promise.resolve({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
       if (url === '/orari/') return Promise.resolve({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '08:00', fine: '10:00' }, tipo: 'NORMALE', user_id: 'u' }] })
       return Promise.resolve({ data: [] })
     })
@@ -71,7 +71,7 @@ describe('SchedulePage', () => {
   })
 
   it('adds a new turno', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.post.mockResolvedValueOnce({
       data: {
@@ -108,7 +108,7 @@ describe('SchedulePage', () => {
   })
 
   it('adds a new turno with tipo RIPOSO', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.post.mockResolvedValueOnce({
       data: {
@@ -144,7 +144,7 @@ describe('SchedulePage', () => {
   })
 
   it('adds a new turno with tipo FESTIVO', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.post.mockResolvedValueOnce({
       data: {
@@ -180,7 +180,7 @@ describe('SchedulePage', () => {
   })
 
   it('deletes a turno', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '07:00', fine: '09:00' }, tipo: 'NORMALE', user_id: 'u' }] })
     mockedApi.delete.mockResolvedValueOnce({})
 
@@ -194,7 +194,7 @@ describe('SchedulePage', () => {
   })
 
   it('creates events after import', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.get.mockResolvedValueOnce({
       data: [
@@ -211,7 +211,7 @@ describe('SchedulePage', () => {
   })
 
   it('shows imported shifts in table after import', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.get.mockResolvedValueOnce({
       data: [
@@ -230,7 +230,7 @@ describe('SchedulePage', () => {
 
   it('downloads weekly PDF', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2023-05-01T00:00:00Z'))
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
 
     renderPage()


### PR DESCRIPTION
## Summary
- add `nome` field to `Utente` interface
- update SchedulePage tests to include `nome` in mocked API responses

## Testing
- `npm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68657db0ad588323bb9be1b29e9016e4