### PR TITLE
Update SchedulePage nome handling

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -3,6 +3,7 @@ import api from './axios'
 export interface Utente {
   id: string
   email: string
+  nome?: string
 }
 
 export const listUtenti = () => api.get<Utente[]>('/users/')

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -190,7 +190,7 @@ export default function SchedulePage() {
         >
           {utenti.map(u => (
             <option key={u.id} value={u.id}>
-              {stripDomain(u.email)}
+              {u.nome || stripDomain(u.email)}
             </option>
           ))}
         </select>
@@ -245,7 +245,12 @@ export default function SchedulePage() {
           <tbody>
             {turni.map(t => (
               <tr key={t.id}>
-                <td>{stripDomain(utenti.find(u => u.id === t.user_id)?.email || '')}</td>
+                <td>
+                  {
+                    utenti.find(u => u.id === t.user_id)?.nome ||
+                    stripDomain(utenti.find(u => u.id === t.user_id)?.email || '')
+                  }
+                </td>
                 <td>{t.giorno}</td>
                 <td>{`${t.slot1.inizio}–${t.slot1.fine}`}</td>
                 <td>{t.slot2 ? `${t.slot2.inizio}–${t.slot2.fine}` : '—'}</td>
@@ -291,9 +296,9 @@ export default function SchedulePage() {
           </thead>
           <tbody>
             {importedTurni.map(t => {
-              const nome = stripDomain(
-                utenti.find(u => u.id === t.user_id)?.email || ''
-              );
+              const nome =
+                utenti.find(u => u.id === t.user_id)?.nome ||
+                stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
               const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
               const slot1 = ferieLike
                 ? t.tipo

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -58,7 +58,7 @@ const renderPage = () =>
 describe('SchedulePage', () => {
   it('loads turni from API', async () => {
     mockedApi.get.mockImplementation(url => {
-      if (url === '/users/') return Promise.resolve({ data: [{ id: 'u', email: 'u@e' }] })
+      if (url === '/users/') return Promise.resolve({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
       if (url === '/orari/') return Promise.resolve({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '08:00', fine: '10:00' }, tipo: 'NORMALE', user_id: 'u' }] })
       return Promise.resolve({ data: [] })
     })
@@ -71,7 +71,7 @@ describe('SchedulePage', () => {
   })
 
   it('adds a new turno', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.post.mockResolvedValueOnce({
       data: {
@@ -108,7 +108,7 @@ describe('SchedulePage', () => {
   })
 
   it('adds a new turno with tipo RIPOSO', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.post.mockResolvedValueOnce({
       data: {
@@ -144,7 +144,7 @@ describe('SchedulePage', () => {
   })
 
   it('adds a new turno with tipo FESTIVO', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.post.mockResolvedValueOnce({
       data: {
@@ -180,7 +180,7 @@ describe('SchedulePage', () => {
   })
 
   it('deletes a turno', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '07:00', fine: '09:00' }, tipo: 'NORMALE', user_id: 'u' }] })
     mockedApi.delete.mockResolvedValueOnce({})
 
@@ -194,7 +194,7 @@ describe('SchedulePage', () => {
   })
 
   it('creates events after import', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.get.mockResolvedValueOnce({
       data: [
@@ -211,7 +211,7 @@ describe('SchedulePage', () => {
   })
 
   it('shows imported shifts in table after import', async () => {
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.get.mockResolvedValueOnce({
       data: [
@@ -230,7 +230,7 @@ describe('SchedulePage', () => {
 
   it('downloads weekly PDF', async () => {
     jest.useFakeTimers().setSystemTime(new Date('2023-05-01T00:00:00Z'))
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'Uno' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
 
     renderPage()


### PR DESCRIPTION
## Summary
- support optional `nome` on `Utente`
- show `nome` if available in SchedulePage
- adjust SchedulePage tests for new property

## Testing
- `npm test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68657db2c2008323bc2279983dd5c131