### PR TITLE
Use schedule import API in ImportExcel

### DIFF
--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, ChangeEvent } from 'react';
-import api from '../api/axios';
+import { importTurniExcel } from '../api/schedule';
 
 interface ImportExcelProps {
   onComplete?: (success: boolean) => void;
@@ -20,14 +20,8 @@ export default function ImportExcel({ onComplete }: ImportExcelProps) {
     setBusy(true);
     setMessage('');
 
-    const formData = new FormData();
-    formData.append('file', file);
-
     try {
-      const response = await api.post('/import/xlsx', formData, {
-        responseType: 'blob',
-      });
-      const pdfBlob: Blob = response.data;
+      const pdfBlob = await importTurniExcel(file);
       const pdfURL = URL.createObjectURL(pdfBlob);
       window.open(pdfURL, '_blank');
       URL.revokeObjectURL(pdfURL);


### PR DESCRIPTION
## Summary
- pull in `importTurniExcel` from the schedule API
- send the uploaded file through `importTurniExcel` instead of using `api.post`

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_68657f5b3040832390dae2017265297c