### PR TITLE
Fix SchedulePage name display

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -190,7 +190,7 @@ export default function SchedulePage() {
         >
           {utenti.map(u => (
             <option key={u.id} value={u.id}>
-              {stripDomain(u.email)}
+              {u.nome || stripDomain(u.email)}
             </option>
           ))}
         </select>
@@ -243,18 +243,23 @@ export default function SchedulePage() {
             </tr>
           </thead>
           <tbody>
-            {turni.map(t => (
-              <tr key={t.id}>
-                <td>{stripDomain(utenti.find(u => u.id === t.user_id)?.email || '')}</td>
-                <td>{t.giorno}</td>
+            {turni.map(t => {
+              const nome =
+                utenti.find(u => u.id === t.user_id)?.nome ||
+                stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
+              return (
+                <tr key={t.id}>
+                  <td>{nome}</td>
+                  <td>{t.giorno}</td>
                 <td>{`${t.slot1.inizio}–${t.slot1.fine}`}</td>
                 <td>{t.slot2 ? `${t.slot2.inizio}–${t.slot2.fine}` : '—'}</td>
                 <td>{t.slot3 ? `${t.slot3.inizio}–${t.slot3.fine}` : '—'}</td>
                 <td>{t.tipo}</td>
                 <td>{t.note || '—'}</td>
-                <td><button onClick={() => handleDelete(t.id)}>🗑️</button></td>
-              </tr>
-            ))}
+                  <td><button onClick={() => handleDelete(t.id)}>🗑️</button></td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </details>
@@ -293,9 +298,9 @@ export default function SchedulePage() {
             </thead>
             <tbody>
               {importedTurni.map(t => {
-                const nome = stripDomain(
-                  utenti.find(u => u.id === t.user_id)?.email || ''
-                );
+                const nome =
+                  utenti.find(u => u.id === t.user_id)?.nome ||
+                  stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
               const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
               const slot1 = ferieLike
                 ? t.tipo

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -65,7 +65,8 @@ describe('SchedulePage', () => {
 
     renderPage()
 
-    expect(await screen.findByText('08:00–10:00')).toBeInTheDocument()
+    const row = await screen.findByRole('row', { name: /u\s+2023-01-01/i })
+    expect(row).toBeInTheDocument()
     expect(mockedApi.get).toHaveBeenCalledWith('/users/')
     expect(mockedApi.get).toHaveBeenCalledWith('/orari/')
   })
@@ -85,6 +86,7 @@ describe('SchedulePage', () => {
 
     renderPage()
     await screen.findByRole('button', { name: /salva turno/i })
+    expect(screen.getByRole('option', { name: 'u' })).toBeInTheDocument()
 
     const inputs = screen.getAllByRole('textbox')
     await userEvent.type(inputs[0], '2023-05-02')
@@ -225,6 +227,7 @@ describe('SchedulePage', () => {
 
     const tables = await screen.findAllByRole('table')
     expect(tables).toHaveLength(2)
+    expect(within(tables[1]).getByText('u')).toBeInTheDocument()
     expect(within(tables[1]).getByText('2023-06-02')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary
- display the user's `nome` on SchedulePage, falling back to email
- show name in both saved shifts and imported shifts tables
- adjust tests to expect user names

## Testing
- `npm test` *(fails: ENOTCACHED for @tanstack/query-core)*

------
https://chatgpt.com/codex/tasks/task_e_68657fe833708323a63432d75d13fed0