### PR TITLE
Use name field in header greeting

### DIFF
--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -8,10 +8,19 @@ const Greeting: React.FC = () => {
   if (!token) return null;
 
   const decoded = decodeToken(token);
-  const email: string | undefined = decoded?.email || decoded?.sub || decoded?.user_id || decoded?.id;
-  if (!email) return null;
+  const name: string | undefined = decoded?.nome || decoded?.name;
+  let username: string | undefined = name;
 
-  const username = email.endsWith('@comune.castione.bg.it') ? email.split('@')[0] : email;
+  if (!username) {
+    const email: string | undefined =
+      decoded?.email || decoded?.sub || decoded?.user_id || decoded?.id;
+    if (email)
+      username = email.endsWith('@comune.castione.bg.it')
+        ? email.split('@')[0]
+        : email;
+  }
+
+  if (!username) return null;
   const hour = new Date().getHours();
   let salutation = 'Buonasera';
   if (hour < 12) salutation = 'Buongiorno';

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -40,7 +40,7 @@ describe('PageTemplate', () => {
   });
 
   it('displays greeting when user token exists', () => {
-    const payload = btoa(JSON.stringify({ email: 'test@comune.castione.bg.it' }));
+    const payload = btoa(JSON.stringify({ nome: 'test' }));
     localStorage.setItem('token', `xx.${payload}.yy`);
 
     render(


### PR DESCRIPTION
## Summary
- show `nome` or `name` from the JWT in the greeting component
- update PageTemplate test to encode `nome` in the test token

## Testing
- `npm test` *(fails: ENOTCACHED - cannot fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865b5ae54148323bbe85b3a5ec1c366