### PR TITLE
Remove calendar selector from schedule page

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -53,7 +53,7 @@ export default function SchedulePage() {
   const [tipo, setTipo] = useState<'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'>('NORMALE');
   const [note, setNote] = useState('');
 
-  const [calendarId, setCalendarId] = useState<string>(SCHEDULE_CALENDAR_IDS[0]);
+  const calendarId = SCHEDULE_CALENDAR_IDS[0];
 
   /* -- stato dati -- */
   const [utenti, setUtenti] = useState<Utente[]>([]);
@@ -177,18 +177,6 @@ export default function SchedulePage() {
       <h2>Turni di servizio</h2>
 
       <ImportExcel onComplete={handleImportComplete} />
-      <label style={{ display: 'block', marginBottom: '0.5rem' }}>
-        Calendario
-        <select
-          value={calendarId}
-          onChange={e => setCalendarId(e.target.value)}
-          style={{ marginLeft: '0.5rem' }}
-        >
-          {SCHEDULE_CALENDAR_IDS.map(id => (
-            <option key={id} value={id}>{id}</option>
-          ))}
-        </select>
-      </label>
 
       {/* -------- FORM -------- */}
       <form className="item-form" onSubmit={handleAdd}>

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -131,7 +131,7 @@ describe('SchedulePage', () => {
     await userEvent.type(inputs[2], '12:00')
 
     const selects = screen.getAllByRole('combobox')
-    await userEvent.selectOptions(selects[2], 'RIPOSO')
+    await userEvent.selectOptions(selects[1], 'RIPOSO')
 
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
@@ -167,7 +167,7 @@ describe('SchedulePage', () => {
     await userEvent.type(inputs[2], '13:00')
 
     const selects = screen.getAllByRole('combobox')
-    await userEvent.selectOptions(selects[2], 'FESTIVO')
+    await userEvent.selectOptions(selects[1], 'FESTIVO')
 
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 


### PR DESCRIPTION
## Summary
- simplify calendar selection logic
- update SchedulePage tests for new combobox index

## Testing
- `npm test` *(fails: request to registry.npmjs.org denied)*

------
https://chatgpt.com/codex/tasks/task_e_6865bff8335c83239b43575237dd4242