### PR TITLE
Implement local fallback for API URL

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,7 +1,12 @@
 import axios from 'axios';
 import { useAuthStore } from '../store/auth';
 
-const api = axios.create({ baseURL: import.meta.env.VITE_API_URL || '' });
+const api = axios.create({
+  baseURL: (import.meta.env.VITE_API_URL ?? 'http://localhost:8000').replace(
+    /\/+$/,
+    ''
+  ),
+});
 
 api.interceptors.request.use((config) => {
   const token = useAuthStore.getState().token || localStorage.getItem('token');


### PR DESCRIPTION
## Summary
- default axios baseURL to localhost:8000 when `VITE_API_URL` isn't set
- strip trailing slashes from the configured URL

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_68666949e6c4832385873867d3361e93