### PR TITLE
Add mobile viewport hook

### DIFF
--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export default function useIsMobile(breakpoint = 600): boolean {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== 'undefined' ? window.innerWidth <= breakpoint : false
+  );
+
+  useEffect(() => {
+    const handler = () => setIsMobile(window.innerWidth <= breakpoint);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, [breakpoint]);
+
+  return isMobile;
+}

--- a/src/pages/DeterminationsPage.tsx
+++ b/src/pages/DeterminationsPage.tsx
@@ -7,6 +7,7 @@ import {
   Determination,
 } from '../api/determinations';
 import './ListPages.css';
+import useIsMobile from '../hooks/useIsMobile';
 import { withOffline, withoutResult } from '../utils/offline';
 
 const DeterminationsPage: React.FC = () => {
@@ -17,7 +18,7 @@ const DeterminationsPage: React.FC = () => {
   const [descrizione, setDescrizione] = useState('');
   const [scadenza, setScadenza] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
-  const isMobile = window.innerWidth <= 600;
+  const isMobile = useIsMobile();
 
   const saveLocal = (data: Determination[]): void => {
     const trimmed = data.map(d => ({

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -14,6 +14,7 @@ import {
   DbEvent,
 } from '../api/events';
 import './ListPages.css';
+import useIsMobile from '../hooks/useIsMobile';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey, getUserId, decodeToken } from '../utils/auth';
 
@@ -46,7 +47,7 @@ export default function EventsPage() {
     isPublic: false,
   });
   const [editing, setEditing] = useState<{ id: string; source: 'db' | 'gc' } | null>(null);
-  const isMobile = window.innerWidth <= 600;
+  const isMobile = useIsMobile();
   const token = useAuthStore(s => s.token);
   const storageKey = useMemo(
     () =>

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -8,6 +8,7 @@ import {
 import { listDeterminations, Determination } from '../api/determinations';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import './ListPages.css';
+import useIsMobile from '../hooks/useIsMobile';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import { withOffline, withoutResult } from '../utils/offline';
@@ -24,7 +25,7 @@ export default function TodoPage() {
   const [text, setText] = useState('');
   const [due, setDue] = useState('');
   const [edit, setEdit] = useState<string | null>(null);
-  const isMobile = window.innerWidth <= 600;
+  const isMobile = useIsMobile();
   const token = useAuthStore(s => s.token);
   const storageKey = useMemo(
     () => getUserStorageKey('todos', token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)),


### PR DESCRIPTION
## Summary
- create `useIsMobile` hook for determining viewport width
- refactor EventsPage, DeterminationsPage and TodoPage to use the new hook

## Testing
- `npm test` *(fails: ENOTCACHED)*

------
https://chatgpt.com/codex/tasks/task_e_686675dd49648323a6288df4aec69665