### PR TITLE
Fix object URL revocation timing

### DIFF
--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -23,8 +23,14 @@ export default function ImportExcel({ onComplete }: ImportExcelProps) {
     try {
       const pdfBlob = await importTurniExcel(file);
       const pdfURL = URL.createObjectURL(pdfBlob);
-      window.open(pdfURL, '_blank');
-      URL.revokeObjectURL(pdfURL);
+      const newWindow = window.open(pdfURL, '_blank');
+      if (newWindow) {
+        newWindow.addEventListener('load', () => {
+          URL.revokeObjectURL(pdfURL);
+        });
+      } else {
+        setTimeout(() => URL.revokeObjectURL(pdfURL));
+      }
       setMessage('File importato correttamente.');
       onComplete?.(true);
     } catch (error) {

--- a/src/components/__tests__/ImportExcel.test.tsx
+++ b/src/components/__tests__/ImportExcel.test.tsx
@@ -33,7 +33,9 @@ describe('ImportExcel', () => {
     await waitFor(() => {
       expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank')
     })
-    expect(revokeSpy).toHaveBeenCalledWith('blob:1')
+    await waitFor(() => {
+      expect(revokeSpy).toHaveBeenCalledWith('blob:1')
+    })
 
     openSpy.mockRestore()
     createSpy.mockRestore()


### PR DESCRIPTION
## Summary
- handleFileChange waits for new window load before revoking the object URL (with a timeout fallback)
- adjust ImportExcel test to wait for async revocation

## Testing
- `npm test` *(fails: ENOTCACHED - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686675d557e08323a2d12c5e0b8138c1