### PR TITLE
Add calendarId parameter to Google Calendar API

### DIFF
--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -1,7 +1,7 @@
 // src/api/googleCalendar.ts
 import type { GcEvent } from './types'
 
-const CALENDAR_ID = 'primary'
+const DEFAULT_CALENDAR_ID = 'primary'
 
 export const signIn = async (): Promise<void> => {
   const gapi = (window as any).gapi
@@ -15,10 +15,12 @@ export const signIn = async (): Promise<void> => {
   await gapi.auth2.getAuthInstance().signIn()
 }
 
-export const listEvents = async (): Promise<GcEvent[]> => {
+export const listEvents = async (
+  calendarId: string = DEFAULT_CALENDAR_ID,
+): Promise<GcEvent[]> => {
   const gapi = (window as any).gapi
   const res = await gapi.client.calendar.events.list({
-    calendarId: CALENDAR_ID,
+    calendarId,
     singleEvents: true,
     orderBy: 'startTime',
     timeMin: new Date(0).toISOString(),
@@ -26,7 +28,9 @@ export const listEvents = async (): Promise<GcEvent[]> => {
   return res.result.items || []
 }
 
-export const createEvent = async (event: {
+export const createEvent = async (
+  calendarId: string = DEFAULT_CALENDAR_ID,
+  event: {
   summary: string
   description?: string
   start: { dateTime: string }
@@ -34,7 +38,7 @@ export const createEvent = async (event: {
 }): Promise<GcEvent> => {
   const gapi = (window as any).gapi
   const res = await gapi.client.calendar.events.insert({
-    calendarId: CALENDAR_ID,
+    calendarId,
     resource: event,
   })
   return res.result
@@ -43,6 +47,7 @@ export const createEvent = async (event: {
 // ---- Nuove funzioni ----
 
 export const updateEvent = async (
+  calendarId: string = DEFAULT_CALENDAR_ID,
   id: string,
   event: {
     summary?: string
@@ -53,17 +58,20 @@ export const updateEvent = async (
 ): Promise<GcEvent> => {
   const gapi = (window as any).gapi
   const res = await gapi.client.calendar.events.patch({
-    calendarId: CALENDAR_ID,
+    calendarId,
     eventId: id,
     resource: event,
   })
   return res.result
 }
 
-export const deleteEvent = async (id: string): Promise<void> => {
+export const deleteEvent = async (
+  calendarId: string = DEFAULT_CALENDAR_ID,
+  id: string,
+): Promise<void> => {
   const gapi = (window as any).gapi
   await gapi.client.calendar.events.delete({
-    calendarId: CALENDAR_ID,
+    calendarId,
     eventId: id,
   })
 }
@@ -78,7 +86,7 @@ export interface ShiftData {
 }
 
 export const createShiftEvents = async (
-  calendarId: string,
+  calendarId: string = DEFAULT_CALENDAR_ID,
   turno: ShiftData
 ): Promise<void> => {
   const gapi = (window as any).gapi

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -16,6 +16,7 @@ import {
 import './ListPages.css';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey, getUserId, decodeToken } from '../utils/auth';
+import { DEFAULT_CALENDAR_ID } from '../constants';
 
 interface UnifiedEvent {
   id: string;
@@ -48,6 +49,9 @@ export default function EventsPage() {
   const [editing, setEditing] = useState<{ id: string; source: 'db' | 'gc' } | null>(null);
   const isMobile = window.innerWidth <= 600;
   const token = useAuthStore(s => s.token);
+  const CALENDAR_ID =
+    import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
+    DEFAULT_CALENDAR_ID;
   const storageKey = useMemo(
     () =>
       getUserStorageKey(
@@ -76,7 +80,10 @@ export default function EventsPage() {
       if (navigator.onLine) {
         try {
           await signIn();
-          const [gc, db] = await Promise.all([listGcEvents(), listDbEvents()]);
+          const [gc, db] = await Promise.all([
+            listGcEvents(CALENDAR_ID),
+            listDbEvents(),
+          ]);
           const gcEvents: UnifiedEvent[] = gc.map(ev => ({
             id: ev.id,
             title: ev.summary,
@@ -140,7 +147,7 @@ export default function EventsPage() {
       if (navigator.onLine) {
         try {
           if (source === 'gc') {
-            await updateGcEvent(id, {
+            await updateGcEvent(CALENDAR_ID, id, {
               summary: title,
               description,
               start: { dateTime },
@@ -170,7 +177,7 @@ export default function EventsPage() {
       let dbEvent: UnifiedEvent | null = null
       if (navigator.onLine) {
         try {
-          const res = await createGcEvent({
+          const res = await createGcEvent(CALENDAR_ID, {
             summary: title,
             description,
             start: { dateTime },
@@ -246,7 +253,7 @@ export default function EventsPage() {
   const onDelete = async (id: string, source: 'gc' | 'db'): Promise<void> => {
     if (navigator.onLine) {
       try {
-        if (source === 'gc') await deleteGcEvent(id);
+        if (source === 'gc') await deleteGcEvent(CALENDAR_ID, id);
         else await deleteDbEvent(id);
       } catch {
         // ignore


### PR DESCRIPTION
## Summary
- allow google calendar API helpers to receive a calendarId
- use schedule calendar ID when calling Google Calendar functions

## Testing
- `npm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686675d9ce0483238f0184213b40b811