### PR TITLE
Avoid auth header on login

### DIFF
--- a/src/api/__tests__/axios.test.ts
+++ b/src/api/__tests__/axios.test.ts
@@ -1,0 +1,15 @@
+describe('axios request interceptor', () => {
+  const api = require('../axios').default
+  const { useAuthStore } = require('../../store/auth')
+
+  beforeEach(() => {
+    useAuthStore.getState().setToken('test-token')
+  })
+
+  it('does not set Authorization header for /login requests', () => {
+    const fulfilled = api.interceptors.request.handlers[0].fulfilled
+    const config = fulfilled({ url: '/login', headers: {} })
+    expect(config.headers.Authorization).toBeUndefined()
+  })
+})
+

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -10,7 +10,8 @@ const api = axios.create({
 
 api.interceptors.request.use((config) => {
   const token = useAuthStore.getState().token || localStorage.getItem('token');
-  if (token) {
+  const isLoginRequest = config.url?.endsWith('/login');
+  if (token && !isLoginRequest) {
     config.headers = config.headers || {};
     (config.headers as any).Authorization = `Bearer ${token}`;
   }


### PR DESCRIPTION
## Summary
- skip the Authorization header when hitting `/login`
- test that `/login` requests don't include auth header

## Testing
- `npm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686679dbcc788323a7fefbcf71cc2ff0