### PR TITLE
Refactor Turno slot typing

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -3,9 +3,9 @@ import api from './axios'
 export interface Turno {
   id: string
   user_id: string
-  slot1: string
-  slot2?: string | null
-  slot3?: string | null
+  slot1: { inizio: string; fine: string }
+  slot2?: { inizio: string; fine: string } | null
+  slot3?: { inizio: string; fine: string } | null
 }
 
 export const listTurni = (): Promise<Turno[]> =>


### PR DESCRIPTION
## Summary
- refine `Turno` interface slots to contain `inizio` and `fine`
- keep schedule API functions using new type

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached' but no cached response is available)*

------
https://chatgpt.com/codex/tasks/task_e_68667caacf34832397de0184d010f466