### PR TITLE
Fix env example API comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,3 @@ VITE_GAPI_API_KEY="your-google-api-key"
 # The first ID is selected by default (defaults to
 # 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
-# API key used for public read-only access to those calendars


### PR DESCRIPTION
## Summary
- remove dangling comment in `.env.example`

## Testing
- `npm test` *(fails: cache mode is 'only-if-cached')*

------
https://chatgpt.com/codex/tasks/task_e_68667caca19083238a92fa5c6d6cccf5