### PR TITLE
Use query params for getUtente

### DIFF
--- a/src/api/__tests__/users.test.ts
+++ b/src/api/__tests__/users.test.ts
@@ -1,0 +1,18 @@
+import { getUtente } from '../users'
+import api from '../axios'
+
+jest.mock('../axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}))
+
+const mockedApi = api as jest.Mocked<typeof api>
+
+describe('getUtente', () => {
+  it('requests user by email via query params', () => {
+    getUtente('u@e')
+    expect(mockedApi.get).toHaveBeenCalledWith('/users', { params: { email: 'u@e' } })
+  })
+})

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -8,4 +8,5 @@ export interface Utente {
 
 export const listUtenti = () => api.get<Utente[]>('/users/')
 
-export const getUtente = (id: string) => api.get<Utente>(`/users/${id}`)
+export const getUtente = (id: string) =>
+  api.get<Utente>('/users', { params: { email: id } })

--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -14,9 +14,9 @@ const Greeting: React.FC = () => {
     const initial = decoded?.nome || decoded?.name;
     if (initial) setUsername(initial);
     else {
-      const id = getUserId(token);
-      if (id)
-        getUtente(id)
+      const identifier = getUserId(token);
+      if (identifier)
+        getUtente(identifier)
           .then(r => setUsername(r.data.nome))
           .catch(() => {});
     }


### PR DESCRIPTION
## Summary
- fetch user by email using query params
- update Greeting component to use the new `getUtente`
- test that `getUtente` calls the API with `params`

## Testing
- `npm test -- -t "getUtente"` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b01cfc9483239a8253fc4494ca99