### PR TITLE
Add shared Turno interface

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -1,12 +1,5 @@
 import api from './axios'
-
-export interface Turno {
-  id: string
-  user_id: string
-  slot1: { inizio: string; fine: string }
-  slot2?: { inizio: string; fine: string } | null
-  slot3?: { inizio: string; fine: string } | null
-}
+import { Turno } from '../types/turno'
 
 export const listTurni = (): Promise<Turno[]> =>
   api.get<Turno[]>('/orari/').then(r => r.data)

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -10,16 +10,7 @@ import './ListPages.css';
 
 /* ---------- TIPI ---------- */
 interface Slot { inizio: string; fine: string; }
-interface Turno {
-  id: string;
-  giorno: string;
-  slot1: Slot;
-  slot2?: Slot;
-  slot3?: Slot;
-  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO';
-  note?: string;
-  user_id: string;
-}
+import { Turno } from '../types/turno';
 
 interface NewTurnoPayload {
   user_id: string;

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -1,0 +1,13 @@
+export interface Turno {
+  id: string;
+  user_id: string;
+  giorno: string;
+  inizio_1: string;
+  fine_1: string;
+  inizio_2?: string;
+  fine_2?: string;
+  inizio_3?: string;
+  fine_3?: string;
+  tipo: "NORMALE" | "RIPOSO" | "FESTIVO" | "FERIE" | "RECUPERO";
+  note?: string;
+}


### PR DESCRIPTION
## Summary
- create `src/types/turno.ts` and define the `Turno` interface
- import the shared type in `SchedulePage` and `api/schedule`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb540d608323b3185fa252f8f96a