### PR TITLE
Replace Utente type with User

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,12 +1,7 @@
 import api from './axios'
+import { User } from '../types/user'
 
-export interface Utente {
-  id: string
-  email: string
-  nome: string
-}
-
-export const listUtenti = () => api.get<Utente[]>('/users/')
+export const listUsers = () => api.get<User[]>('/users/')
 
 export const getUtente = (id: string) =>
-  api.get<Utente>('/users', { params: { email: id } })
+  api.get<User>('/users', { params: { email: id } })

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import api from '../api/axios';
-import { listUtenti, Utente } from '../api/users';
+import { listUsers } from '../api/users';
+import { User } from '../types/user';
 import { getSchedulePdf } from '../api/pdfs';
 import { format, startOfISOWeek, addDays } from 'date-fns';
 import { DEFAULT_CALENDAR_ID } from '../constants';
@@ -56,7 +57,7 @@ export default function SchedulePage() {
   const calendarId = SCHEDULE_CALENDAR_IDS[0];
 
   /* -- stato dati -- */
-  const [utenti, setUtenti] = useState<Utente[]>([]);
+  const [utenti, setUtenti] = useState<User[]>([]);
   const [turni, setTurni] = useState<Turno[]>([]);
   const [importedTurni, setImportedTurni] = useState<Turno[]>([]);
   const [refreshCal, setRefreshCal] = useState(false);
@@ -114,7 +115,7 @@ export default function SchedulePage() {
 
   /* --- caricamento iniziale --- */
   useEffect(() => {
-    listUtenti().then(r => {
+    listUsers().then(r => {
       setUtenti(r.data);
       setUtenteSel(r.data[0]?.id ?? '');
     });

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string;
+  email: string;
+  nome: string;
+}


### PR DESCRIPTION
## Summary
- add `User` interface in `src/types/user.ts`
- use `User` type in API and pages
- rename `listUtenti` to `listUsers`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb5788e08323a28be6a4ee5bec49