### PR TITLE
Add PDF upload/download APIs

### DIFF
--- a/src/api/pdfs.ts
+++ b/src/api/pdfs.ts
@@ -1,8 +1,17 @@
 import api from './axios'
 import type { PDFFile } from './types'
 
-export const listPDFs = (): Promise<PDFFile[]> =>
+export const listPdfs = (): Promise<PDFFile[]> =>
   api.get<PDFFile[]>('/pdfs').then(r => r.data)
+
+export const uploadPdf = (data: FormData): Promise<PDFFile> =>
+  api.post<PDFFile>('/pdfs', data).then(r => r.data)
+
+export const downloadPdf = (id: string): void => {
+  const base = api.defaults.baseURL || ''
+  const url = `${base}/pdfs/${id}`
+  window.open(url, '_blank')
+}
 
 export const getSchedulePdf = (week: string): Promise<Blob> =>
   api

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { listPDFs } from '../api/pdfs';
+import { listPdfs } from '../api/pdfs';
 import type { PDFFile } from '../api/types';
 import './ListPages.css';
 import { TEAMS_URL } from '../constants';
@@ -10,7 +10,7 @@ export default function UtilitaPage() {
   useEffect(() => {
     const fetchPdfs = async () => {
       try {
-        const data = await listPDFs();
+        const data = await listPdfs();
         setPdfs(data);
       } catch {
         // ignore errors fetching PDFs

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -6,18 +6,18 @@ import * as pdfApi from '../../api/pdfs';
 
 jest.mock('../../api/pdfs', () => ({
   __esModule: true,
-  listPDFs: jest.fn(),
+  listPdfs: jest.fn(),
 }));
 
 const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
 
 beforeEach(() => {
-  mockedApi.listPDFs.mockResolvedValue([]);
+  mockedApi.listPdfs.mockResolvedValue([]);
 });
 
 describe('UtilitaPage', () => {
   it('shows PDFs from API', async () => {
-    mockedApi.listPDFs.mockResolvedValue([{ id: '1', name: 'doc.pdf', url: '/doc.pdf' }]);
+    mockedApi.listPdfs.mockResolvedValue([{ id: '1', name: 'doc.pdf', url: '/doc.pdf' }]);
 
     render(
       <MemoryRouter initialEntries={["/utilita"]}>


### PR DESCRIPTION
## Summary
- rename `listPDFs` to `listPdfs`
- support PDF upload and direct download
- use new list API in `UtilitaPage`
- update tests for changed API

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb59e75c8323bbf99e1348f1beaa