### PR TITLE
Add Pdf files page with download

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const TodoPage = React.lazy(() => import("./pages/TodoPage"));
 const DeterminationsPage = React.lazy(() => import("./pages/DeterminationsPage"));
 const UtilitaPage = React.lazy(() => import("./pages/UtilitaPage"));
 const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
+const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 
 
 const App: React.FC = () => {
@@ -41,6 +42,7 @@ const App: React.FC = () => {
           <Route path="/events" element={<EventsPage />} />
           <Route path="/todo" element={<TodoPage />} />
           <Route path="/utilita" element={<UtilitaPage />} />
+          <Route path="/pdfs" element={<PdfFilesPage />} />
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
         </Route>

--- a/src/api/pdfs.ts
+++ b/src/api/pdfs.ts
@@ -4,6 +4,12 @@ import type { PDFFile } from './types'
 export const listPDFs = (): Promise<PDFFile[]> =>
   api.get<PDFFile[]>('/pdfs').then(r => r.data)
 
+// Alias with camelCase naming for convenience
+export const listPdfs = listPDFs
+
+export const downloadPdf = (id: string): Promise<Blob> =>
+  api.get(`/pdfs/${id}`, { responseType: 'blob' }).then(r => r.data)
+
 export const getSchedulePdf = (week: string): Promise<Blob> =>
   api
     .get('/orari/pdf', { params: { week }, responseType: 'blob' })

--- a/src/pages/PdfFilesPage.tsx
+++ b/src/pages/PdfFilesPage.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { listPdfs, downloadPdf } from '../api/pdfs';
+import type { PDFFile } from '../api/types';
+import './ListPages.css';
+
+export default function PdfFilesPage() {
+  const [pdfs, setPdfs] = useState<PDFFile[]>([]);
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const data = await listPdfs();
+        setPdfs(data);
+      } catch {
+        // ignore fetch errors
+      }
+    };
+    fetch();
+  }, []);
+
+  const handleDownload = async (id: string) => {
+    try {
+      const blob = await downloadPdf(id);
+      const url = URL.createObjectURL(blob);
+      window.open(url, '_blank');
+    } catch {
+      // ignore download errors
+    }
+  };
+
+  return (
+    <div className="list-page">
+      <h2>File PDF</h2>
+      <table className="item-table">
+        <thead>
+          <tr>
+            <th>Titolo</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {pdfs.map(p => (
+            <tr key={p.id}>
+              <td>{p.name}</td>
+              <td>
+                <button onClick={() => handleDownload(p.id)}>Download</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/__tests__/PdfFilesPage.test.tsx
+++ b/src/pages/__tests__/PdfFilesPage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PdfFilesPage from '../PdfFilesPage';
+import PageTemplate from '../../components/PageTemplate';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import * as pdfApi from '../../api/pdfs';
+
+jest.mock('../../api/pdfs', () => ({
+  __esModule: true,
+  listPdfs: jest.fn(),
+  downloadPdf: jest.fn(),
+}));
+
+const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
+
+beforeEach(() => {
+  mockedApi.listPdfs.mockResolvedValue([]);
+  mockedApi.downloadPdf.mockResolvedValue(new Blob());
+});
+
+describe('PdfFilesPage', () => {
+  const renderPage = () =>
+    render(
+      <MemoryRouter initialEntries={["/pdfs"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/pdfs" element={<PdfFilesPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+  it('shows titles from API', async () => {
+    mockedApi.listPdfs.mockResolvedValueOnce([
+      { id: '1', name: 'doc.pdf', url: '/doc.pdf' },
+    ]);
+
+    renderPage();
+
+    expect(await screen.findByText('doc.pdf')).toBeInTheDocument();
+  });
+
+  it('downloads file on click', async () => {
+    mockedApi.listPdfs.mockResolvedValueOnce([
+      { id: '1', name: 'doc.pdf', url: '/doc.pdf' },
+    ]);
+
+    renderPage();
+
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    const urlSpy = jest
+      .spyOn(URL, 'createObjectURL')
+      .mockReturnValue('blob:1');
+
+    await userEvent.click(await screen.findByRole('button', { name: /download/i }));
+
+    expect(mockedApi.downloadPdf).toHaveBeenCalledWith('1');
+    expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank');
+
+    openSpy.mockRestore();
+    urlSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- create `PdfFilesPage` to display available PDFs
- add `downloadPdf` and camelCase alias `listPdfs`
- register the route in `App.tsx`
- test listing and downloading PDFs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866eb5e3c9c8323a28d9990ab513d86