### PR TITLE
Update schedule API interface

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -1,20 +1,8 @@
 import api from './axios'
+import type { Turno } from 'src/types/turno'
 
-export interface Turno {
-  id: string
-  user_id: string
-  slot1: { inizio: string; fine: string }
-  slot2?: { inizio: string; fine: string } | null
-  slot3?: { inizio: string; fine: string } | null
-}
-
-export const listTurni = (): Promise<Turno[]> =>
-  api.get<Turno[]>('/orari/').then(r => r.data)
-
-export const createTurno = (
-  data: Omit<Turno, 'id'>
-): Promise<Turno> =>
-  api.post<Turno>('/orari/', data).then(r => r.data)
+export const fetchTurni = () => api.get<Turno[]>('/orari/')
+export const saveTurno = (t: Turno) => api.post<Turno>('/orari/', t)
 
 export const deleteTurno = (id: string): Promise<void> =>
   api.delete(`/orari/${id}`).then(() => undefined)

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -1,0 +1,15 @@
+export interface Slot {
+  inizio: string;
+  fine: string;
+}
+
+export interface Turno {
+  id: string;
+  giorno: string;
+  slot1: Slot;
+  slot2?: Slot;
+  slot3?: Slot;
+  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO';
+  note?: string;
+  user_id: string;
+}


### PR DESCRIPTION
## Summary
- centralize Turno type under `src/types`
- expose new `fetchTurni` and `saveTurno` helpers
- update SchedulePage to use the new helpers

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6866eb57e3ac8323be2ac214f88eb642