### PR TITLE
Add PdfFiles page and tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const TodoPage = React.lazy(() => import("./pages/TodoPage"));
 const DeterminationsPage = React.lazy(() => import("./pages/DeterminationsPage"));
 const UtilitaPage = React.lazy(() => import("./pages/UtilitaPage"));
 const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
+const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 
 
 const App: React.FC = () => {
@@ -41,6 +42,7 @@ const App: React.FC = () => {
           <Route path="/events" element={<EventsPage />} />
           <Route path="/todo" element={<TodoPage />} />
           <Route path="/utilita" element={<UtilitaPage />} />
+          <Route path="/pdfs" element={<PdfFilesPage />} />
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
         </Route>

--- a/src/pages/PdfFilesPage.tsx
+++ b/src/pages/PdfFilesPage.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react';
+import { listPdfs, downloadPdf } from '../api/pdfs';
+import type { PDFFile } from '../api/types';
+import './ListPages.css';
+
+export default function PdfFilesPage() {
+  const [pdfs, setPdfs] = useState<PDFFile[]>([]);
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const data = await listPdfs();
+        setPdfs(data);
+      } catch {
+        // ignore fetch errors
+      }
+    };
+    fetch();
+  }, []);
+
+  return (
+    <div className="list-page">
+      <h2>PDF</h2>
+      <table className="item-table">
+        <thead>
+          <tr>
+            <th>Titolo</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {pdfs.map(p => (
+            <tr key={p.id}>
+              <td className="desc-cell">{p.name}</td>
+              <td>
+                <button onClick={() => downloadPdf(p.id)}>Download</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/__tests__/PdfFilesPage.test.tsx
+++ b/src/pages/__tests__/PdfFilesPage.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PdfFilesPage from '../PdfFilesPage';
+import PageTemplate from '../../components/PageTemplate';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import * as pdfApi from '../../api/pdfs';
+
+jest.mock('../../api/pdfs', () => ({
+  __esModule: true,
+  listPdfs: jest.fn(),
+  downloadPdf: jest.fn(),
+}));
+
+const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
+
+beforeEach(() => {
+  mockedApi.listPdfs.mockResolvedValue([]);
+});
+
+describe('PdfFilesPage', () => {
+  it('lists PDFs and downloads file', async () => {
+    mockedApi.listPdfs.mockResolvedValue([{ id: '1', name: 'file.pdf', url: '/file.pdf' }]);
+
+    render(
+      <MemoryRouter initialEntries={["/pdfs"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/pdfs" element={<PdfFilesPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('file.pdf')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /download/i }));
+    expect(mockedApi.downloadPdf).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add a simple PdfFilesPage component for listing PDFs
- register the new route under `/pdfs`
- add tests for listing and downloading

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ed22cff483238d2b282542548447