### PR TITLE
Handle Base64URL tokens

### DIFF
--- a/src/utils/__tests__/auth.test.ts
+++ b/src/utils/__tests__/auth.test.ts
@@ -11,4 +11,17 @@ describe('getUserStorageKey', () => {
     const token = `${header}.${payload}.sig`;
     expect(getUserStorageKey('todos', token)).toBe('todos_123');
   });
+
+  it('handles base64url tokens', () => {
+    const base64Url = (b: Buffer) =>
+      b
+        .toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/, '');
+    const header = base64Url(Buffer.from('{}'));
+    const payload = base64Url(Buffer.from(JSON.stringify({ sub: 'xyz' })));
+    const token = `${header}.${payload}.sig`;
+    expect(getUserStorageKey('todos', token)).toBe('todos_xyz');
+  });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,8 @@
 export function decodeToken(token: string): any | null {
   try {
-    const payload = token.split('.')[1];
+    let payload = token.split('.')[1];
+    payload = payload.replace(/-/g, '+').replace(/_/g, '/');
+    while (payload.length % 4) payload += '=';
     const json = atob(payload);
     return JSON.parse(json);
   } catch {


### PR DESCRIPTION
## Summary
- support decoding Base64URL tokens in `decodeToken`
- verify Base64URL encoding via new test case

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ee993f408323a8efa6f46684b5aa