### PR TITLE
Update Turno type structure

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -10,18 +10,9 @@ import { createShiftEvents, ShiftData, signIn } from '../api/googleCalendar';
 import './ListPages.css';
 
 /* ---------- TIPI ---------- */
-interface Slot { inizio: string; fine: string; }
-import { Turno } from '../types/turno';
+import { Turno, Slot } from '../types/turno';
 
-interface NewTurnoPayload {
-  user_id: string;
-  giorno: string;
-  slot1: Slot;
-  slot2?: Slot;
-  slot3?: Slot;
-  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO';
-  note?: string;
-}
+type NewTurnoPayload = Omit<Turno, 'id'>;
 
 /* ---------- COSTANTI ---------- */
 const SCHEDULE_CALENDAR_IDS =

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -1,13 +1,15 @@
+export interface Slot {
+  inizio: string
+  fine: string
+}
+
 export interface Turno {
-  id: string;
-  user_id: string;
-  giorno: string;
-  inizio_1: string;
-  fine_1: string;
-  inizio_2?: string;
-  fine_2?: string;
-  inizio_3?: string;
-  fine_3?: string;
-  tipo: "NORMALE" | "RIPOSO" | "FESTIVO" | "FERIE" | "RECUPERO";
-  note?: string;
+  id: string
+  user_id: string
+  giorno: string
+  slot1: Slot
+  slot2?: Slot
+  slot3?: Slot
+  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'
+  note?: string
 }


### PR DESCRIPTION
## Summary
- update `Turno` type to use `slot` objects
- use the new `Turno` and `Slot` types in `SchedulePage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ef452e948323a63d397d344d8ff3