### PR TITLE
Add user profile state and greeting fetch

### DIFF
--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -1,33 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useAuthStore } from '../store/auth';
-import { decodeToken, getUserId } from '../utils/auth';
-import { getUtente } from '../api/users';
 import './Greeting.css';
 
 const Greeting: React.FC = () => {
-  const token = useAuthStore(s => s.token) || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null);
-  const [username, setUsername] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!token) return;
-    const decoded = decodeToken(token);
-    const initial = decoded?.nome || decoded?.name;
-    if (initial) setUsername(initial);
-    else {
-      const identifier = getUserId(token);
-      if (identifier)
-        getUtente(identifier)
-          .then(r => setUsername(r.data.nome))
-          .catch(() => {});
-    }
-  }, [token]);
-
-  if (!token || !username) return null;
+  const user = useAuthStore(s => s.user);
+  if (!user) return null;
   const hour = new Date().getHours();
   let salutation = 'Buonasera';
   if (hour < 12) salutation = 'Buongiorno';
   else if (hour < 18) salutation = 'Buon pomeriggio';
-  return <div className="user-greeting">{salutation} {username}</div>;
+  return <div className="user-greeting">{salutation} {user.nome}</div>;
 };
 
 export default Greeting;

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -1,16 +1,36 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Footer from './Footer';
+import api from '../api/axios';
+import { useAuthStore } from '../store/auth';
 
-const PageTemplate: React.FC = () => (
-  <>
-    <Header />
-    <main className="app-container">
-      <Outlet />
-    </main>
-    <Footer />
-  </>
-);
+const PageTemplate: React.FC = () => {
+  const token = useAuthStore(s => s.token);
+  const user = useAuthStore(s => s.user);
+  const setUser = useAuthStore(s => s.setUser);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await api.get('/users/me');
+        setUser(res.data);
+      } catch {
+        // ignore
+      }
+    };
+    if (token && !user) fetchUser();
+  }, [token, user, setUser]);
+
+  return (
+    <>
+      <Header />
+      <main className="app-container">
+        <Outlet />
+      </main>
+      <Footer />
+    </>
+  );
+};
 
 export default PageTemplate;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -12,6 +12,7 @@ const LoginPage: React.FC = () => {
   const [error, setError] = useState("");
   const navigate = useNavigate();
   const setToken = useAuthStore(s => s.setToken);
+  const setUser = useAuthStore(s => s.setUser);
 
   useEffect(() => {
     document.body.classList.add("login-bg");
@@ -28,6 +29,12 @@ const LoginPage: React.FC = () => {
     try {
       const res = await api.post("/login", { email, password });
       setToken(res.data.access_token);
+      try {
+        const me = await api.get("/users/me");
+        setUser(me.data);
+      } catch {
+        // ignore failure
+      }
       navigate("/");
     } catch {
       setError("Credenziali errate");

--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -8,6 +8,7 @@ jest.mock('../../api/axios', () => ({
   __esModule: true,
   default: {
     post: jest.fn(),
+    get: jest.fn(),
   },
 }));
 
@@ -21,6 +22,7 @@ beforeEach(() => {
 describe('LoginPage', () => {
   it('navigates to dashboard on valid credentials', async () => {
     mockedApi.post.mockResolvedValue({ data: { access_token: 'tok' } });
+    mockedApi.get.mockResolvedValue({ data: { id: '1', nome: 'test', email: 'e' } });
 
     render(
       <MemoryRouter initialEntries={["/login"]}>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,8 +1,12 @@
 import { create } from 'zustand';
 
+import { User } from '../types/user';
+
 interface AuthState {
   token: string | null;
+  user: User | null;
   setToken: (token: string | null) => void;
+  setUser: (user: User | null) => void;
 }
 
 export const useAuthStore = create<AuthState>((set) => {
@@ -13,10 +17,14 @@ export const useAuthStore = create<AuthState>((set) => {
 
   return {
     token: getInitialToken(),
+    user: null,
     setToken: (token) => {
       if (token) localStorage.setItem('token', token);
       else localStorage.removeItem('token');
       set({ token });
+    },
+    setUser: (user) => {
+      set({ user });
     },
   };
 });


### PR DESCRIPTION
## Summary
- extend auth store with `user` and `setUser`
- fetch `/users/me` after login
- load user profile on every protected page
- update greeting to read the user from the store
- adjust tests to mock profile fetch

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f22a4c248323840a56244937a623