### PR TITLE
Use Cormorant Garamond font for all form controls

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,14 @@ body.login-bg {
   font-family: 'Almendra SC', serif;
 }
 
+/* Use Cormorant Garamond for all input elements */
+input,
+textarea,
+select,
+button {
+  font-family: 'Cormorant Garamond', serif;
+}
+
 
 
 /* LOGIN */


### PR DESCRIPTION
## Summary
- ensure `input`, `textarea`, `select` and `button` elements use the Cormorant Garamond font so forms keep the same typography even on pages that override `body` fonts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f74e7af8832397ebdce9ea9e7ead