### PR TITLE
Add Greeting component tests

### DIFF
--- a/src/components/__tests__/Greeting.test.tsx
+++ b/src/components/__tests__/Greeting.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import Greeting from '../Greeting'
+import { useAuthStore } from '../../store/auth'
+
+jest.mock('../../store/auth')
+
+const mockedUseAuthStore = useAuthStore as jest.Mock
+
+const user = { id: '1', nome: 'Mario', email: 'mario@example.com' }
+
+describe('Greeting', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('shows morning greeting', () => {
+    mockedUseAuthStore.mockImplementation((sel: any) => sel({ user }))
+    jest.spyOn(Date.prototype, 'getHours').mockReturnValue(9)
+    render(<Greeting />)
+    expect(screen.getByText(/Buongiorno Mario/i)).toBeInTheDocument()
+  })
+
+  it('shows afternoon greeting', () => {
+    mockedUseAuthStore.mockImplementation((sel: any) => sel({ user }))
+    jest.spyOn(Date.prototype, 'getHours').mockReturnValue(15)
+    render(<Greeting />)
+    expect(screen.getByText(/Buon pomeriggio Mario/i)).toBeInTheDocument()
+  })
+
+  it('shows evening greeting', () => {
+    mockedUseAuthStore.mockImplementation((sel: any) => sel({ user }))
+    jest.spyOn(Date.prototype, 'getHours').mockReturnValue(20)
+    render(<Greeting />)
+    expect(screen.getByText(/Buonasera Mario/i)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for Greeting component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f89e28b88323a8a0bd45e88768bb