### PR TITLE
Handle greeting when /users/me fails

### DIFF
--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -4,12 +4,12 @@ import './Greeting.css';
 
 const Greeting: React.FC = () => {
   const user = useAuthStore(s => s.user);
-  if (!user) return null;
   const hour = new Date().getHours();
   let salutation = 'Buonasera';
   if (hour < 12) salutation = 'Buongiorno';
   else if (hour < 18) salutation = 'Buon pomeriggio';
-  return <div className="user-greeting">{salutation} {user.nome}</div>;
+  const namePart = user && user.nome ? ` ${user.nome}` : '';
+  return <div className="user-greeting">{salutation}{namePart}</div>;
 };
 
 export default Greeting;

--- a/src/components/PageTemplate.tsx
+++ b/src/components/PageTemplate.tsx
@@ -4,6 +4,7 @@ import Header from './Header';
 import Footer from './Footer';
 import api from '../api/axios';
 import { useAuthStore } from '../store/auth';
+import { User } from '../types/user';
 
 const PageTemplate: React.FC = () => {
   const token = useAuthStore(s => s.token);
@@ -15,8 +16,9 @@ const PageTemplate: React.FC = () => {
       try {
         const res = await api.get('/users/me');
         setUser(res.data);
-      } catch {
-        // ignore
+      } catch (err) {
+        console.error(err);
+        setUser({ id: '', email: '', nome: '' } as User);
       }
     };
     if (token && !user) fetchUser();

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -71,4 +71,25 @@ describe('PageTemplate', () => {
     const salutation = hour < 12 ? 'Buongiorno' : hour < 18 ? 'Buon pomeriggio' : 'Buonasera';
     expect(await screen.findByText(new RegExp(`${salutation} test`, 'i'))).toBeInTheDocument();
   });
+
+  it('shows placeholder greeting when fetching profile fails', async () => {
+    useAuthStore.getState().setToken('tok');
+    mockedApi.get.mockRejectedValueOnce(new Error('fail'));
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dummy />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(mockedApi.get).toHaveBeenCalledWith('/users/me');
+
+    const hour = new Date().getHours();
+    const salutation = hour < 12 ? 'Buongiorno' : hour < 18 ? 'Buon pomeriggio' : 'Buonasera';
+    expect(await screen.findByText(new RegExp(`^${salutation}$`, 'i'))).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- allow `Greeting` to display just the salutation when user name is missing
- log and handle errors while fetching user profile so a default greeting shows
- test placeholder greeting on profile fetch failure

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f8a316748323a1c945e88e93cbe9