### PR TITLE
Replace Utilita page with tabbed meeting iframe

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -162,6 +162,42 @@
   height: auto;
 }
 
+/* Simple tabs for Utilità page */
+.tabs {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 1rem;
+}
+
+.tab-button {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.tab-button.active {
+  border-bottom: 2px solid #A52019;
+  font-weight: bold;
+}
+
+.tab-button img {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.iframe-container iframe {
+  width: 100%;
+  height: 80vh;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
 @media (min-width: 601px) {
   .meeting-links img {
     width: 15cm;

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,56 +1,67 @@
-import React, { useEffect, useState } from 'react';
-import { listPdfs } from '../api/pdfs';
-import type { PDFFile } from '../api/types';
+import React, { useState } from 'react';
 import './ListPages.css';
 import { TEAMS_URL } from '../constants';
 
 export default function UtilitaPage() {
-  const [pdfs, setPdfs] = useState<PDFFile[]>([]);
+  const [active, setActive] = useState<'meet' | 'teams' | 'zoom'>('meet');
 
-  useEffect(() => {
-    const fetchPdfs = async () => {
-      try {
-        const data = await listPdfs();
-        setPdfs(data);
-      } catch {
-        // ignore errors fetching PDFs
-      }
-    };
-    fetchPdfs();
-  }, []);
 
+  const meetUrl = 'https://meet.google.com/landing?pli=1';
+  const teamsUrl = TEAMS_URL;
+  const zoomUrl = 'https://zoom.us/it/signin#/login';
 
   return (
     <div className="list-page">
       <h2>Utilità</h2>
-      <div className="meeting-links">
-        <a
-          href="https://meet.google.com/landing?pli=1"
-          target="_blank"
-          rel="noopener noreferrer"
+      <div className="tabs">
+        <button
+          data-testid="tab-meet"
+          className={`tab-button ${active === 'meet' ? 'active' : ''}`}
+          onClick={() => setActive('meet')}
         >
-          <img src="/meet.png" alt="Google Meet" />
-        </a>
-        <a href={TEAMS_URL} target="_blank" rel="noopener noreferrer">
-          <img src="/teams.png" alt="Microsoft Teams" />
-        </a>
-        <a
-          href="https://zoom.us/it/signin#/login"
-          target="_blank"
-          rel="noopener noreferrer"
+          <img src="/meet.png" alt="Google Meet" className="tab-icon" />
+          <span>Meet</span>
+        </button>
+        <button
+          data-testid="tab-teams"
+          className={`tab-button ${active === 'teams' ? 'active' : ''}`}
+          onClick={() => setActive('teams')}
         >
-          <img src="/zoom.png" alt="Zoom" />
-        </a>
+          <img src="/teams.png" alt="Microsoft Teams" className="tab-icon" />
+          <span>Teams</span>
+        </button>
+        <button
+          data-testid="tab-zoom"
+          className={`tab-button ${active === 'zoom' ? 'active' : ''}`}
+          onClick={() => setActive('zoom')}
+        >
+          <img src="/zoom.png" alt="Zoom" className="tab-icon" />
+          <span>Zoom</span>
+        </button>
       </div>
-      <ul className="item-list">
-        {pdfs.map(p => (
-          <li key={p.id}>
-            <a href={p.url} target="_blank" rel="noopener noreferrer">
-              {p.name}
-            </a>
-          </li>
-        ))}
-      </ul>
+      <div className="iframe-container">
+        {active === 'meet' && (
+          <iframe
+            title="Google Meet"
+            src={meetUrl}
+            allow="camera; microphone; fullscreen"
+          />
+        )}
+        {active === 'teams' && (
+          <iframe
+            title="Microsoft Teams"
+            src={teamsUrl}
+            allow="camera; microphone; fullscreen"
+          />
+        )}
+        {active === 'zoom' && (
+          <iframe
+            title="Zoom"
+            src={zoomUrl}
+            allow="camera; microphone; fullscreen"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -1,24 +1,11 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import UtilitaPage from '../UtilitaPage';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import * as pdfApi from '../../api/pdfs';
-
-jest.mock('../../api/pdfs', () => ({
-  __esModule: true,
-  listPdfs: jest.fn(),
-}));
-
-const mockedApi = pdfApi as jest.Mocked<typeof pdfApi>;
-
-beforeEach(() => {
-  mockedApi.listPdfs.mockResolvedValue([]);
-});
 
 describe('UtilitaPage', () => {
-  it('shows PDFs from API', async () => {
-    mockedApi.listPdfs.mockResolvedValue([{ id: '1', name: 'doc.pdf', url: '/doc.pdf' }]);
-
+  it('switches meeting iframe when selecting tabs', async () => {
     render(
       <MemoryRouter initialEntries={["/utilita"]}>
         <Routes>
@@ -29,8 +16,9 @@ describe('UtilitaPage', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('doc.pdf')).toBeInTheDocument();
+    expect(screen.getByTitle('Google Meet')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('tab-teams'));
+    expect(screen.getByTitle('Microsoft Teams')).toBeInTheDocument();
   });
-
-
 });


### PR DESCRIPTION
## Summary
- rework `UtilitaPage` to show meeting links in tabs with an iframe area
- style new tab components in `ListPages.css`
- update Utilita page test to reflect new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fa15c25c832395cb3d3267abe608