### PR TITLE
Add conferencing URL config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,8 @@ VITE_GAPI_API_KEY="your-google-api-key"
 # The first ID is selected by default (defaults to
 # 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
+
+# Video conferencing links for the Utilità page
+VITE_MEET_URL="https://meet.google.com/xyz-abcq-wvu"
+VITE_TEAMS_URL="https://teams.microsoft.com/l/meetup-join/…"
+VITE_ZOOM_URL="https://zoom.us/wc/join/123456789?pwd=abcdef"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The variables are:
   by the schedule page. The first ID is selected by default and it falls back to
   `9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com`
   when unset.
+- `VITE_MEET_URL` – Google Meet room URL shown on the Utilità page.
+- `VITE_TEAMS_URL` – Microsoft Teams meeting link used by the Utilità page.
+- `VITE_ZOOM_URL` – Zoom meeting link used by the Utilità page.
 
 4. Start the development server:
 

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -7,17 +7,20 @@ export default function UtilitaPages() {
     {
       name: 'Google Meet',
       icon: <Google className="w-6 h-6" />,
-      url: 'https://meet.google.com/xyz-abcq-wvu',
+      url: import.meta.env.VITE_MEET_URL ??
+        'https://meet.google.com/xyz-abcq-wvu',
     },
     {
       name: 'Microsoft Teams',
       icon: <Microsoft className="w-6 h-6" />,
-      url: 'https://teams.microsoft.com/l/meetup-join/…',
+      url: import.meta.env.VITE_TEAMS_URL ??
+        'https://teams.microsoft.com/l/meetup-join/…',
     },
     {
       name: 'Zoom',
       icon: <Video className="w-6 h-6" />,
-      url: 'https://zoom.us/wc/join/123456789?pwd=abcdef',
+      url: import.meta.env.VITE_ZOOM_URL ??
+        'https://zoom.us/wc/join/123456789?pwd=abcdef',
     },
   ];
 


### PR DESCRIPTION
## Summary
- allow overriding conferencing URLs via env vars
- document new variables in setup docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686717ba36f88323b7ac4e89f4d63818