### PR TITLE
style(greeting): add extra space before name

### DIFF
--- a/src/components/Greeting.tsx
+++ b/src/components/Greeting.tsx
@@ -10,7 +10,7 @@ const Greeting: React.FC = () => {
   else if (hour < 18) salutation = 'Buon pomeriggio';
   const namePart =
     user && user.nome ? (
-      <span className="greeting-name"> {user.nome}</span>
+      <span className="greeting-name">  {user.nome}</span>
     ) : null;
   return <div className="user-greeting">{salutation}{namePart}</div>;
 };

--- a/src/components/__tests__/Greeting.test.tsx
+++ b/src/components/__tests__/Greeting.test.tsx
@@ -17,20 +17,20 @@ describe('Greeting', () => {
     mockedUseAuthStore.mockImplementation((sel: any) => sel({ user }))
     jest.spyOn(Date.prototype, 'getHours').mockReturnValue(9)
     render(<Greeting />)
-    expect(screen.getByText(/Buongiorno Mario/i)).toBeInTheDocument()
+    expect(screen.getByText(/Buongiorno  Mario/i)).toBeInTheDocument()
   })
 
   it('shows afternoon greeting', () => {
     mockedUseAuthStore.mockImplementation((sel: any) => sel({ user }))
     jest.spyOn(Date.prototype, 'getHours').mockReturnValue(15)
     render(<Greeting />)
-    expect(screen.getByText(/Buon pomeriggio Mario/i)).toBeInTheDocument()
+    expect(screen.getByText(/Buon pomeriggio  Mario/i)).toBeInTheDocument()
   })
 
   it('shows evening greeting', () => {
     mockedUseAuthStore.mockImplementation((sel: any) => sel({ user }))
     jest.spyOn(Date.prototype, 'getHours').mockReturnValue(20)
     render(<Greeting />)
-    expect(screen.getByText(/Buonasera Mario/i)).toBeInTheDocument()
+    expect(screen.getByText(/Buonasera  Mario/i)).toBeInTheDocument()
   })
 })

--- a/src/components/__tests__/PageTemplate.test.tsx
+++ b/src/components/__tests__/PageTemplate.test.tsx
@@ -69,7 +69,7 @@ describe('PageTemplate', () => {
 
     const hour = new Date().getHours();
     const salutation = hour < 12 ? 'Buongiorno' : hour < 18 ? 'Buon pomeriggio' : 'Buonasera';
-    expect(await screen.findByText(new RegExp(`${salutation} test`, 'i'))).toBeInTheDocument();
+    expect(await screen.findByText(new RegExp(`${salutation}  test`, 'i'))).toBeInTheDocument();
   });
 
   it('shows placeholder greeting when fetching profile fails', async () => {


### PR DESCRIPTION
## Summary
- double the spacing before the user's name in `Greeting`
- adjust greeting tests for the extra space
- update page template test for new greeting format

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68678d14bba48323a854640f889448bd