### PR TITLE
Modifica intestazione tabella orari

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -179,9 +179,13 @@ label {
 /* Special font for numeric content */
 .digit-font,
 input[type="number"],
-input[type="date"],
 input[type="datetime-local"] {
   font-family: 'Roboto Mono', monospace;
+}
+
+/* Override font for date inputs */
+input[type="date"] {
+  font-family: 'Cormorant Garamond', serif;
 }
 
 .desc-cell {

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -248,8 +248,16 @@ export default function SchedulePage() {
         <summary>Turni salvati</summary>
         <table className="item-table">
           <thead>
-            <tr>
-              <th>Utente</th><th>Data</th><th>Slot 1</th><th>Slot 2</th><th>Slot 3</th><th>Tipo</th><th>Note</th><th></th>
+            <tr style={{ fontFamily: 'Cormorant Garamond, serif', color: '#000' }}>
+              <th>Utente</th>
+              <th>Data</th>
+              <th>Mattino (inizio)</th>
+              <th>Mattino (fine)</th>
+              <th>Pomeriggio/serale (inizio)</th>
+              <th>Pomeriggio/serale (fine)</th>
+              <th>Straordinario (inizio)</th>
+              <th>Straordinario (fine)</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -261,11 +269,12 @@ export default function SchedulePage() {
                 <tr key={t.id}>
                   <td>{nome}</td>
                   <td>{t.giorno}</td>
-                <td>{`${t.slot1.inizio}–${t.slot1.fine}`}</td>
-                <td>{t.slot2 ? `${t.slot2.inizio}–${t.slot2.fine}` : '—'}</td>
-                <td>{t.slot3 ? `${t.slot3.inizio}–${t.slot3.fine}` : '—'}</td>
-                <td>{t.tipo}</td>
-                <td>{t.note || '—'}</td>
+                  <td>{t.slot1.inizio}</td>
+                  <td>{t.slot1.fine}</td>
+                  <td>{t.slot2 ? t.slot2.inizio : '—'}</td>
+                  <td>{t.slot2 ? t.slot2.fine : '—'}</td>
+                  <td>{t.slot3 ? t.slot3.inizio : '—'}</td>
+                  <td>{t.slot3 ? t.slot3.fine : '—'}</td>
                   <td><button onClick={() => handleDelete(t.id)}>🗑️</button></td>
                 </tr>
               );

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -94,7 +94,9 @@ describe('SchedulePage', () => {
     await userEvent.type(inputs[2], '11:00')
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
-    expect(await screen.findByText('09:00–11:00')).toBeInTheDocument()
+    const row = await screen.findByRole('row', { name: /u\s+2023-05-02/i })
+    expect(within(row).getByText('09:00')).toBeInTheDocument()
+    expect(within(row).getByText('11:00')).toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-02',
@@ -135,7 +137,9 @@ describe('SchedulePage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
-    expect(await screen.findByText('RIPOSO')).toBeInTheDocument()
+    const row = await screen.findByRole('row', { name: /u\s+2023-05-03/i })
+    expect(within(row).getByText('10:00')).toBeInTheDocument()
+    expect(within(row).getByText('12:00')).toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-03',
@@ -171,7 +175,9 @@ describe('SchedulePage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
-    expect(await screen.findByText('FESTIVO')).toBeInTheDocument()
+    const row = await screen.findByRole('row', { name: /u\s+2023-05-04/i })
+    expect(within(row).getByText('11:00')).toBeInTheDocument()
+    expect(within(row).getByText('13:00')).toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-04',
@@ -188,10 +194,10 @@ describe('SchedulePage', () => {
 
     renderPage()
 
-    await screen.findByText('07:00–09:00')
+    await screen.findByText('07:00')
     await userEvent.click(screen.getByRole('button', { name: '🗑️' }))
 
-    expect(screen.queryByText('07:00–09:00')).not.toBeInTheDocument()
+    expect(screen.queryByText('07:00')).not.toBeInTheDocument()
     expect(mockedApi.delete).toHaveBeenCalledWith('/orari/1')
   })
 
@@ -208,7 +214,8 @@ describe('SchedulePage', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /importa/i }))
 
-    expect(await screen.findByText('08:00–10:00')).toBeInTheDocument()
+    expect(await screen.findByText('08:00')).toBeInTheDocument()
+    expect(screen.getByText('10:00')).toBeInTheDocument()
     expect(mockedGcApi.createShiftEvents).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ giorno: '2023-06-01' }))
   })
 


### PR DESCRIPTION
## Summary
- update schedule table header labels
- split slot time columns and remove `tipo` and `note`
- ensure date input uses Cormorant Garamond font
- adapt schedule page tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867b558887483239b67a75f1dc19df0