### PR TITLE
Use env vars for Utilità video links

### DIFF
--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -35,9 +35,23 @@ const ZoomIcon = () => (
 
 export default function UtilitaPage() {
   const links = [
-    { name: 'Google Meet', icon: <GoogleIcon />, url: 'https://meet.google.com/xyz-abcq-wvu' },
-    { name: 'Microsoft Teams', icon: <TeamsIcon />, url: 'https://teams.microsoft.com/l/meetup-join/…' },
-    { name: 'Zoom', icon: <ZoomIcon />, url: 'https://zoom.us/wc/join/123456789?pwd=abcdef' },
+    {
+      name: 'Google Meet',
+      icon: <GoogleIcon />,
+      url: import.meta.env.VITE_MEET_URL || 'https://meet.google.com/xyz-abcq-wvu',
+    },
+    {
+      name: 'Microsoft Teams',
+      icon: <TeamsIcon />,
+      url:
+        import.meta.env.VITE_TEAMS_URL ||
+        'https://teams.microsoft.com/l/meetup-join/…',
+    },
+    {
+      name: 'Zoom',
+      icon: <ZoomIcon />,
+      url: import.meta.env.VITE_ZOOM_URL || 'https://zoom.us/wc/join/123456789?pwd=abcdef',
+    },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- read video conferencing URLs from env vars on Utilità page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867d85d551c8323befa974e644134cd