### PR TITLE
Update Riunioni layout

### DIFF
--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './ListPages.css';
 
 const GoogleIcon = () => (
   <svg
@@ -35,10 +36,10 @@ const ZoomIcon = () => (
 
 export default function UtilitaPage() {
   return (
-    <div className="p-4 flex flex-row justify-around items-center space-x-4">
-      <img src="/teams.png" alt="Microsoft Teams" className="h-32" />
-      <img src="/zoom.png" alt="Zoom" className="h-32" />
-      <img src="/meet.png" alt="Google Meet" className="h-32" />
+    <div className="meeting-links">
+      <img src="/meet.png" alt="Google Teams" />
+      <img src="/zoom.png" alt="Zoom" />
+      <img src="/teams.png" alt="Microsoft Teams" />
     </div>
   );
 }

--- a/src/pages/__tests__/UtilitaPage.test.tsx
+++ b/src/pages/__tests__/UtilitaPage.test.tsx
@@ -15,8 +15,8 @@ describe('UtilitaPage', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByAltText(/microsoft teams/i)).toBeInTheDocument();
+    expect(screen.getByAltText(/google teams/i)).toBeInTheDocument();
     expect(screen.getByAltText(/zoom/i)).toBeInTheDocument();
-    expect(screen.getByAltText(/google meet/i)).toBeInTheDocument();
+    expect(screen.getByAltText(/microsoft teams/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- style the meetings page using `meeting-links` CSS
- show Google Teams, Zoom and Microsoft Teams logos
- update tests to match alt text

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f47082ac83238bf5376fc14054f3