### PR TITLE
Map new backend schedule fields

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -1,8 +1,42 @@
 import api from './axios'
-import { Turno } from 'src/types/turno'
+import { Turno, BackendTurno } from 'src/types/turno'
 
-export const fetchTurni = () => api.get<Turno[]>('/orari/')
-export const saveTurno = (t: Turno) => api.post<Turno>('/orari/', t)
+const fromBackend = (t: BackendTurno): Turno => ({
+  id: t.id,
+  user_id: t.user_id,
+  giorno: t.giorno,
+  slot1: { inizio: t.slot1_inizio, fine: t.slot1_fine },
+  slot2:
+    t.slot2_inizio && t.slot2_fine
+      ? { inizio: t.slot2_inizio, fine: t.slot2_fine }
+      : undefined,
+  slot3:
+    t.slot3_inizio && t.slot3_fine
+      ? { inizio: t.slot3_inizio, fine: t.slot3_fine }
+      : undefined,
+  tipo: t.tipo,
+  note: t.note ?? undefined,
+})
+
+const toBackend = (t: Turno): BackendTurno => ({
+  id: t.id,
+  user_id: t.user_id,
+  giorno: t.giorno,
+  slot1_inizio: t.slot1.inizio,
+  slot1_fine: t.slot1.fine,
+  slot2_inizio: t.slot2?.inizio ?? null,
+  slot2_fine: t.slot2?.fine ?? null,
+  slot3_inizio: t.slot3?.inizio ?? null,
+  slot3_fine: t.slot3?.fine ?? null,
+  tipo: t.tipo,
+  note: t.note ?? null,
+})
+
+export const fetchTurni = () =>
+  api.get<BackendTurno[]>('/orari/').then(r => r.data.map(fromBackend))
+
+export const saveTurno = (t: Turno) =>
+  api.post<BackendTurno>('/orari/', toBackend(t)).then(r => fromBackend(r.data))
 
 export const deleteTurno = (id: string): Promise<void> =>
   api.delete(`/orari/${id}`).then(() => undefined)

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -50,7 +50,7 @@ export default function SchedulePage() {
 
   const loadTurni = async () => {
     try {
-      const { data } = await fetchTurni();
+      const data = await fetchTurni();
       setTurni(data);
       setLoadError('');
       return data;
@@ -142,7 +142,7 @@ export default function SchedulePage() {
     if (s2Start && s2End) payload.slot2 = { inizio: s2Start, fine: s2End };
     if (s3Start && s3End) payload.slot3 = { inizio: s3Start, fine: s3End };
 
-    const { data } = await saveTurno(payload as Turno);
+    const data = await saveTurno(payload as Turno);
     setTurni(prev =>
       prev.some(t => t.id === data.id) ? prev.map(t => t.id === data.id ? data : t) : [...prev, data]
     );

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -59,7 +59,19 @@ describe('SchedulePage', () => {
   it('loads turni from API', async () => {
     mockedApi.get.mockImplementation(url => {
       if (url === '/users/') return Promise.resolve({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
-      if (url === '/orari/') return Promise.resolve({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '08:00', fine: '10:00' }, tipo: 'NORMALE', user_id: 'u' }] })
+      if (url === '/orari/')
+        return Promise.resolve({
+          data: [
+            {
+              id: '1',
+              giorno: '2023-01-01',
+              slot1_inizio: '08:00',
+              slot1_fine: '10:00',
+              tipo: 'NORMALE',
+              user_id: 'u',
+            },
+          ],
+        })
       return Promise.resolve({ data: [] })
     })
 
@@ -78,7 +90,8 @@ describe('SchedulePage', () => {
       data: {
         id: '2',
         giorno: '2023-05-02',
-        slot1: { inizio: '09:00', fine: '11:00' },
+        slot1_inizio: '09:00',
+        slot1_fine: '11:00',
         tipo: 'NORMALE',
         user_id: 'u',
       },
@@ -100,9 +113,14 @@ describe('SchedulePage', () => {
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-02',
-      slot1: { inizio: '09:00', fine: '11:00' },
+      slot1_inizio: '09:00',
+      slot1_fine: '11:00',
+      slot2_inizio: null,
+      slot2_fine: null,
+      slot3_inizio: null,
+      slot3_fine: null,
       tipo: 'NORMALE',
-      note: undefined,
+      note: null,
     })
     expect((inputs[0] as HTMLInputElement).value).toBe('')
     expect(mockedGcApi.createShiftEvents).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
@@ -118,7 +136,8 @@ describe('SchedulePage', () => {
       data: {
         id: '3',
         giorno: '2023-05-03',
-        slot1: { inizio: '10:00', fine: '12:00' },
+        slot1_inizio: '10:00',
+        slot1_fine: '12:00',
         tipo: 'RIPOSO',
         user_id: 'u',
       },
@@ -143,9 +162,14 @@ describe('SchedulePage', () => {
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-03',
-      slot1: { inizio: '10:00', fine: '12:00' },
+      slot1_inizio: '10:00',
+      slot1_fine: '12:00',
+      slot2_inizio: null,
+      slot2_fine: null,
+      slot3_inizio: null,
+      slot3_fine: null,
       tipo: 'RIPOSO',
-      note: undefined,
+      note: null,
     })
   })
 
@@ -156,7 +180,8 @@ describe('SchedulePage', () => {
       data: {
         id: '4',
         giorno: '2023-05-04',
-        slot1: { inizio: '11:00', fine: '13:00' },
+        slot1_inizio: '11:00',
+        slot1_fine: '13:00',
         tipo: 'FESTIVO',
         user_id: 'u',
       },
@@ -181,15 +206,31 @@ describe('SchedulePage', () => {
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-04',
-      slot1: { inizio: '11:00', fine: '13:00' },
+      slot1_inizio: '11:00',
+      slot1_fine: '13:00',
+      slot2_inizio: null,
+      slot2_fine: null,
+      slot3_inizio: null,
+      slot3_fine: null,
       tipo: 'FESTIVO',
-      note: undefined,
+      note: null,
     })
   })
 
   it('deletes a turno', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
-    mockedApi.get.mockResolvedValueOnce({ data: [{ id: '1', giorno: '2023-01-01', slot1: { inizio: '07:00', fine: '09:00' }, tipo: 'NORMALE', user_id: 'u' }] })
+    mockedApi.get.mockResolvedValueOnce({
+      data: [
+        {
+          id: '1',
+          giorno: '2023-01-01',
+          slot1_inizio: '07:00',
+          slot1_fine: '09:00',
+          tipo: 'NORMALE',
+          user_id: 'u',
+        },
+      ],
+    })
     mockedApi.delete.mockResolvedValueOnce({})
 
     renderPage()
@@ -206,7 +247,14 @@ describe('SchedulePage', () => {
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.get.mockResolvedValueOnce({
       data: [
-        { id: '1', giorno: '2023-06-01', slot1: { inizio: '08:00', fine: '10:00' }, tipo: 'NORMALE', user_id: 'u' },
+        {
+          id: '1',
+          giorno: '2023-06-01',
+          slot1_inizio: '08:00',
+          slot1_fine: '10:00',
+          tipo: 'NORMALE',
+          user_id: 'u',
+        },
       ],
     })
 
@@ -224,7 +272,14 @@ describe('SchedulePage', () => {
     mockedApi.get.mockResolvedValueOnce({ data: [] })
     mockedApi.get.mockResolvedValueOnce({
       data: [
-        { id: '1', giorno: '2023-06-02', slot1: { inizio: '09:00', fine: '11:00' }, tipo: 'NORMALE', user_id: 'u' },
+        {
+          id: '1',
+          giorno: '2023-06-02',
+          slot1_inizio: '09:00',
+          slot1_fine: '11:00',
+          tipo: 'NORMALE',
+          user_id: 'u',
+        },
       ],
     })
 

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -13,3 +13,17 @@ export interface Turno {
   tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'
   note?: string
 }
+
+export interface BackendTurno {
+  id: string
+  user_id: string
+  giorno: string
+  slot1_inizio: string
+  slot1_fine: string
+  slot2_inizio?: string | null
+  slot2_fine?: string | null
+  slot3_inizio?: string | null
+  slot3_fine?: string | null
+  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'
+  note?: string | null
+}


### PR DESCRIPTION
## Summary
- support backend schedule field names
- convert backend slot fields to frontend structure in schedule API
- adjust SchedulePage to use updated helper functions
- update SchedulePage tests for new mapping

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868315b3f988323970f1f825f7b827f