### PR TITLE
Fix gapi load promise and add signIn test

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -1,4 +1,4 @@
-import { createShiftEvents } from '../googleCalendar'
+import { createShiftEvents, signIn } from '../googleCalendar'
 
 describe('createShiftEvents', () => {
   const insert = jest.fn().mockResolvedValue({})
@@ -30,3 +30,26 @@ describe('createShiftEvents', () => {
     })
   })
 })
+
+describe('signIn', () => {
+  it('waits for gapi.load before initializing client', async () => {
+    const init = jest.fn().mockResolvedValue({})
+    const sign = jest.fn().mockResolvedValue({})
+    const load = jest.fn()
+    ;(window as any).gapi = {
+      load,
+      client: { init },
+      auth2: { getAuthInstance: () => ({ signIn: sign }) },
+    }
+
+    load.mockImplementation((_lib, opts) => {
+      setTimeout(opts.callback, 0)
+    })
+
+    const promise = signIn()
+    expect(init).not.toHaveBeenCalled()
+    await promise
+    expect(init).toHaveBeenCalled()
+  })
+})
+

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -5,7 +5,9 @@ const DEFAULT_CALENDAR_ID = 'primary'
 
 export const signIn = async (): Promise<void> => {
   const gapi = (window as any).gapi
-  await gapi.load('client:auth2')
+  await new Promise((resolve, reject) =>
+    gapi.load('client:auth2', { callback: resolve, onerror: reject })
+  )
   await gapi.client.init({
     apiKey: import.meta.env.VITE_GAPI_API_KEY,
     clientId: import.meta.env.VITE_GAPI_CLIENT_ID,


### PR DESCRIPTION
## Summary
- wait for `gapi.load` using a promise
- test that `signIn` waits for `gapi.load`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684922e2f08323a2af5daecf2dbd02