### PR TITLE
Refactor turno types

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -11,7 +11,7 @@ import { createShiftEvents, ShiftData, signIn } from '../api/googleCalendar';
 import './ListPages.css';
 
 /* ---------- TIPI ---------- */
-import { Turno, Slot } from '../types/turno';
+import { Turno, Slot, TipoTurno } from '../types/turno';
 
 type NewTurnoPayload = Omit<Turno, 'id'>;
 
@@ -34,7 +34,7 @@ export default function SchedulePage() {
   const [s2End,   setS2End]   = useState('');
   const [s3Start, setS3Start] = useState('');
   const [s3End,   setS3End]   = useState('');
-  const [tipo, setTipo] = useState<'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'>('NORMALE');
+  const [tipo, setTipo] = useState<TipoTurno>('NORMALE');
   const [note, setNote] = useState('');
 
   const calendarId = SCHEDULE_CALENDAR_IDS[0];

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -3,6 +3,13 @@ export interface Slot {
   fine: string
 }
 
+export type TipoTurno =
+  | 'NORMALE'
+  | 'STRAORD'
+  | 'FERIE'
+  | 'RIPOSO'
+  | 'FESTIVO';
+
 export interface Turno {
   id: string
   user_id: string
@@ -10,7 +17,7 @@ export interface Turno {
   slot1: Slot
   slot2?: Slot
   slot3?: Slot
-  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'
+  tipo: TipoTurno
   note?: string
 }
 
@@ -24,6 +31,6 @@ export interface BackendTurno {
   slot2_fine?: string | null
   slot3_inizio?: string | null
   slot3_fine?: string | null
-  tipo: 'NORMALE' | 'STRAORD' | 'FERIE' | 'RIPOSO' | 'FESTIVO'
+  tipo: TipoTurno
   note?: string | null
 }


### PR DESCRIPTION
## Summary
- introduce `TipoTurno` type
- use `TipoTurno` in `Turno` and `BackendTurno`
- update `SchedulePage` to use `TipoTurno`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868495aba488323b648161f13ec78e3