### PR TITLE
Fix turno id handling

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -2,7 +2,7 @@ import api from './axios'
 import { Turno, BackendTurno } from 'src/types/turno'
 
 const fromBackend = (t: BackendTurno): Turno => ({
-  id: t.id,
+  id: t.id!,
   user_id: t.user_id,
   giorno: t.giorno,
   slot1: { inizio: t.slot1_inizio, fine: t.slot1_fine },
@@ -19,7 +19,7 @@ const fromBackend = (t: BackendTurno): Turno => ({
 })
 
 const toBackend = (t: Turno): BackendTurno => ({
-  id: t.id,
+  ...(t.id ? { id: t.id } : {}),
   user_id: t.user_id,
   giorno: t.giorno,
   slot1_inizio: t.slot1.inizio,

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -15,7 +15,7 @@ export interface Turno {
 }
 
 export interface BackendTurno {
-  id: string
+  id?: string
   user_id: string
   giorno: string
   slot1_inizio: string


### PR DESCRIPTION
## Summary
- allow BackendTurno `id` to be optional
- add conditional `id` spread in `toBackend`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file for 'jest')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684961d2a48323b506f549c0bf7517