### PR TITLE
Fix gapi load promise

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -47,6 +47,10 @@ describe('signIn', () => {
     })
 
     const promise = signIn()
+    expect(load).toHaveBeenCalledWith(
+      'client:auth2',
+      expect.objectContaining({ callback: expect.any(Function), onerror: expect.any(Function) })
+    )
     expect(init).not.toHaveBeenCalled()
     await promise
     expect(init).toHaveBeenCalled()

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -5,7 +5,7 @@ const DEFAULT_CALENDAR_ID = 'primary'
 
 export const signIn = async (): Promise<void> => {
   const gapi = (window as any).gapi
-  await new Promise((resolve, reject) =>
+  await new Promise<void>((resolve, reject) =>
     gapi.load('client:auth2', { callback: resolve, onerror: reject })
   )
   await gapi.client.init({


### PR DESCRIPTION
## Summary
- ensure `signIn` waits for `gapi.load` with a Promise
- verify `signIn` waits for `gapi.load` before initializing the client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e79aabe08323b1bdf6749a50549d