### PR TITLE
Fix SchedulePage delete function

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import api from '../api/axios';
-import { fetchTurni, saveTurno } from '../api/schedule';
+import { fetchTurni, saveTurno, deleteTurno } from '../api/schedule';
 import { listUsers } from '../api/users';
 import { User } from '../types/user';
 import { getSchedulePdf } from '../api/pdfs';
@@ -166,7 +165,7 @@ export default function SchedulePage() {
 
   /* --- delete --- */
   const handleDelete = async (id: string) => {
-    await api.delete(`/orari/${id}`);
+    await deleteTurno(id);
     setTurni(prev => prev.filter(t => t.id !== id));
   };
 

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import api from '../../api/axios'
 import * as pdfApi from '../../api/pdfs'
 import * as gcApi from '../../api/googleCalendar'
+import * as scheduleApi from '../../api/schedule'
 
 jest.mock('../../components/ImportExcel', () => ({
   __esModule: true,
@@ -33,15 +34,26 @@ jest.mock('../../api/googleCalendar', () => ({
   createShiftEvents: jest.fn(),
 }))
 
+jest.mock('../../api/schedule', () => {
+  const actual = jest.requireActual('../../api/schedule')
+  return {
+    __esModule: true,
+    ...actual,
+    deleteTurno: jest.fn(),
+  }
+})
+
 const mockedApi = api as jest.Mocked<typeof api>
 const mockedPdfApi = pdfApi as jest.Mocked<typeof pdfApi>
 const mockedGcApi = gcApi as jest.Mocked<typeof gcApi>
+const mockedScheduleApi = scheduleApi as jest.Mocked<typeof scheduleApi>
 
 beforeEach(() => {
   jest.resetAllMocks()
   mockedApi.get.mockResolvedValue({ data: [] })
   mockedPdfApi.getSchedulePdf.mockResolvedValue(new Blob())
   mockedGcApi.createShiftEvents.mockResolvedValue()
+  mockedScheduleApi.deleteTurno.mockResolvedValue()
 })
 
 const renderPage = () =>
@@ -231,7 +243,7 @@ describe('SchedulePage', () => {
         },
       ],
     })
-    mockedApi.delete.mockResolvedValueOnce({})
+    mockedScheduleApi.deleteTurno.mockResolvedValueOnce()
 
     renderPage()
 
@@ -239,7 +251,7 @@ describe('SchedulePage', () => {
     await userEvent.click(screen.getByRole('button', { name: '🗑️' }))
 
     expect(screen.queryByText('07:00')).not.toBeInTheDocument()
-    expect(mockedApi.delete).toHaveBeenCalledWith('/orari/1')
+    expect(mockedScheduleApi.deleteTurno).toHaveBeenCalledWith('1')
   })
 
   it('creates events after import', async () => {


### PR DESCRIPTION
## Summary
- replace direct `api.delete` usage with `deleteTurno`
- update SchedulePage tests to mock `deleteTurno`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868e8984eb483238fbec6369739c9ce