### PR TITLE
Prune react-big-calendar from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,33 +1126,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-big-calendar": {
-      "version": "1.19.4",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "clsx": "^1.2.1",
-        "date-arithmetic": "^4.1.0",
-        "dayjs": "^1.11.7",
-        "dom-helpers": "^5.2.1",
-        "globalize": "^0.1.1",
-        "invariant": "^2.2.4",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "luxon": "^3.2.1",
-        "memoize-one": "^6.0.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40",
-        "prop-types": "^15.8.1",
-        "react-overlays": "^5.2.1",
-        "uncontrollable": "^7.2.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17 || ^18 || ^19",
-        "react-dom": "^16.14.0 || ^17 || ^18 || ^19"
-      }
-    },
     "node_modules/react-calendar": {
       "version": "6.0.0",
       "license": "MIT",


### PR DESCRIPTION
## Summary
- remove `react-big-calendar` entry from `package-lock.json`

## Testing
- `npm test` *(fails: jest not found)*
- `npm prune` *(fails due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6868e89b31d88323ac3a13716af594ba