### PR TITLE
Add typed JWT helpers

### DIFF
--- a/src/utils/__tests__/auth.test.ts
+++ b/src/utils/__tests__/auth.test.ts
@@ -1,4 +1,18 @@
-import { getUserStorageKey } from '../auth';
+import { decodeToken, getUserId, getUserStorageKey } from '../auth';
+
+describe('decodeToken', () => {
+  it('parses a jwt payload', () => {
+    const header = Buffer.from('{}').toString('base64');
+    const payload = Buffer.from(JSON.stringify({ sub: 'abc' })).toString('base64');
+    const token = `${header}.${payload}.sig`;
+    const decoded = decodeToken(token);
+    expect(decoded).toEqual({ sub: 'abc' });
+  });
+
+  it('returns null for malformed token', () => {
+    expect(decodeToken('bad')).toBeNull();
+  });
+});
 
 describe('getUserStorageKey', () => {
   it('returns prefix when token missing', () => {
@@ -23,5 +37,18 @@ describe('getUserStorageKey', () => {
     const payload = base64Url(Buffer.from(JSON.stringify({ sub: 'xyz' })));
     const token = `${header}.${payload}.sig`;
     expect(getUserStorageKey('todos', token)).toBe('todos_xyz');
+  });
+});
+
+describe('getUserId', () => {
+  it('returns null when token missing', () => {
+    expect(getUserId(null)).toBeNull();
+  });
+
+  it('extracts id from token', () => {
+    const header = Buffer.from('{}').toString('base64');
+    const payload = Buffer.from(JSON.stringify({ email: 'me@example.com' })).toString('base64');
+    const token = `${header}.${payload}.sig`;
+    expect(getUserId(token)).toBe('me@example.com');
   });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,10 +1,18 @@
-export function decodeToken(token: string): any | null {
+export interface JwtPayload {
+  sub?: string;
+  user_id?: string;
+  id?: string;
+  email?: string;
+  [key: string]: unknown;
+}
+
+export function decodeToken(token: string): JwtPayload | null {
   try {
     let payload = token.split('.')[1];
     payload = payload.replace(/-/g, '+').replace(/_/g, '/');
     while (payload.length % 4) payload += '=';
     const json = atob(payload);
-    return JSON.parse(json);
+    return JSON.parse(json) as JwtPayload;
   } catch {
     return null;
   }
@@ -13,13 +21,13 @@ export function decodeToken(token: string): any | null {
 export function getUserId(token: string | null): string | null {
   if (!token) return null;
   const decoded = decodeToken(token);
-  const id = decoded?.sub || decoded?.user_id || decoded?.id || decoded?.email;
-  return id || null;
+  const id = decoded?.sub ?? decoded?.user_id ?? decoded?.id ?? decoded?.email;
+  return id ?? null;
 }
 
 export function getUserStorageKey(prefix: string, token: string | null): string {
   if (!token) return prefix;
   const decoded = decodeToken(token);
-  const id = decoded?.sub || decoded?.user_id || decoded?.id || decoded?.email;
+  const id = decoded?.sub ?? decoded?.user_id ?? decoded?.id ?? decoded?.email;
   return id ? `${prefix}_${id}` : prefix;
 }


### PR DESCRIPTION
## Summary
- define `JwtPayload` interface
- type-check token decoding results
- update `getUserId` and `getUserStorageKey` to use typed fields
- expand auth utility tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f4003c548323bed47714a7024080