### PR TITLE
Add ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint", "react"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended"
+  ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Install dependencies
       run: npm install
 
+    - name: Run ESLint
+      run: npm run lint
+
     - name: Run tests
       run: npm test
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ npm run serve
 
 This serves the `dist` directory using Vite's preview mode.
 
+## Linting
+
+Run ESLint to check for style issues:
+
+```bash
+npm run lint
+```
+
+Execute this command locally before committing or in your CI pipeline to keep the codebase consistent.
+
 ## Utilità page
 
 When the development server is running you can visit `/utilita` for assorted

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "vite --host --port 3000",
     "build": "vite build",
     "serve": "vite preview",
-    "test": "jest"
+    "test": "jest",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint --config .eslintrc.json . --ext .ts,.tsx"
   },
   "dependencies": {
     "axios": "^1.3.4",
@@ -30,6 +31,10 @@
     "@types/react-dom": "^18.2.7",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.0.1",
-    "@testing-library/user-event": "^14.4.3"
+    "@testing-library/user-event": "^14.4.3",
+    "eslint": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint-plugin-react": "^7.33.2"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint config with React and TypeScript rules
- install eslint and plugins
- add `lint` script to npm scripts
- run lint in the deploy workflow
- document lint script in README

## Testing
- `npm run lint` *(fails: plugin not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f3ff3284832380e47544c26b9b73