### PR TITLE
Add getErrorDetail helper

### DIFF
--- a/src/components/ImportExcel.tsx
+++ b/src/components/ImportExcel.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState, ChangeEvent } from 'react';
-import axios from 'axios';
 import { importTurniExcel } from '../api/schedule';
+import { getErrorDetail } from '../utils/errors';
 
 interface ImportExcelProps {
   onComplete?: (success: boolean) => void;
@@ -35,15 +35,10 @@ export default function ImportExcel({ onComplete }: ImportExcelProps) {
       setMessage('File importato correttamente.');
       onComplete?.(true);
     } catch (error) {
-      console.error('ImportExcel error:', error);
-      let errMessage = "Errore durante l'importazione del file";
-      if (axios.isAxiosError(error)) {
-        const detail = (error.response?.data as any)?.message || (error.response?.data as any)?.detail;
-        if (detail) {
-          errMessage += `: ${detail}`;
-        }
-      }
-      setMessage(errMessage);
+      const detail = await getErrorDetail(error);
+      console.error('ImportExcel error →', detail);
+      const msg = detail ? `Errore durante l'importazione del file: ${detail}` : "Errore durante l'importazione del file";
+      setMessage(msg);
       onComplete?.(false);
     } finally {
       setBusy(false);

--- a/src/utils/__tests__/errors.test.ts
+++ b/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,25 @@
+import { getErrorDetail } from '../errors';
+
+describe('getErrorDetail', () => {
+  it('returns detail from JSON blob', async () => {
+    const blob = new Blob([JSON.stringify({ detail: 'fail' })], { type: 'application/json' });
+    const err: any = { response: { data: blob } };
+    await expect(getErrorDetail(err)).resolves.toBe('fail');
+  });
+
+  it('falls back to blob text', async () => {
+    const blob = new Blob(['plain error'], { type: 'text/plain' });
+    const err: any = { response: { data: blob } };
+    await expect(getErrorDetail(err)).resolves.toBe('plain error');
+  });
+
+  it('returns detail field when present', async () => {
+    const err: any = { response: { data: { detail: 'bad' } } };
+    await expect(getErrorDetail(err)).resolves.toBe('bad');
+  });
+
+  it('falls back to message', async () => {
+    const err: any = { message: 'oops' };
+    await expect(getErrorDetail(err)).resolves.toBe('oops');
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,12 @@
+export async function getErrorDetail(err: any): Promise<string> {
+  if (err.response?.data instanceof Blob) {
+    const text = await err.response.data.text();
+    try {
+      const json = JSON.parse(text);
+      return json.detail ?? text;
+    } catch {
+      return text;
+    }
+  }
+  return err.response?.data?.detail ?? err.message;
+}


### PR DESCRIPTION
## Summary
- provide `getErrorDetail` utility for parsing backend errors
- use `getErrorDetail` in `ImportExcel` component
- test `getErrorDetail`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f42e528483239ceeb76e88ef4534