### PR TITLE
Handle calendar sync warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ The frontend expects a REST backend exposing at least the following endpoints:
 - `GET /pdfs` – list uploaded PDF files.
 - `POST /pdfs` – upload a new PDF file.
 
+When Google Calendar synchronization fails the backend should include a warning
+message. Endpoints that normally return a PDF can send the message using an
+`X-Warning` response header (or include a `warning` field in a JSON payload).
+The frontend reads this value and shows it to the user.
+
+Example JSON response:
+
+```json
+{
+  "url": "/orari/pdf/2023-W18",
+  "warning": "Unable to sync with Google Calendar"
+}
+```
+
 
 ## Backend Setup
 

--- a/src/api/pdfs.ts
+++ b/src/api/pdfs.ts
@@ -13,8 +13,19 @@ export const downloadPdf = (id: string): void => {
   window.open(url, '_blank')
 }
 
-export const getSchedulePdf = (week: string): Promise<Blob> =>
-  api
-    .get('/orari/pdf', { params: { week }, responseType: 'blob' })
-    .then(r => r.data)
+export interface SchedulePdfResult {
+  blob: Blob
+  warning?: string
+}
+
+export const getSchedulePdf = async (
+  week: string,
+): Promise<SchedulePdfResult> => {
+  const res = await api.get('/orari/pdf', {
+    params: { week },
+    responseType: 'blob',
+  })
+  const warning = res.headers['x-warning'] as string | undefined
+  return { blob: res.data, warning }
+}
 

--- a/src/index.css
+++ b/src/index.css
@@ -202,6 +202,11 @@ input[type="date"] {
   margin-bottom: 1rem;
 }
 
+.warning {
+  color: #b36b00;
+  margin-bottom: 1rem;
+}
+
 /* Imported shifts section */
 .imported-turni-section h3 {
   color: #A52019;

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -50,6 +50,7 @@ export default function SchedulePage() {
   const [loadError, setLoadError] = useState('');
   const [signedIn, setSignedIn] = useState(false);
   const [signInError, setSignInError] = useState('');
+  const [pdfWarning, setPdfWarning] = useState('');
   const token = useAuthStore(s => s.token);
   const storageKey = useMemo(
     () =>
@@ -283,9 +284,10 @@ export default function SchedulePage() {
   const handleDownloadPdf = async () => {
     const week = format(new Date(), "RRRR-'W'II");
     try {
-      const blob = await getSchedulePdf(week);
+      const { blob, warning } = await getSchedulePdf(week);
       const url = URL.createObjectURL(blob);
       window.open(url, '_blank');
+      if (warning) setPdfWarning(warning);
     } catch {
       // ignore download errors
     }
@@ -297,6 +299,7 @@ export default function SchedulePage() {
       <h2>Turni di servizio</h2>
       {loadError && <p className="error">{loadError}</p>}
       {signInError && <p className="error">{signInError}</p>}
+      {pdfWarning && <p className="warning">{pdfWarning}</p>}
 
       <ImportExcel onComplete={handleImportComplete} />
 

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -310,6 +310,8 @@ describe('SchedulePage', () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })
 
+    mockedPdfApi.getSchedulePdf.mockResolvedValueOnce({ blob: new Blob(), warning: undefined })
+
     renderPage()
     await screen.findByRole('button', { name: /pdf settimana/i })
 
@@ -323,6 +325,19 @@ describe('SchedulePage', () => {
 
     openSpy.mockRestore()
     urlSpy.mockRestore()
+  })
+
+  it('shows warning when PDF API returns it', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-01T00:00:00Z'))
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [] })
+    mockedPdfApi.getSchedulePdf.mockResolvedValueOnce({ blob: new Blob(), warning: 'GC failed' })
+
+    renderPage()
+    await screen.findByRole('button', { name: /pdf settimana/i })
+    await userEvent.click(screen.getByRole('button', { name: /pdf settimana/i }))
+
+    expect(await screen.findByText('GC failed')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary
- support `X-Warning` header for schedule PDFs
- surface warning banner on schedule page
- add warning styles
- document the new field in README
- update tests for new API return shape

## Testing
- `npm run lint` *(fails: ESLint plugin missing)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbf8ebeb48323b041d5a38caf8c92