### PR TITLE
Add preconnect links for fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Segretaria Digitale</title>
 
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
     <!-- Almendra SC font -->
     <link
       href="https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap"


### PR DESCRIPTION
## Summary
- insert Google Fonts preconnect hints in `index.html`

## Testing
- `npm run build` *(fails: cannot find module '@rollup/rollup-linux-x64-gnu')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1dd13588323a4468964f7a93456