### PR TITLE
Add lazy loading to login page logo

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -46,7 +46,7 @@ const LoginPage: React.FC = () => {
     <>
       <div className="login-page">
       <div className="login-card">
-          <img src="/logo.png" alt="Logo" className="login-logo" />
+          <img src="/logo.png" alt="Logo" className="login-logo" loading="lazy" />
           {loading ? (
             <Loader />
           ) : (


### PR DESCRIPTION
## Summary
- improve performance by lazy-loading the logo on the Login page

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1e1388c8323b72fb43ed7ffee2d