### PR TITLE
Add dashboard calendar env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ VITE_GAPI_CLIENT_ID="your-google-client-id"
 VITE_GAPI_API_KEY="your-google-api-key"
 
 # Schedule page configuration
+# Dashboard and Events page calendar ID
+VITE_DASHBOARD_CALENDAR_ID="your-dashboard-calendar-id"
 # Comma-separated IDs of the Google Calendars displayed on the schedule page
 # The first ID is selected by default (defaults to
 # 9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The variables are:
   by the schedule page. The first ID is selected by default and it falls back to
   `9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com`
   when unset.
+- `VITE_DASHBOARD_CALENDAR_ID` – calendar ID used by the Dashboard and Events
+  pages. If unset, the first ID from `VITE_SCHEDULE_CALENDAR_IDS` is used,
+  falling back to the default calendar.
 - `VITE_MEET_URL` – Google Meet room URL shown on the Utilità page.
 - `VITE_TEAMS_URL` – Microsoft Teams meeting link used by the Utilità page.
 - `VITE_ZOOM_URL` – Zoom meeting link used by the Utilità page.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ export default function Dashboard() {
   const [events] = useLocalStorage<EventItem[]>('events', []);
   const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
   const CALENDAR_ID =
+    import.meta.env.VITE_DASHBOARD_CALENDAR_ID ||
     import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
     DEFAULT_CALENDAR_ID;
 

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -52,6 +52,7 @@ export default function EventsPage() {
   const isMobile = useIsMobile();
   const token = useAuthStore(s => s.token);
   const CALENDAR_ID =
+    import.meta.env.VITE_DASHBOARD_CALENDAR_ID ||
     import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
     DEFAULT_CALENDAR_ID;
   const storageKey = useMemo(


### PR DESCRIPTION
## Summary
- add `VITE_DASHBOARD_CALENDAR_ID` variable
- document dashboard calendar ID in README
- allow Dashboard and Events pages to read the new variable

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686bc6dba7c48323ad58611ea29fdd4e