### PR TITLE
Document setup for ESLint dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Run ESLint to check for style issues:
 npm run lint
 ```
 
+Ensure you have installed project dependencies first using `npm install` or
+`./scripts/setup.sh`; this installs the TypeScript ESLint plugins required by
+the lint step.
+
 Execute this command locally before committing or in your CI pipeline to keep the codebase consistent.
 
 ## Utilità page

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-# Install project dependencies
+# Install project dependencies (required for linting)
 npm install


### PR DESCRIPTION
## Summary
- clarify dependency install requirement in Linting section of README
- note that setup script installs deps needed for linting

## Testing
- `npm run lint` *(fails: plugin not installed)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc7ccd85083238769ce382640ff43