### PR TITLE
Add login redirect if token exists

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -11,6 +11,7 @@ const LoginPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
+  const token = useAuthStore(s => s.token);
   const setToken = useAuthStore(s => s.setToken);
   const setUser = useAuthStore(s => s.setUser);
 
@@ -20,6 +21,10 @@ const LoginPage: React.FC = () => {
       document.body.classList.remove("login-bg");
     };
   }, []);
+
+  useEffect(() => {
+    if (token) navigate("/");
+  }, [token, navigate]);
 
 
   const onSubmit = async (e: React.FormEvent) => {

--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -58,4 +58,19 @@ describe('LoginPage', () => {
 
     expect(await screen.findByText('Credenziali errate')).toBeInTheDocument();
   });
+
+  it('redirects to home when token exists', async () => {
+    localStorage.setItem('token', 'tok');
+
+    render(
+      <MemoryRouter initialEntries={["/login"]}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/" element={<div>Home</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Home')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- read `token` from the auth store in `LoginPage`
- automatically redirect to the homepage when a token is present
- test redirect behaviour

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: missing `@typescript-eslint/eslint-plugin`)*

------
https://chatgpt.com/codex/tasks/task_e_686bdb86fdc48323940e2d19e8f1cfa3