### PR TITLE
Fix login navigation

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -12,7 +12,6 @@ const LoginPage: React.FC = () => {
   const [error, setError] = useState("");
   const navigate = useNavigate();
   const setToken = useAuthStore(s => s.setToken);
-  const setUser = useAuthStore(s => s.setUser);
 
   useEffect(() => {
     document.body.classList.add("login-bg");
@@ -29,12 +28,6 @@ const LoginPage: React.FC = () => {
     try {
       const res = await api.post("/login", { email, password });
       setToken(res.data.access_token);
-      try {
-        const me = await api.get("/users/me");
-        setUser(me.data);
-      } catch {
-        // ignore failure
-      }
       navigate("/");
     } catch {
       setError("Credenziali errate");

--- a/src/pages/__tests__/LoginPage.test.tsx
+++ b/src/pages/__tests__/LoginPage.test.tsx
@@ -8,7 +8,6 @@ jest.mock('../../api/axios', () => ({
   __esModule: true,
   default: {
     post: jest.fn(),
-    get: jest.fn(),
   },
 }));
 
@@ -22,7 +21,6 @@ beforeEach(() => {
 describe('LoginPage', () => {
   it('navigates to dashboard on valid credentials', async () => {
     mockedApi.post.mockResolvedValue({ data: { access_token: 'tok' } });
-    mockedApi.get.mockResolvedValue({ data: { id: '1', nome: 'test', email: 'e' } });
 
     render(
       <MemoryRouter initialEntries={["/login"]}>


### PR DESCRIPTION
## Summary
- store login token and navigate without fetching the profile
- update LoginPage test to only mock the login request

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bdb82ea64832395d271f4434471f5