### PR TITLE
Fix GitHub Actions token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '45 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- restrict default `GITHUB_TOKEN` permissions for the Vercel deploy workflow
- restrict default `GITHUB_TOKEN` permissions for the CodeQL workflow

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: missing @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686bde2a928c8323928be76c81225e28