### PR TITLE
Improve login loading time

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 
 import Loader from "./components/Loader";
 
-const LoginPage = React.lazy(() => import("./pages/LoginPage"));
+import LoginPage from "./pages/LoginPage";
 const Dashboard = React.lazy(() => import("./pages/Dashboard"));
 const EventsPage = React.lazy(() => import("./pages/EventsPage"));
 const TodoPage = React.lazy(() => import("./pages/TodoPage"));


### PR DESCRIPTION
## Summary
- inline `LoginPage` import so it loads with the initial bundle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686be18eef4c83239b20e8ae15948742