### PR TITLE
Update Google calendar sign-in test

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -33,28 +33,20 @@ describe('createShiftEvents', () => {
 })
 
 describe('signIn', () => {
-  it('waits for gapi.load before initializing client', async () => {
-    const init = jest.fn().mockResolvedValue({})
-    const sign = jest.fn().mockResolvedValue({})
-    const load = jest.fn()
-    ;(window as any).gapi = {
-      load,
-      client: { init },
-      auth2: { getAuthInstance: () => ({ signIn: sign }) },
+  it('initializes google identity clients', async () => {
+    const initialize = jest.fn()
+    const initTokenClient = jest.fn().mockReturnValue({ requestAccessToken: jest.fn() })
+    ;(window as any).google = {
+      accounts: {
+        id: { initialize },
+        oauth2: { initTokenClient },
+      },
     }
 
-    load.mockImplementation((_lib, opts) => {
-      setTimeout(opts.callback, 0)
-    })
+    await signIn()
 
-    const promise = signIn()
-    expect(load).toHaveBeenCalledWith(
-      'client:auth2',
-      expect.objectContaining({ callback: expect.any(Function), onerror: expect.any(Function) })
-    )
-    expect(init).not.toHaveBeenCalled()
-    await promise
-    expect(init).toHaveBeenCalled()
+    expect(initialize).toHaveBeenCalled()
+    expect(initTokenClient).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Summary
- update signIn unit test to mock new Google Identity Services API

## Testing
- `npm test -- -t googleCalendar.test.ts` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bedb079188323bc341784511a2610