### PR TITLE
Handle ferie-like shifts

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -6,7 +6,10 @@ const fromBackend = (t: BackendTurno): Turno => ({
   id: t.id!,
   user_id: t.user_id,
   giorno: dayjs(t.giorno),
-  slot1: { inizio: dayjs(`${t.giorno}T${t.inizio_1}`), fine: dayjs(`${t.giorno}T${t.fine_1}`) },
+  slot1:
+    t.inizio_1 && t.fine_1
+      ? { inizio: dayjs(`${t.giorno}T${t.inizio_1}`), fine: dayjs(`${t.giorno}T${t.fine_1}`) }
+      : null,
   slot2:
     t.inizio_2 && t.fine_2
       ? { inizio: dayjs(`${t.giorno}T${t.inizio_2}`), fine: dayjs(`${t.giorno}T${t.fine_2}`) }
@@ -19,19 +22,22 @@ const fromBackend = (t: BackendTurno): Turno => ({
   note: t.note ?? undefined,
 })
 
-const toBackend = (t: Turno): BackendTurno => ({
-  ...(t.id ? { id: t.id } : {}),
-  user_id: t.user_id,
-  giorno: t.giorno.format('YYYY-MM-DD'),
-  inizio_1: t.slot1.inizio.format('HH:mm'),
-  fine_1: t.slot1.fine.format('HH:mm'),
-  inizio_2: t.slot2 ? t.slot2.inizio.format('HH:mm') : null,
-  fine_2: t.slot2 ? t.slot2.fine.format('HH:mm') : null,
-  inizio_3: t.slot3 ? t.slot3.inizio.format('HH:mm') : null,
-  fine_3: t.slot3 ? t.slot3.fine.format('HH:mm') : null,
-  tipo: t.tipo,
-  note: t.note ?? null,
-})
+const toBackend = (t: Turno): BackendTurno => {
+  const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo)
+  return {
+    ...(t.id ? { id: t.id } : {}),
+    user_id: t.user_id,
+    giorno: t.giorno.format('YYYY-MM-DD'),
+    inizio_1: ferieLike || !t.slot1 ? null : t.slot1.inizio.format('HH:mm'),
+    fine_1: ferieLike || !t.slot1 ? null : t.slot1.fine.format('HH:mm'),
+    inizio_2: ferieLike ? null : t.slot2 ? t.slot2.inizio.format('HH:mm') : null,
+    fine_2: ferieLike ? null : t.slot2 ? t.slot2.fine.format('HH:mm') : null,
+    inizio_3: ferieLike ? null : t.slot3 ? t.slot3.inizio.format('HH:mm') : null,
+    fine_3: ferieLike ? null : t.slot3 ? t.slot3.fine.format('HH:mm') : null,
+    tipo: t.tipo,
+    note: t.note ?? null,
+  }
+}
 
 export const fetchTurni = () =>
   api.get<BackendTurno[]>('/orari/').then(r => r.data.map(fromBackend))

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -16,7 +16,7 @@ export interface Turno {
   id: string
   user_id: string
   giorno: Dayjs
-  slot1: Slot
+  slot1: Slot | null
   slot2?: Slot
   slot3?: Slot
   tipo: TipoTurno
@@ -29,8 +29,8 @@ export interface BackendTurno {
   id?: string
   user_id: string
   giorno: string
-  inizio_1: string
-  fine_1: string
+  inizio_1: string | null
+  fine_1: string | null
   inizio_2?: string | null
   fine_2?: string | null
   inizio_3?: string | null


### PR DESCRIPTION
## Summary
- allow `slot1` field and backend first-slot times to be null
- skip creating shift objects when shift type is FERIE/RIPOSO/FESTIVO
- send null slot times to the backend for those types
- relax UI requirements when selecting these types and skip calendar events

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf177f70883239e1669b358dd4b14