### PR TITLE
Update rest shift tests

### DIFF
--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -6,7 +6,10 @@ const fromBackend = (t: BackendTurno): Turno => ({
   id: t.id!,
   user_id: t.user_id,
   giorno: dayjs(t.giorno),
-  slot1: { inizio: dayjs(`${t.giorno}T${t.inizio_1}`), fine: dayjs(`${t.giorno}T${t.fine_1}`) },
+  slot1:
+    t.inizio_1 && t.fine_1
+      ? { inizio: dayjs(`${t.giorno}T${t.inizio_1}`), fine: dayjs(`${t.giorno}T${t.fine_1}`) }
+      : { inizio: dayjs(`${t.giorno}T00:00`), fine: dayjs(`${t.giorno}T00:00`) },
   slot2:
     t.inizio_2 && t.fine_2
       ? { inizio: dayjs(`${t.giorno}T${t.inizio_2}`), fine: dayjs(`${t.giorno}T${t.fine_2}`) }
@@ -19,19 +22,22 @@ const fromBackend = (t: BackendTurno): Turno => ({
   note: t.note ?? undefined,
 })
 
-const toBackend = (t: Turno): BackendTurno => ({
-  ...(t.id ? { id: t.id } : {}),
-  user_id: t.user_id,
-  giorno: t.giorno.format('YYYY-MM-DD'),
-  inizio_1: t.slot1.inizio.format('HH:mm'),
-  fine_1: t.slot1.fine.format('HH:mm'),
-  inizio_2: t.slot2 ? t.slot2.inizio.format('HH:mm') : null,
-  fine_2: t.slot2 ? t.slot2.fine.format('HH:mm') : null,
-  inizio_3: t.slot3 ? t.slot3.inizio.format('HH:mm') : null,
-  fine_3: t.slot3 ? t.slot3.fine.format('HH:mm') : null,
-  tipo: t.tipo,
-  note: t.note ?? null,
-})
+const toBackend = (t: Turno): BackendTurno => {
+  const ferieLike = ['RIPOSO', 'FESTIVO'].includes(t.tipo)
+  return {
+    ...(t.id ? { id: t.id } : {}),
+    user_id: t.user_id,
+    giorno: t.giorno.format('YYYY-MM-DD'),
+    inizio_1: ferieLike ? null : t.slot1.inizio.format('HH:mm'),
+    fine_1: ferieLike ? null : t.slot1.fine.format('HH:mm'),
+    inizio_2: t.slot2 ? t.slot2.inizio.format('HH:mm') : null,
+    fine_2: t.slot2 ? t.slot2.fine.format('HH:mm') : null,
+    inizio_3: t.slot3 ? t.slot3.inizio.format('HH:mm') : null,
+    fine_3: t.slot3 ? t.slot3.fine.format('HH:mm') : null,
+    tipo: t.tipo,
+    note: t.note ?? null,
+  }
+}
 
 export const fetchTurni = () =>
   api.get<BackendTurno[]>('/orari/').then(r => r.data.map(fromBackend))

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -154,8 +154,8 @@ describe('SchedulePage', () => {
       data: {
         id: '3',
         giorno: '2023-05-03',
-        inizio_1: '10:00',
-        fine_1: '12:00',
+        inizio_1: null,
+        fine_1: null,
         tipo: 'RIPOSO',
         user_id: 'u',
       },
@@ -166,8 +166,6 @@ describe('SchedulePage', () => {
 
     const inputs = screen.getAllByRole('textbox')
     await userEvent.type(inputs[0], '2023-05-03')
-    await userEvent.type(inputs[1], '10:00')
-    await userEvent.type(inputs[2], '12:00')
 
     const selects = screen.getAllByRole('combobox')
     await userEvent.selectOptions(selects[1], 'RIPOSO')
@@ -175,13 +173,12 @@ describe('SchedulePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
     const row = await screen.findByRole('row', { name: /u\s+2023-05-03/i })
-    expect(within(row).getByText('10:00')).toBeInTheDocument()
-    expect(within(row).getByText('12:00')).toBeInTheDocument()
+    expect(within(row).getByText('RIPOSO')).toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-03',
-      inizio_1: '10:00',
-      fine_1: '12:00',
+      inizio_1: null,
+      fine_1: null,
       inizio_2: null,
       fine_2: null,
       inizio_3: null,
@@ -198,8 +195,8 @@ describe('SchedulePage', () => {
       data: {
         id: '4',
         giorno: '2023-05-04',
-        inizio_1: '11:00',
-        fine_1: '13:00',
+        inizio_1: null,
+        fine_1: null,
         tipo: 'FESTIVO',
         user_id: 'u',
       },
@@ -210,8 +207,6 @@ describe('SchedulePage', () => {
 
     const inputs = screen.getAllByRole('textbox')
     await userEvent.type(inputs[0], '2023-05-04')
-    await userEvent.type(inputs[1], '11:00')
-    await userEvent.type(inputs[2], '13:00')
 
     const selects = screen.getAllByRole('combobox')
     await userEvent.selectOptions(selects[1], 'FESTIVO')
@@ -219,13 +214,12 @@ describe('SchedulePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
     const row = await screen.findByRole('row', { name: /u\s+2023-05-04/i })
-    expect(within(row).getByText('11:00')).toBeInTheDocument()
-    expect(within(row).getByText('13:00')).toBeInTheDocument()
+    expect(within(row).getByText('FESTIVO')).toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-04',
-      inizio_1: '11:00',
-      fine_1: '13:00',
+      inizio_1: null,
+      fine_1: null,
       inizio_2: null,
       fine_2: null,
       inizio_3: null,


### PR DESCRIPTION
## Summary
- support missing times when shift type is RIPOSO or FESTIVO
- post null values for inizio_1 and fine_1 when saving rest shifts
- display shift type or placeholder instead of times in schedule table
- update tests for RIPOSO and FESTIVO shifts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf18583808323b5124b76a15582d7