### PR TITLE
Allow optional slot1

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -32,6 +32,31 @@ describe('createShiftEvents', () => {
     )
     expect(ids).toEqual(['1', '1'])
   })
+
+  it('creates events without slot1', async () => {
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve({ id: '1' }) })
+
+    const ids = await createShiftEvents('cal', {
+      userEmail: 'u@e',
+      giorno: '2023-05-02',
+      slot2: { inizio: '10:00', fine: '11:00' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.googleapis.com/calendar/v3/calendars/cal/events',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          summary: 'u@e',
+          description: undefined,
+          start: { dateTime: '2023-05-02T10:00' },
+          end: { dateTime: '2023-05-02T11:00' },
+        }),
+      }),
+    )
+    expect(ids).toEqual(['1'])
+  })
 })
 
 describe('signIn', () => {

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -121,7 +121,7 @@ export const deleteEvent = async (
 export interface ShiftData {
   userEmail: string
   giorno: string
-  slot1: { inizio: string; fine: string }
+  slot1?: { inizio: string; fine: string }
   slot2?: { inizio: string; fine: string }
   slot3?: { inizio: string; fine: string }
   note?: string


### PR DESCRIPTION
## Summary
- make calendar slot1 optional
- update schedule page to support missing slot1
- adjust imported-turni and table rendering
- add test case for missing slot1

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf347da948323b2e9712df4516847