### PR TITLE
Fix ferie display in schedule table

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -454,15 +454,18 @@ export default function SchedulePage() {
                 utenti.find(u => u.id === t.user_id)?.nome ||
                 stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
               const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
-              const start = t.slot1 ? t.slot1.inizio.format('HH:mm') : '—';
-              const end = t.slot1 ? t.slot1.fine.format('HH:mm') : '—';
-              const showType = ferieLike && !t.slot1;
+              const start = ferieLike
+                ? t.tipo
+                : t.slot1?.inizio.format('HH:mm') ?? '—';
+              const end = ferieLike
+                ? t.tipo
+                : t.slot1?.fine.format('HH:mm') ?? '—';
               return (
                 <tr key={t.id}>
                   <td>{nome}</td>
                   <td>{t.giorno.format('YYYY-MM-DD')}</td>
-                  <td>{showType ? t.tipo : start}</td>
-                  <td>{showType ? '—' : end}</td>
+                  <td>{start}</td>
+                  <td>{end}</td>
                   <td>{t.slot2 ? t.slot2.inizio.format('HH:mm') : '—'}</td>
                   <td>{t.slot2 ? t.slot2.fine.format('HH:mm') : '—'}</td>
                   <td>{t.slot3 ? t.slot3.inizio.format('HH:mm') : '—'}</td>

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -175,8 +175,8 @@ describe('SchedulePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
     const row = await screen.findByRole('row', { name: /u\s+2023-05-03/i })
-    expect(within(row).getByText('10:00')).toBeInTheDocument()
-    expect(within(row).getByText('12:00')).toBeInTheDocument()
+    const cells = within(row).getAllByText('RIPOSO')
+    expect(cells).toHaveLength(2)
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-03',
@@ -219,8 +219,8 @@ describe('SchedulePage', () => {
     await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
 
     const row = await screen.findByRole('row', { name: /u\s+2023-05-04/i })
-    expect(within(row).getByText('11:00')).toBeInTheDocument()
-    expect(within(row).getByText('13:00')).toBeInTheDocument()
+    const cells = within(row).getAllByText('FESTIVO')
+    expect(cells).toHaveLength(2)
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-04',


### PR DESCRIPTION
## Summary
- show FERIE/RIPOSO/FESTIVO label instead of start/end times
- update SchedulePage tests

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: plugin @typescript-eslint/eslint-plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bf4c44014832380ea1574bd3ac5bf