### PR TITLE
Update RIPOSO/FESTIVO tests for empty times

### DIFF
--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -154,8 +154,8 @@ describe('SchedulePage', () => {
       data: {
         id: '3',
         giorno: '2023-05-03',
-        inizio_1: '10:00',
-        fine_1: '12:00',
+        inizio_1: null,
+        fine_1: null,
         tipo: 'RIPOSO',
         user_id: 'u',
       },
@@ -166,8 +166,7 @@ describe('SchedulePage', () => {
 
     const inputs = screen.getAllByRole('textbox')
     await userEvent.type(inputs[0], '2023-05-03')
-    await userEvent.type(inputs[1], '10:00')
-    await userEvent.type(inputs[2], '12:00')
+
 
     const selects = screen.getAllByRole('combobox')
     await userEvent.selectOptions(selects[1], 'RIPOSO')
@@ -177,11 +176,14 @@ describe('SchedulePage', () => {
     const row = await screen.findByRole('row', { name: /u\s+2023-05-03/i })
     const cells = within(row).getAllByText('RIPOSO')
     expect(cells).toHaveLength(2)
+    expect(within(row).getAllByText('—')).toHaveLength(4)
+    expect(within(row).queryByText('10:00')).not.toBeInTheDocument()
+    expect(within(row).queryByText('12:00')).not.toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-03',
-      inizio_1: '10:00',
-      fine_1: '12:00',
+      inizio_1: null,
+      fine_1: null,
       inizio_2: null,
       fine_2: null,
       inizio_3: null,
@@ -198,8 +200,8 @@ describe('SchedulePage', () => {
       data: {
         id: '4',
         giorno: '2023-05-04',
-        inizio_1: '11:00',
-        fine_1: '13:00',
+        inizio_1: null,
+        fine_1: null,
         tipo: 'FESTIVO',
         user_id: 'u',
       },
@@ -210,8 +212,7 @@ describe('SchedulePage', () => {
 
     const inputs = screen.getAllByRole('textbox')
     await userEvent.type(inputs[0], '2023-05-04')
-    await userEvent.type(inputs[1], '11:00')
-    await userEvent.type(inputs[2], '13:00')
+
 
     const selects = screen.getAllByRole('combobox')
     await userEvent.selectOptions(selects[1], 'FESTIVO')
@@ -221,11 +222,14 @@ describe('SchedulePage', () => {
     const row = await screen.findByRole('row', { name: /u\s+2023-05-04/i })
     const cells = within(row).getAllByText('FESTIVO')
     expect(cells).toHaveLength(2)
+    expect(within(row).getAllByText('—')).toHaveLength(4)
+    expect(within(row).queryByText('11:00')).not.toBeInTheDocument()
+    expect(within(row).queryByText('13:00')).not.toBeInTheDocument()
     expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
       user_id: 'u',
       giorno: '2023-05-04',
-      inizio_1: '11:00',
-      fine_1: '13:00',
+      inizio_1: null,
+      fine_1: null,
       inizio_2: null,
       fine_2: null,
       inizio_3: null,


### PR DESCRIPTION
## Summary
- adjust RIPOSO and FESTIVO test cases to omit time inputs
- expect null values in POST payloads
- assert table shows shift type and placeholder instead of times

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf78bd1108323b494a3bc0b26d13a