### PR TITLE
Add agent filter to schedule page

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -47,6 +47,7 @@ export default function SchedulePage() {
   const [tipo, setTipo] = useState<TipoTurno>('NORMALE');
   const [note, setNote] = useState('');
   const [editing, setEditing] = useState<Turno | null>(null);
+  const [filtroAgente, setFiltroAgente] = useState('');
 
   const calendarId = SCHEDULE_CALENDAR_IDS[0];
 
@@ -430,6 +431,20 @@ export default function SchedulePage() {
       {/* -------- LISTA -------- */}
       <details open style={{ marginTop: '1rem' }}>
         <summary>Turni salvati</summary>
+        <div style={{ margin: '0.5rem 0' }}>
+          <label>Filtra per agente </label>
+          <select
+            value={filtroAgente}
+            onChange={e => setFiltroAgente(e.target.value)}
+          >
+            <option value="">Tutti</option>
+            {utenti.map(u => (
+              <option key={u.id} value={u.id}>
+                {u.nome || stripDomain(u.email)}
+              </option>
+            ))}
+          </select>
+        </div>
         <table className="item-table">
           <thead>
             <tr style={{ fontFamily: 'Cormorant Garamond, serif', color: '#000' }}>
@@ -445,7 +460,9 @@ export default function SchedulePage() {
             </tr>
           </thead>
           <tbody>
-            {turni.map(t => {
+            {turni
+              .filter(t => !filtroAgente || t.user_id === filtroAgente)
+              .map(t => {
               const nome =
                 utenti.find(u => u.id === t.user_id)?.nome ||
                 stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -101,6 +101,51 @@ describe('SchedulePage', () => {
     expect(mockedApi.get).toHaveBeenCalledWith('/orari/')
   })
 
+  it('filters turni by agent', async () => {
+    mockedApi.get.mockImplementation(url => {
+      if (url === '/users/')
+        return Promise.resolve({
+          data: [
+            { id: 'a', email: 'a@e', nome: 'a' },
+            { id: 'b', email: 'b@e', nome: 'b' },
+          ],
+        })
+      if (url === '/orari/')
+        return Promise.resolve({
+          data: [
+            {
+              id: '1',
+              giorno: '2023-01-01',
+              inizio_1: '08:00',
+              fine_1: '10:00',
+              tipo: 'NORMALE',
+              user_id: 'a',
+            },
+            {
+              id: '2',
+              giorno: '2023-01-02',
+              inizio_1: '09:00',
+              fine_1: '11:00',
+              tipo: 'NORMALE',
+              user_id: 'b',
+            },
+          ],
+        })
+      return Promise.resolve({ data: [] })
+    })
+
+    renderPage()
+
+    await screen.findByRole('row', { name: /a\s+2023-01-01/i })
+    await screen.findByRole('row', { name: /b\s+2023-01-02/i })
+
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[2], 'a')
+
+    expect(screen.getByRole('row', { name: /a\s+2023-01-01/i })).toBeInTheDocument()
+    expect(screen.queryByRole('row', { name: /b\s+2023-01-02/i })).not.toBeInTheDocument()
+  })
+
   it('adds a new turno', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })


### PR DESCRIPTION
## Summary
- add `filtroAgente` state and dropdown on schedule page
- filter schedule table rows by selected agent
- test filtering behaviour

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686bfd2205f88323bf06cf3138f1bc82