### PR TITLE
Add default schedule filter for logged user

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -47,7 +47,8 @@ export default function SchedulePage() {
   const [tipo, setTipo] = useState<TipoTurno>('NORMALE');
   const [note, setNote] = useState('');
   const [editing, setEditing] = useState<Turno | null>(null);
-  const [filtroAgente, setFiltroAgente] = useState('');
+  const user = useAuthStore(s => s.user);
+  const [filtroAgente, setFiltroAgente] = useState(user?.id || '');
 
   const calendarId = SCHEDULE_CALENDAR_IDS[0];
 
@@ -213,6 +214,10 @@ export default function SchedulePage() {
     };
     doSignIn();
   }, []);
+
+  useEffect(() => {
+    if (user?.id) setFiltroAgente(user.id);
+  }, [user]);
 
   /* --- helper --- */
   const resetForm = () => {


### PR DESCRIPTION
## Summary
- set the 'Filtra per agente' select to the authenticated user's ID by default
- update state whenever the logged user changes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686bff45331083238fe6af765a1ded26