### PR TITLE
Update header to show 'esci'

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,7 +30,7 @@ const Header: React.FC = () => {
           <Link to="/orari">🕑 Orari</Link>
           <Link to="/determinazioni">📄 Determine</Link>
           <Link to="/utilita">🤝 Riunioni</Link>
-          <button onClick={logout} aria-label="Esci">🚪</button>
+          <button onClick={logout} aria-label="Esci">🚪 esci</button>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- keep visible lowercase "esci" text next to the door icon in the header

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c37f54b8483238c8bf95c94dbd7a0