### PR TITLE
Customize saved shifts list header

### DIFF
--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -128,6 +128,11 @@
   display: none;
 }
 
+/* Hide default arrow for saved shifts summary */
+.saved-shifts-summary::-webkit-details-marker {
+  display: none;
+}
+
 .list-page h2 {
   text-align: center;
 }

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -435,7 +435,10 @@ export default function SchedulePage() {
 
       {/* -------- LISTA -------- */}
       <details open style={{ marginTop: '1rem' }}>
-        <summary>Turni salvati</summary>
+        <summary className="saved-shifts-summary" style={{ color: '#A52019', fontWeight: 'bold' }}>
+          Turni salvati
+          <span style={{ fontSize: '0.8em', marginLeft: '0.25em' }}>▼</span>
+        </summary>
         <div style={{ margin: '0.5rem 0' }}>
           <label>Filtra per agente </label>
           <select


### PR DESCRIPTION
## Summary
- style the saved shifts summary with a red bold label and arrow
- hide the default details marker for saved shift summaries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3cc976e083238b716b3618dcd9db