### PR TITLE
Add RECUPERO turno type

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The schedule page lets you create shifts with up to three optional time slots.
 **Fine1** is blank, that slot is not saved. The same rule applies to the other
 slots.
 
-To insert a day off select `RIPOSO` or `FESTIVO` and leave all time fields
+To insert a day off select `RIPOSO`, `FESTIVO` or `RECUPERO` and leave all time fields
 blank:
 
 ```json

--- a/src/api/schedule.ts
+++ b/src/api/schedule.ts
@@ -23,7 +23,7 @@ const fromBackend = (t: BackendTurno): Turno => ({
 })
 
 const toBackend = (t: Turno): BackendTurno => {
-  const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo)
+  const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO', 'RECUPERO'].includes(t.tipo)
   return {
     ...(t.id ? { id: t.id } : {}),
     user_id: t.user_id,

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -155,7 +155,7 @@ export default function SchedulePage() {
         setImportedTurni(imported);
           if (signedIn) {
             for (const t of imported) {
-              const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
+              const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO', 'RECUPERO'].includes(t.tipo);
               if (ferieLike) continue;
               try {
                 const email = utenti.find(u => u.id === t.user_id)?.email || '';
@@ -246,7 +246,7 @@ export default function SchedulePage() {
   /* --- submit --- */
   const handleAdd = async (e: React.FormEvent) => {
     e.preventDefault();
-    const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(tipo);
+    const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO', 'RECUPERO'].includes(tipo);
     if (!giorno || !utenteSel) return;
 
     const payload: NewTurnoPayload & { id?: string } = {
@@ -426,6 +426,7 @@ export default function SchedulePage() {
           <option value="FERIE">Ferie</option>
           <option value="RIPOSO">Riposo</option>
           <option value="FESTIVO">Festivo</option>
+          <option value="RECUPERO">Recupero</option>
         </select>
 
         <input placeholder="Note" value={note} onChange={e => setNote(e.target.value)} />
@@ -474,7 +475,7 @@ export default function SchedulePage() {
               const nome =
                 utenti.find(u => u.id === t.user_id)?.nome ||
                 stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
-              const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
+              const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO', 'RECUPERO'].includes(t.tipo);
               const start = ferieLike
                 ? t.tipo
                 : t.slot1?.inizio.format('HH:mm') ?? '—';
@@ -539,7 +540,7 @@ export default function SchedulePage() {
                 const nome =
                   utenti.find(u => u.id === t.user_id)?.nome ||
                   stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
-              const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO'].includes(t.tipo);
+              const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO', 'RECUPERO'].includes(t.tipo);
               const slot1 = ferieLike
                 ? t.tipo
                 : t.slot1

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -284,6 +284,49 @@ describe('SchedulePage', () => {
     })
   })
 
+  it('adds a new turno with tipo RECUPERO', async () => {
+    mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
+    mockedApi.get.mockResolvedValueOnce({ data: [] })
+    mockedApi.post.mockResolvedValueOnce({
+      data: {
+        id: '5a',
+        giorno: '2023-05-05',
+        inizio_1: null,
+        fine_1: null,
+        tipo: 'RECUPERO',
+        user_id: 'u',
+      },
+    })
+
+    renderPage()
+    await screen.findByRole('button', { name: /salva turno/i })
+
+    const inputs = screen.getAllByRole('textbox')
+    await userEvent.type(inputs[0], '2023-05-05')
+
+    const selects = screen.getAllByRole('combobox')
+    await userEvent.selectOptions(selects[1], 'RECUPERO')
+
+    await userEvent.click(screen.getByRole('button', { name: /salva turno/i }))
+
+    const row = await screen.findByRole('row', { name: /u\s+2023-05-05/i })
+    const cells = within(row).getAllByText('RECUPERO')
+    expect(cells).toHaveLength(2)
+    expect(within(row).getAllByText('—')).toHaveLength(4)
+    expect(mockedApi.post).toHaveBeenCalledWith('/orari/', {
+      user_id: 'u',
+      giorno: '2023-05-05',
+      inizio_1: null,
+      fine_1: null,
+      inizio_2: null,
+      fine_2: null,
+      inizio_3: null,
+      fine_3: null,
+      tipo: 'RECUPERO',
+      note: null,
+    })
+  })
+
   it('updates event when editing a turno', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })

--- a/src/types/turno.ts
+++ b/src/types/turno.ts
@@ -10,7 +10,8 @@ export type TipoTurno =
   | 'STRAORD'
   | 'FERIE'
   | 'RIPOSO'
-  | 'FESTIVO';
+  | 'FESTIVO'
+  | 'RECUPERO';
 
 export interface Turno {
   id: string


### PR DESCRIPTION
## Summary
- introduce `RECUPERO` in `TipoTurno`
- extend `ferieLike` arrays with the new type
- allow selecting `RECUPERO` from the schedule page
- document new day‑off type
- test saving a RECUPERO shift

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c47a42f208323a75f8970a8d0334d