### PR TITLE
Fix calendar timestamps

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -25,8 +25,8 @@ describe('createShiftEvents', () => {
         body: JSON.stringify({
           summary: 'u@e',
           description: 'note',
-          start: { dateTime: '2023-05-01T08:00' },
-          end: { dateTime: '2023-05-01T09:00' },
+          start: { dateTime: new Date('2023-05-01T08:00:00').toISOString() },
+          end: { dateTime: new Date('2023-05-01T09:00:00').toISOString() },
         }),
       }),
     )
@@ -50,8 +50,8 @@ describe('createShiftEvents', () => {
         body: JSON.stringify({
           summary: 'u@e',
           description: undefined,
-          start: { dateTime: '2023-05-02T10:00' },
-          end: { dateTime: '2023-05-02T11:00' },
+          start: { dateTime: new Date('2023-05-02T10:00:00').toISOString() },
+          end: { dateTime: new Date('2023-05-02T11:00:00').toISOString() },
         }),
       }),
     )

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -169,8 +169,12 @@ export const createShiftEvents = async (
     const res = await createEvent(calendarId, {
       summary: turno.userEmail,
       description: turno.note,
-      start: { dateTime: `${turno.giorno}T${slot.inizio}` },
-      end: { dateTime: `${turno.giorno}T${slot.fine}` },
+      start: {
+        dateTime: new Date(`${turno.giorno}T${slot.inizio}:00`).toISOString(),
+      },
+      end: {
+        dateTime: new Date(`${turno.giorno}T${slot.fine}:00`).toISOString(),
+      },
     })
     if (res.id) ids.push(res.id)
   }

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -311,8 +311,16 @@ export default function SchedulePage() {
             await updateEvent(calendarId, eventIds[i], {
               summary: shift.userEmail,
               description: shift.note,
-              start: { dateTime: `${shift.giorno}T${slots[i].inizio}` },
-              end: { dateTime: `${shift.giorno}T${slots[i].fine}` },
+              start: {
+                dateTime: new Date(
+                  `${shift.giorno}T${slots[i].inizio}:00`,
+                ).toISOString(),
+              },
+              end: {
+                dateTime: new Date(
+                  `${shift.giorno}T${slots[i].fine}:00`,
+                ).toISOString(),
+              },
             });
           }
         } else {


### PR DESCRIPTION
## Summary
- fix `createShiftEvents` to send RFC3339 timestamps
- update SchedulePage to send same timestamp when updating events
- update tests to check for timezone-aware timestamps

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686d8be2171c83238a13e9e4e3400b97