### PR TITLE
Refresh schedule data after Excel import

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -141,7 +141,7 @@ export default function SchedulePage() {
 
   const handleImportComplete = async (success: boolean) => {
     if (success) {
-        const data = await loadTurni();
+      const data = await loadTurni();
       if (data.length) {
         const maxDate = new Date(
           Math.max(...data.map(t => t.giorno.toDate().getTime()))
@@ -188,6 +188,7 @@ export default function SchedulePage() {
               }
             }
           }
+        await loadTurni();
         setRefreshCal(prev => !prev);
       }
     }


### PR DESCRIPTION
## Summary
- refresh schedule data again after importing Excel shifts to show updates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e59bcac948323876b0c672cb0becc