### PR TITLE
Filter schedule by week

### DIFF
--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -71,6 +71,8 @@ export default function SchedulePage() {
       ),
     [token]
   );
+  const weekStart = startOfISOWeek(new Date());
+  const weekEnd = addDays(weekStart, 6);
 
   const toPlain = (t: Turno) => ({
     id: t.id,
@@ -479,7 +481,14 @@ export default function SchedulePage() {
           </thead>
           <tbody>
             {turni
-              .filter(t => !filtroAgente || t.user_id === filtroAgente)
+              .filter(t => {
+                const d = t.giorno.toDate();
+                return (
+                  d >= weekStart &&
+                  d <= weekEnd &&
+                  (!filtroAgente || t.user_id === filtroAgente)
+                );
+              })
               .map(t => {
               const nome =
                 utenti.find(u => u.id === t.user_id)?.nome ||

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -146,6 +146,52 @@ describe('SchedulePage', () => {
     expect(screen.queryByRole('row', { name: /b\s+2023-01-02/i })).not.toBeInTheDocument()
   })
 
+  it('shows only current week turni', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-03T00:00:00Z'))
+    mockedApi.get.mockImplementation(url => {
+      if (url === '/users/')
+        return Promise.resolve({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
+      if (url === '/orari/')
+        return Promise.resolve({
+          data: [
+            {
+              id: '1',
+              giorno: '2023-05-03',
+              inizio_1: '08:00',
+              fine_1: '10:00',
+              tipo: 'NORMALE',
+              user_id: 'u',
+            },
+            {
+              id: '2',
+              giorno: '2023-04-28',
+              inizio_1: '08:00',
+              fine_1: '10:00',
+              tipo: 'NORMALE',
+              user_id: 'u',
+            },
+            {
+              id: '3',
+              giorno: '2023-05-10',
+              inizio_1: '08:00',
+              fine_1: '10:00',
+              tipo: 'NORMALE',
+              user_id: 'u',
+            },
+          ],
+        })
+      return Promise.resolve({ data: [] })
+    })
+
+    renderPage()
+
+    await screen.findByRole('row', { name: /u\s+2023-05-03/i })
+
+    expect(screen.getByRole('row', { name: /u\s+2023-05-03/i })).toBeInTheDocument()
+    expect(screen.queryByRole('row', { name: /2023-04-28/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('row', { name: /2023-05-10/i })).not.toBeInTheDocument()
+  })
+
   it('adds a new turno', async () => {
     mockedApi.get.mockResolvedValueOnce({ data: [{ id: 'u', email: 'u@e', nome: 'u' }] })
     mockedApi.get.mockResolvedValueOnce({ data: [] })


### PR DESCRIPTION
## Summary
- show only schedule rows in the current ISO week
- add test for current week filtering

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5e47f2788323943be3a22f55845f