### PR TITLE
Implement swiper carousel for meeting links

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",
     "vite": "^4.5.14",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "swiper": "^8.4.7"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/src/components/MeetingCarousel.css
+++ b/src/components/MeetingCarousel.css
@@ -1,0 +1,51 @@
+.riunioni-swiper {
+  width: 90%;
+  max-width: 600px;
+  padding-top: 40px;
+  padding-bottom: 40px;
+  margin: 0 auto;
+}
+
+.riunioni-swiper .swiper-slide {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 12px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.1);
+  background: white;
+}
+
+.riunioni-swiper img {
+  width: 200px;
+  height: auto;
+  object-fit: contain;
+  padding: 30px;
+  transition: transform 0.3s ease;
+}
+
+.riunioni-swiper a:hover img {
+  transform: scale(1.05);
+}
+
+.swiper-pagination-bullet,
+.swiper-pagination-bullet-active {
+  background: #0077ff;
+}
+
+.swiper-slide--riunione1 {
+  background: linear-gradient(to top, #0f2027, #203a4300, #2c536400),
+    url('https://images.unsplash.com/photo-1581092160612-ade902d2f4e4?fit=crop&w=900&q=80')
+      no-repeat center/cover;
+}
+
+.swiper-slide--riunione2 {
+  background: linear-gradient(to top, #0f2027, #203a4300, #2c536400),
+    url('https://images.unsplash.com/photo-1629904853893-c2c8981a1f5b?fit=crop&w=900&q=80')
+      no-repeat center/cover;
+}
+
+.swiper-slide--riunione3 {
+  background: linear-gradient(to top, #0f2027, #203a4300, #2c536400),
+    url('https://images.unsplash.com/photo-1596495577886-d920f1fb7238?fit=crop&w=900&q=80')
+      no-repeat center/cover;
+}

--- a/src/components/MeetingCarousel.tsx
+++ b/src/components/MeetingCarousel.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { EffectCoverflow, Pagination } from 'swiper';
+import 'swiper/css';
+import 'swiper/css/effect-coverflow';
+import 'swiper/css/pagination';
+import './MeetingCarousel.css';
+
+const MeetingCarousel: React.FC = () => {
+  const meetUrl = import.meta.env.VITE_MEET_URL;
+  const teamsUrl = import.meta.env.VITE_TEAMS_URL;
+  const zoomUrl = import.meta.env.VITE_ZOOM_URL;
+
+  return (
+    <Swiper
+      modules={[EffectCoverflow, Pagination]}
+      effect="coverflow"
+      grabCursor
+      centeredSlides
+      slidesPerView="auto"
+      loop
+      spaceBetween={40}
+      pagination={{ clickable: true }}
+      coverflowEffect={{
+        rotate: 0,
+        stretch: 0,
+        depth: 100,
+        modifier: 2,
+        slideShadows: false,
+      }}
+      className="riunioni-swiper"
+    >
+      <SwiperSlide className="swiper-slide--riunione1">
+        <a href={meetUrl} target="_blank" rel="noopener noreferrer">
+          <img src="/meet.png" alt="Google Meet" />
+        </a>
+      </SwiperSlide>
+      <SwiperSlide className="swiper-slide--riunione2">
+        <a href={teamsUrl} target="_blank" rel="noopener noreferrer">
+          <img src="/teams.png" alt="Microsoft Teams" />
+        </a>
+      </SwiperSlide>
+      <SwiperSlide className="swiper-slide--riunione3">
+        <a href={zoomUrl} target="_blank" rel="noopener noreferrer">
+          <img src="/zoom.png" alt="Zoom" />
+        </a>
+      </SwiperSlide>
+    </Swiper>
+  );
+};
+
+export default MeetingCarousel;

--- a/src/pages/UtilitaPage.tsx
+++ b/src/pages/UtilitaPage.tsx
@@ -1,45 +1,7 @@
 import React from 'react';
 import './ListPages.css';
-
-const GoogleIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 533.5 544.3"
-    className="w-4 h-4"
-  >
-    <path fill="#4285f4" d="M533.5 278.4c0-18.5-1.5-36.3-4.4-53.6H272v101.3h146.9c-6.3 34.1-25 63-53.3 82.2v68h86.2c50.3-46.3 81.7-114.5 81.7-197.9z"/>
-    <path fill="#34a853" d="M272 544.3c72.6 0 133.5-24 178-65.3l-86.2-68c-24 16-55 25.4-91.8 25.4-70 0-129.5-47.3-150.7-110.7H34v69.2C78.8 477 170.4 544.3 272 544.3z"/>
-    <path fill="#fbbc04" d="M121.3 325.7c-10.4-30.8-10.4-64.8 0-95.6V160.9H34c-43.2 86.4-43.2 189.9 0 276.3l87.3-68z"/>
-    <path fill="#ea4335" d="M272 107.6c39.6 0 75 13.6 103.2 40.4l77-74.7C411.3 24.3 352.7 0 272 0 170.4 0 78.8 67.3 34 164.5l87.3 68C142.5 154.9 202 107.6 272 107.6z"/>
-  </svg>
-);
-
-const TeamsIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 48 48"
-    className="w-4 h-4"
-  >
-    <path fill="#6264A7" d="M43 4H5a3 3 0 0 0-3 3v34a3 3 0 0 0 3 3h38a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3zm-6 9h-7v7h-6v-7h-7v25h7v-7h6v7h7V13z"/>
-  </svg>
-);
-
-const ZoomIcon = () => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    className="w-4 h-4"
-  >
-    <path fill="#2D8CFF" d="M6.432 0C2.882 0 0 2.882 0 6.432v11.136C0 20.118 2.882 23 6.432 23h11.136C20.118 23 23 20.118 23 17.568V6.432C23 2.882 20.118 0 17.568 0H6.432zm9.44 6.062l4.63 2.93a.324.324 0 01.158.281v5.267a.324.324 0 01-.158.281l-4.63 2.93a.324.324 0 01-.495-.281V6.343a.324.324 0 01.495-.281z"/>
-  </svg>
-);
+import MeetingCarousel from '../components/MeetingCarousel';
 
 export default function UtilitaPage() {
-  return (
-    <div className="meeting-links">
-      <img src="/meet.png" alt="Google Meet" />
-      <img src="/zoom.png" alt="Zoom" />
-      <img src="/teams.png" alt="Microsoft Teams" />
-    </div>
-  );
+  return <MeetingCarousel />;
 }


### PR DESCRIPTION
## Summary
- add `swiper` dependency
- add `MeetingCarousel` component with custom CSS
- display the carousel on Utilità page

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6eee4aec83239e6e6b53095ddc28