### PR TITLE
Improve login performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://accounts.google.com/gsi/client" async defer></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -10,10 +10,10 @@ body {
   font-family: 'Cormorant Garamond', serif;
   font-weight: bold;
   color: #333;
-  background: url('/Login.png') no-repeat center/cover fixed;
+  background: #fff;
 }
 body.login-bg {
-  background-size: contain;
+  background: url('/Login.png') no-repeat center/contain fixed;
   font-family: 'Almendra SC', serif;
 }
 


### PR DESCRIPTION
## Summary
- avoid loading Google identity script on every page
- only fetch Google calendar script when signing in
- load login background only when needed

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7e5b48a88323aeb8a3b5e04e402b