### PR TITLE
Double carousel size on Riunioni page

### DIFF
--- a/src/components/MeetingCarousel.css
+++ b/src/components/MeetingCarousel.css
@@ -1,6 +1,6 @@
 .riunioni-swiper {
   width: 90%;
-  max-width: 600px;
+  max-width: 1200px;
   padding-top: 40px;
   padding-bottom: 40px;
   margin: 0 auto;
@@ -16,7 +16,7 @@
 }
 
 .riunioni-swiper img {
-  width: 200px;
+  width: 400px;
   height: auto;
   object-fit: contain;
   padding: 30px;


### PR DESCRIPTION
## Summary
- enlarge the meeting carousel width
- enlarge meeting carousel images

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_686e860737bc8323b5e335b2f6ab46b7