### PR TITLE
Link meeting carousel images to service home pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,3 @@ VITE_DASHBOARD_CALENDAR_ID="your-dashboard-calendar-id"
 VITE_SCHEDULE_CALENDAR_IDS="your-calendar-id-1,your-calendar-id-2"
 
 # Video conferencing links for the Utilità page
-VITE_MEET_URL="https://meet.google.com/xyz-abcq-wvu"
-VITE_TEAMS_URL="https://teams.microsoft.com/l/meetup-join/…"
-VITE_ZOOM_URL="https://zoom.us/wc/join/123456789?pwd=abcdef"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ The variables are:
 - `VITE_DASHBOARD_CALENDAR_ID` – calendar ID used by the Dashboard and Events
   pages. If unset, the first ID from `VITE_SCHEDULE_CALENDAR_IDS` is used,
   falling back to the default calendar.
-- `VITE_MEET_URL` – Google Meet room URL shown on the Utilità page.
-- `VITE_TEAMS_URL` – Microsoft Teams meeting link used by the Utilità page.
-- `VITE_ZOOM_URL` – Zoom meeting link used by the Utilità page.
+  The Utilità page includes a carousel linking to the Google Meet,
+  Microsoft Teams and Zoom home pages.
 
 4. Start the development server:
 

--- a/src/components/MeetingCarousel.tsx
+++ b/src/components/MeetingCarousel.tsx
@@ -7,9 +7,9 @@ import 'swiper/css/pagination';
 import './MeetingCarousel.css';
 
 const MeetingCarousel: React.FC = () => {
-  const meetUrl = import.meta.env.VITE_MEET_URL;
-  const teamsUrl = import.meta.env.VITE_TEAMS_URL;
-  const zoomUrl = import.meta.env.VITE_ZOOM_URL;
+  const meetUrl = 'https://meet.google.com';
+  const teamsUrl = 'https://teams.microsoft.com';
+  const zoomUrl = 'https://zoom.us';
 
   return (
     <Swiper


### PR DESCRIPTION
## Summary
- update meeting carousel links to point to the Google Meet, Microsoft Teams and Zoom home pages
- document carousel links in README
- remove unused meeting link environment variables from `.env.example`

## Testing
- `npm run lint` *(fails: ESLint couldn't find @typescript-eslint/eslint-plugin)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e87e114c4832396b56ff865e9678d