### PR TITLE
Implement filtered calendar on dashboard

### DIFF
--- a/src/components/DashboardCalendar.tsx
+++ b/src/components/DashboardCalendar.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { signIn, listEvents } from '../api/googleCalendar';
+import { listUsers } from '../api/users';
+import { useAuthStore } from '../store/auth';
+import { DEFAULT_CALENDAR_ID } from '../constants';
+import type { GcEvent } from '../api/types';
+
+interface GroupedEvents {
+  date: string;
+  events: GcEvent[];
+}
+
+const DashboardCalendar: React.FC = () => {
+  const user = useAuthStore(s => s.user);
+  const calendarId =
+    import.meta.env.VITE_DASHBOARD_CALENDAR_ID ||
+    import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
+    DEFAULT_CALENDAR_ID;
+
+  const [events, setEvents] = useState<GcEvent[]>([]);
+  const [userEmails, setUserEmails] = useState<string[]>([]);
+  const [error, setError] = useState('');
+  const [refreshFlag, setRefreshFlag] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await signIn();
+        const [evs, users] = await Promise.all([
+          listEvents(calendarId),
+          listUsers().then(r => r.data).catch(() => []),
+        ]);
+        setUserEmails(users.map(u => u.email));
+        setEvents(evs);
+      } catch {
+        setError('Errore di accesso al calendario');
+      }
+    };
+    fetchData();
+  }, [calendarId, refreshFlag]);
+
+  const filtered = useMemo(() => {
+    return events.filter(ev => {
+      const summary = ev.summary || '';
+      if (summary === user?.email) return true;
+      if (!userEmails.includes(summary)) return true;
+      return false;
+    });
+  }, [events, user, userEmails]);
+
+  const grouped: GroupedEvents[] = useMemo(() => {
+    const map: Record<string, GcEvent[]> = {};
+    for (const ev of filtered) {
+      const dt = ev.start?.dateTime || ev.start?.date;
+      if (!dt) continue;
+      const day = dt.split('T')[0];
+      if (!map[day]) map[day] = [];
+      map[day].push(ev);
+    }
+    return Object.entries(map)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([date, events]) => ({ date, events }));
+  }, [filtered]);
+
+  if (error) return <div>{error}</div>;
+
+  return (
+    <div>
+      {grouped.map(g => (
+        <div key={g.date}>
+          <h3>{new Date(g.date).toLocaleDateString()}</h3>
+          <ul>
+            {g.events.map(ev => (
+              <li key={ev.id}>{ev.summary}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      <button onClick={() => setRefreshFlag(f => !f)}>
+        Aggiorna calendario
+      </button>
+    </div>
+  );
+};
+
+export default DashboardCalendar;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
@@ -6,6 +6,7 @@ import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { DEFAULT_CALENDAR_ID } from '../constants';
+import DashboardCalendar from '../components/DashboardCalendar';
 interface EventItem {
   id: string;
   title: string;
@@ -33,8 +34,6 @@ export default function Dashboard() {
     e => differenceInCalendarDays(parseISO(e.dateTime), today) <= 3
   );
   const dashboardTodos = todos;
-
-  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const onDelete = async (id: string): Promise<void> => {
     if (navigator.onLine) {
@@ -82,22 +81,9 @@ export default function Dashboard() {
         </div>
         <div className="top-wrapper">
           <div className="calendar-container dashboard-section">
-           <iframe
-               ref={iframeRef}
-               title="calendar"
-                src={`https://calendar.google.com/calendar/embed?src=${encodeURIComponent(CALENDAR_ID)}&mode=WEEK&ctz=Europe/Rome`}
-                style={{ border: 0 }}
-                width="100%"
-                height="600"
-                scrolling="no"
-             ></iframe>
-            <button onClick={() => {
-  if (iframeRef.current) iframeRef.current.src = iframeRef.current.src;        // forza reload
-}}>
-  Aggiorna calendario
-</button>
+            <DashboardCalendar />
+          </div>
         </div>
-      </div>
       </div>
   );
 }

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -3,9 +3,31 @@ import userEvent from '@testing-library/user-event';
 import Dashboard from '../Dashboard';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import * as gcApi from '../../api/googleCalendar';
+import * as userApi from '../../api/users';
+import { useAuthStore } from '../../store/auth';
+
+jest.mock('../../api/googleCalendar', () => ({
+  __esModule: true,
+  signIn: jest.fn(),
+  listEvents: jest.fn(),
+}));
+
+jest.mock('../../api/users', () => ({
+  __esModule: true,
+  listUsers: jest.fn(),
+}));
+
+const mockedGcApi = gcApi as jest.Mocked<typeof gcApi>;
+const mockedUserApi = userApi as jest.Mocked<typeof userApi>;
 
 beforeEach(() => {
   localStorage.clear();
+  useAuthStore.getState().setUser(null);
+  jest.resetAllMocks();
+  mockedGcApi.signIn.mockResolvedValue();
+  mockedGcApi.listEvents.mockResolvedValue([] as any);
+  mockedUserApi.listUsers.mockResolvedValue({ data: [] } as any);
 });
 
 describe('Dashboard', () => {
@@ -30,6 +52,35 @@ describe('Dashboard', () => {
     await userEvent.click(screen.getByTestId('dashboard-delete'));
 
     expect(screen.queryByText('Task')).not.toBeInTheDocument();
+  });
+
+  it('shows only user and generic calendar events', async () => {
+    useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
+    mockedUserApi.listUsers.mockResolvedValueOnce({
+      data: [
+        { id: '1', email: 'me@e' },
+        { id: '2', email: 'other@e' },
+      ],
+    } as any);
+    mockedGcApi.listEvents.mockResolvedValueOnce([
+      { id: '1', summary: 'me@e', start: { date: '2023-01-01' } } as any,
+      { id: '2', summary: 'other@e', start: { date: '2023-01-02' } } as any,
+      { id: '3', summary: 'Meeting', start: { date: '2023-01-03' } } as any,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('me@e')).toBeInTheDocument();
+    expect(await screen.findByText('Meeting')).toBeInTheDocument();
+    expect(screen.queryByText('other@e')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- create `DashboardCalendar` component to fetch and filter Google calendar events
- show filtered events on the Dashboard instead of the iframe
- test that only the logged in user's and generic events are shown

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ed586deb4832394007808445c435e