### PR TITLE
Fix dashboard calendar filtering

### DIFF
--- a/src/components/DashboardCalendar.tsx
+++ b/src/components/DashboardCalendar.tsx
@@ -18,7 +18,7 @@ const DashboardCalendar: React.FC = () => {
     DEFAULT_CALENDAR_ID;
 
   const [events, setEvents] = useState<GcEvent[]>([]);
-  const [userEmails, setUserEmails] = useState<string[]>([]);
+  const [userLabels, setUserLabels] = useState<string[]>([]);
   const [error, setError] = useState('');
   const [refreshFlag, setRefreshFlag] = useState(false);
 
@@ -30,7 +30,7 @@ const DashboardCalendar: React.FC = () => {
           listEvents(calendarId),
           listUsers().then(r => r.data).catch(() => []),
         ]);
-        setUserEmails(users.map(u => u.email));
+        setUserLabels(users.flatMap(u => [u.email, u.nome]));
         setEvents(evs);
       } catch {
         setError('Errore di accesso al calendario');
@@ -43,10 +43,11 @@ const DashboardCalendar: React.FC = () => {
     return events.filter(ev => {
       const summary = ev.summary || '';
       if (summary === user?.email) return true;
-      if (!userEmails.includes(summary)) return true;
+      if (summary === user?.nome) return true;
+      if (!userLabels.includes(summary)) return true;
       return false;
     });
-  }, [events, user, userEmails]);
+  }, [events, user, userLabels]);
 
   const grouped: GroupedEvents[] = useMemo(() => {
     const map: Record<string, GcEvent[]> = {};

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -58,8 +58,8 @@ describe('Dashboard', () => {
     useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
     mockedUserApi.listUsers.mockResolvedValueOnce({
       data: [
-        { id: '1', email: 'me@e' },
-        { id: '2', email: 'other@e' },
+        { id: '1', email: 'me@e', nome: 'Me' },
+        { id: '2', email: 'other@e', nome: 'Other' },
       ],
     } as any);
     mockedGcApi.listEvents.mockResolvedValueOnce([
@@ -81,6 +81,35 @@ describe('Dashboard', () => {
     expect(await screen.findByText('me@e')).toBeInTheDocument();
     expect(await screen.findByText('Meeting')).toBeInTheDocument();
     expect(screen.queryByText('other@e')).not.toBeInTheDocument();
+  });
+
+  it('filters events matching other user names', async () => {
+    useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
+    mockedUserApi.listUsers.mockResolvedValueOnce({
+      data: [
+        { id: '1', email: 'me@e', nome: 'Me' },
+        { id: '2', email: 'other@e', nome: 'Other' },
+      ],
+    } as any);
+    mockedGcApi.listEvents.mockResolvedValueOnce([
+      { id: '1', summary: 'Me', start: { date: '2023-01-01' } } as any,
+      { id: '2', summary: 'Other', start: { date: '2023-01-02' } } as any,
+      { id: '3', summary: 'Meeting', start: { date: '2023-01-03' } } as any,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Me')).toBeInTheDocument();
+    expect(await screen.findByText('Meeting')).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- filter DashboardCalendar events by user names as well as emails
- update dashboard tests to cover name filtering

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed988f9188323863ce67953670f8f