### PR TITLE
Limit dashboard events to current week

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ The `Note` column is optional and can be left blank or filled with text.
 Times must be provided in the `HH:mm` format. Cells can be left blank, but any
 value entered must be a valid time string or the backend will reject that row.
 
+## Dashboard
+
+The dashboard calendar shows Google Calendar events for the current week only.
+Events are fetched from the ID defined in `VITE_DASHBOARD_CALENDAR_ID`.
+
 ## Testing
 
 Before running tests, install dependencies if you haven't already:

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -65,12 +65,15 @@ export const signIn = async (): Promise<void> => {
 
 export const listEvents = async (
   calendarId: string = DEFAULT_CALENDAR_ID,
+  timeMin?: Date,
+  timeMax?: Date,
 ): Promise<GcEvent[]> => {
   const params = new URLSearchParams({
     singleEvents: 'true',
     orderBy: 'startTime',
-    timeMin: new Date(0).toISOString(),
   })
+  if (timeMin) params.set('timeMin', timeMin.toISOString())
+  if (timeMax) params.set('timeMax', timeMax.toISOString())
   const res = await fetch(
     `${API_BASE}/calendars/${encodeURIComponent(calendarId)}/events?${params}`,
     {

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -111,5 +111,31 @@ describe('Dashboard', () => {
     expect(await screen.findByText('Meeting')).toBeInTheDocument();
     expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
+
+  it('hides events outside the current week', async () => {
+    useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
+    const today = new Date();
+    const inWeek = today.toISOString().split('T')[0];
+    const outside = new Date(today.getTime() + 14 * 864e5)
+      .toISOString()
+      .split('T')[0];
+    mockedGcApi.listEvents.mockResolvedValueOnce([
+      { id: '1', summary: 'In', start: { date: inWeek } } as any,
+      { id: '2', summary: 'Out', start: { date: outside } } as any,
+    ]);
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('In')).toBeInTheDocument();
+    expect(screen.queryByText('Out')).not.toBeInTheDocument();
+  });
 });
 


### PR DESCRIPTION
## Summary
- query calendar events with `timeMin`/`timeMax`
- only fetch the current week in `DashboardCalendar`
- filter events by week interval
- ensure events outside the week aren't displayed
- document dashboard behaviour

## Testing
- `npm test -- -t Dashboard.test.tsx` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686ee0327d888323b431730587a5dbd2