### PR TITLE
Add weekly calendar grid

### DIFF
--- a/src/components/__tests__/DashboardCalendar.test.tsx
+++ b/src/components/__tests__/DashboardCalendar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, within } from '@testing-library/react';
+import DashboardCalendar from '../DashboardCalendar';
+import { useAuthStore } from '../../store/auth';
+import * as gcApi from '../../api/googleCalendar';
+import * as userApi from '../../api/users';
+
+jest.mock('../../api/googleCalendar', () => ({
+  __esModule: true,
+  signIn: jest.fn(),
+  listEvents: jest.fn(),
+}));
+
+jest.mock('../../api/users', () => ({
+  __esModule: true,
+  listUsers: jest.fn(),
+}));
+
+const mockedGcApi = gcApi as jest.Mocked<typeof gcApi>;
+const mockedUserApi = userApi as jest.Mocked<typeof userApi>;
+
+beforeEach(() => {
+  localStorage.clear();
+  useAuthStore.getState().setUser(null);
+  jest.resetAllMocks();
+  mockedGcApi.signIn.mockResolvedValue();
+  mockedUserApi.listUsers.mockResolvedValue({ data: [] } as any);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('DashboardCalendar', () => {
+  it('renders seven days', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-03T00:00:00Z'));
+    mockedGcApi.listEvents.mockResolvedValueOnce([] as any);
+
+    render(<DashboardCalendar />);
+
+    const headings = await screen.findAllByRole('heading', { level: 3 });
+    expect(headings).toHaveLength(7);
+  });
+
+  it('places events under the correct day', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-03T00:00:00Z'));
+    mockedGcApi.listEvents.mockResolvedValueOnce([
+      { id: '1', summary: 'A', start: { date: '2023-05-01' } } as any,
+      { id: '2', summary: 'B', start: { date: '2023-05-03' } } as any,
+      { id: '3', summary: 'C', start: { date: '2023-05-05' } } as any,
+    ]);
+
+    render(<DashboardCalendar />);
+
+    const monday = await screen.findByTestId('day-2023-05-01');
+    const wednesday = screen.getByTestId('day-2023-05-03');
+    const friday = screen.getByTestId('day-2023-05-05');
+
+    expect(within(monday).getByText('A')).toBeInTheDocument();
+    expect(within(wednesday).getByText('B')).toBeInTheDocument();
+    expect(within(friday).getByText('C')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -77,3 +77,15 @@
   -webkit-text-stroke: 0;
   text-shadow: none;
 }
+
+.week-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.5rem;
+}
+
+.week-day {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  background: #fff;
+}


### PR DESCRIPTION
## Summary
- show dashboard calendar events in a 7‑day grid
- style the calendar grid
- test DashboardCalendar grid layout

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee034fe9c8323902fae1b23a90ed9