### PR TITLE
Remove old week calendar styles

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -78,14 +78,3 @@
   text-shadow: none;
 }
 
-.week-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 0.5rem;
-}
-
-.week-day {
-  border: 1px solid #ddd;
-  padding: 0.5rem;
-  background: #fff;
-}


### PR DESCRIPTION
## Summary
- remove `.week-grid` and `.week-day` CSS rules

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee7a068bc8323b3774f496663d9f9