### PR TITLE
Embed calendar iframe on Dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
@@ -6,7 +6,6 @@ import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { DEFAULT_CALENDAR_ID } from '../constants';
-import DashboardCalendar from '../components/DashboardCalendar';
 interface EventItem {
   id: string;
   title: string;
@@ -24,6 +23,7 @@ export default function Dashboard() {
   );
   const [events] = useLocalStorage<EventItem[]>('events', []);
   const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
+  const [refreshCal, setRefreshCal] = useState(false);
   const CALENDAR_ID =
     import.meta.env.VITE_DASHBOARD_CALENDAR_ID ||
     import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
@@ -81,7 +81,17 @@ export default function Dashboard() {
         </div>
         <div className="top-wrapper">
           <div className="calendar-container dashboard-section">
-            <DashboardCalendar />
+            <iframe
+              key={String(refreshCal)}
+              src={`https://calendar.google.com/calendar/embed?src=${encodeURIComponent(CALENDAR_ID)}&mode=WEEK&ctz=Europe/Rome`}
+              title="Calendario"
+              style={{ border: 0, width: '100%', height: '600px' }}
+              frameBorder={0}
+              scrolling="no"
+            />
+            <button onClick={() => setRefreshCal(prev => !prev)}>
+              Aggiorna calendario
+            </button>
           </div>
         </div>
       </div>

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -3,31 +3,11 @@ import userEvent from '@testing-library/user-event';
 import Dashboard from '../Dashboard';
 import PageTemplate from '../../components/PageTemplate';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import * as gcApi from '../../api/googleCalendar';
-import * as userApi from '../../api/users';
 import { useAuthStore } from '../../store/auth';
-
-jest.mock('../../api/googleCalendar', () => ({
-  __esModule: true,
-  signIn: jest.fn(),
-  listEvents: jest.fn(),
-}));
-
-jest.mock('../../api/users', () => ({
-  __esModule: true,
-  listUsers: jest.fn(),
-}));
-
-const mockedGcApi = gcApi as jest.Mocked<typeof gcApi>;
-const mockedUserApi = userApi as jest.Mocked<typeof userApi>;
 
 beforeEach(() => {
   localStorage.clear();
   useAuthStore.getState().setUser(null);
-  jest.resetAllMocks();
-  mockedGcApi.signIn.mockResolvedValue();
-  mockedGcApi.listEvents.mockResolvedValue([] as any);
-  mockedUserApi.listUsers.mockResolvedValue({ data: [] } as any);
 });
 
 describe('Dashboard', () => {
@@ -54,20 +34,7 @@ describe('Dashboard', () => {
     expect(screen.queryByText('Task')).not.toBeInTheDocument();
   });
 
-  it('shows only user and generic calendar events', async () => {
-    useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
-    mockedUserApi.listUsers.mockResolvedValueOnce({
-      data: [
-        { id: '1', email: 'me@e', nome: 'Me' },
-        { id: '2', email: 'other@e', nome: 'Other' },
-      ],
-    } as any);
-    mockedGcApi.listEvents.mockResolvedValueOnce([
-      { id: '1', summary: 'me@e', start: { date: '2023-01-01' } } as any,
-      { id: '2', summary: 'other@e', start: { date: '2023-01-02' } } as any,
-      { id: '3', summary: 'Meeting', start: { date: '2023-01-03' } } as any,
-    ]);
-
+  it('renders the Google Calendar iframe', () => {
     render(
       <MemoryRouter initialEntries={["/"]}>
         <Routes>
@@ -78,64 +45,8 @@ describe('Dashboard', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('me@e')).toBeInTheDocument();
-    expect(await screen.findByText('Meeting')).toBeInTheDocument();
-    expect(screen.queryByText('other@e')).not.toBeInTheDocument();
-  });
-
-  it('filters events matching other user names', async () => {
-    useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
-    mockedUserApi.listUsers.mockResolvedValueOnce({
-      data: [
-        { id: '1', email: 'me@e', nome: 'Me' },
-        { id: '2', email: 'other@e', nome: 'Other' },
-      ],
-    } as any);
-    mockedGcApi.listEvents.mockResolvedValueOnce([
-      { id: '1', summary: 'Me', start: { date: '2023-01-01' } } as any,
-      { id: '2', summary: 'Other', start: { date: '2023-01-02' } } as any,
-      { id: '3', summary: 'Meeting', start: { date: '2023-01-03' } } as any,
-    ]);
-
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Routes>
-          <Route element={<PageTemplate />}>
-            <Route path="/" element={<Dashboard />} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
-
-    expect(await screen.findByText('Me')).toBeInTheDocument();
-    expect(await screen.findByText('Meeting')).toBeInTheDocument();
-    expect(screen.queryByText('Other')).not.toBeInTheDocument();
-  });
-
-  it('hides events outside the current week', async () => {
-    useAuthStore.getState().setUser({ id: '1', nome: 'Me', email: 'me@e' });
-    const today = new Date();
-    const inWeek = today.toISOString().split('T')[0];
-    const outside = new Date(today.getTime() + 14 * 864e5)
-      .toISOString()
-      .split('T')[0];
-    mockedGcApi.listEvents.mockResolvedValueOnce([
-      { id: '1', summary: 'In', start: { date: inWeek } } as any,
-      { id: '2', summary: 'Out', start: { date: outside } } as any,
-    ]);
-
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <Routes>
-          <Route element={<PageTemplate />}>
-            <Route path="/" element={<Dashboard />} />
-          </Route>
-        </Routes>
-      </MemoryRouter>
-    );
-
-    expect(await screen.findByText('In')).toBeInTheDocument();
-    expect(screen.queryByText('Out')).not.toBeInTheDocument();
+    const iframe = screen.getByTitle('Calendario');
+    expect(iframe).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- embed a Google Calendar iframe directly in Dashboard
- remove unused DashboardCalendar component from Dashboard
- simplify dashboard tests for iframe

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686ee79f0e58832380eea1bc75958f8e