### PR TITLE
Rename third schedule slot to Straordinario

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export. The schedule page also includes a **PDF settimana** button that calls
 ## Schedule
 
 The schedule page lets you create shifts with up to three optional time slots.
-`Slot 1`, `Slot 2` and `Slot 3` can be left empty. When either **Inizio1** or
+`Slot 1`, `Slot 2` and `Straordinario` can be left empty. When either **Inizio1** or
 **Fine1** is blank, that slot is not saved. The same rule applies to the other
 slots.
 

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -474,7 +474,7 @@ export default function SchedulePage() {
         />
 
         <SlotInput
-          label="Slot 3 (facoltativo)"
+          label="Straordinario (facoltativo)"
           startValue={s3Start}
           endValue={s3End}
           onStartChange={e => setS3Start(e.target.value)}
@@ -602,7 +602,7 @@ export default function SchedulePage() {
                 <th>Tipo</th>
                 <th>Slot 1</th>
                 <th>Slot 2</th>
-                <th>Slot 3</th>
+                <th>Straordinario</th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- rename third slot label on the schedule page
- adjust schedule table header
- update documentation accordingly

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6870255a560c8323b4088df49f36c4f5