### PR TITLE
Filter Google events

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -320,7 +320,7 @@ export default function EventsPage() {
           </tr>
         </thead>
         <tbody>
-          {events.map(ev => (
+          {events.filter(ev => ev.source === 'db').map(ev => (
             <tr key={`${ev.source}-${ev.id}`}>
               <td>{ev.title}</td>
               <td className="digit-font">{new Date(ev.dateTime).toLocaleString()}</td>

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -51,5 +51,31 @@ describe('Dashboard', () => {
     expect(screen.getByRole('button', { name: /Aggiorna calendario/i })).toBeInTheDocument();
   });
 
+  it('shows Google events for the current week only', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-03T10:00:00Z'));
+    localStorage.setItem(
+      'events',
+      JSON.stringify([
+        { id: '1', title: 'DB', description: '', dateTime: '2023-05-04T10:00:00Z', isPublic: true, source: 'db' },
+        { id: '2', title: 'GC week', description: '', dateTime: '2023-05-05T10:00:00Z', isPublic: true, source: 'gc' },
+        { id: '3', title: 'GC next', description: '', dateTime: '2023-05-12T10:00:00Z', isPublic: true, source: 'gc' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/GC week/)).toBeInTheDocument();
+    expect(screen.queryByText(/DB/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/GC next/)).not.toBeInTheDocument();
+  });
+
 });
 

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -50,6 +50,7 @@ describe('EventsPage', () => {
           description: 'desc',
           dateTime: '2023-01-01T10:00',
           isPublic: true,
+          source: 'db',
         },
       ])
     );
@@ -75,9 +76,9 @@ describe('EventsPage', () => {
     localStorage.setItem(
       getUserStorageKey('events', token),
       JSON.stringify([
-        { id: '1', title: 'Mine', description: '', dateTime: '2023-01-01T10:00', isPublic: false, owner_id: '123' },
-        { id: '2', title: 'Other', description: '', dateTime: '2023-01-02T10:00', isPublic: false, owner_id: '456' },
-        { id: '3', title: 'Public', description: '', dateTime: '2023-01-03T10:00', isPublic: true, owner_id: '456' },
+        { id: '1', title: 'Mine', description: '', dateTime: '2023-01-01T10:00', isPublic: false, owner_id: '123', source: 'db' },
+        { id: '2', title: 'Other', description: '', dateTime: '2023-01-02T10:00', isPublic: false, owner_id: '456', source: 'db' },
+        { id: '3', title: 'Public', description: '', dateTime: '2023-01-03T10:00', isPublic: true, owner_id: '456', source: 'db' },
       ])
     );
 


### PR DESCRIPTION
## Summary
- ignore Google events on Events page
- show Google events only on Dashboard and filter to current week
- adjust tests for new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870297a538c8323b522bef0f5ab43b2