### PR TITLE
Use agent name in Calendar summaries

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -10,7 +10,7 @@ describe('createShiftEvents', () => {
 
   it('creates an event for each slot', async () => {
     const ids = await createShiftEvents('cal', {
-      userEmail: 'u@e',
+      nome: 'u',
       giorno: '2023-05-01',
       slot1: { inizio: '08:00', fine: '09:00' },
       slot2: { inizio: '10:00', fine: '11:00' },
@@ -23,7 +23,7 @@ describe('createShiftEvents', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
-          summary: 'u@e',
+          summary: 'turno u',
           description: 'note',
           start: { dateTime: new Date('2023-05-01T08:00:00').toISOString() },
           end: { dateTime: new Date('2023-05-01T09:00:00').toISOString() },
@@ -37,7 +37,7 @@ describe('createShiftEvents', () => {
     fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve({ id: '1' }) })
 
     const ids = await createShiftEvents('cal', {
-      userEmail: 'u@e',
+      nome: 'u',
       giorno: '2023-05-02',
       slot2: { inizio: '10:00', fine: '11:00' },
     })
@@ -48,7 +48,7 @@ describe('createShiftEvents', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
-          summary: 'u@e',
+          summary: 'turno u',
           description: undefined,
           start: { dateTime: new Date('2023-05-02T10:00:00').toISOString() },
           end: { dateTime: new Date('2023-05-02T11:00:00').toISOString() },

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -150,7 +150,7 @@ export const deleteEvent = async (
 }
 
 export interface ShiftData {
-  userEmail: string
+  nome: string
   giorno: string
   slot1?: { inizio: string; fine: string }
   slot2?: { inizio: string; fine: string }
@@ -170,7 +170,7 @@ export const createShiftEvents = async (
 
   for (const slot of slots) {
     const res = await createEvent(calendarId, {
-      summary: turno.userEmail,
+      summary: `turno ${turno.nome}`,
       description: turno.note,
       start: {
         dateTime: new Date(`${turno.giorno}T${slot.inizio}:00`).toISOString(),

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -162,9 +162,11 @@ export default function SchedulePage() {
               const ferieLike = ['FERIE', 'RIPOSO', 'FESTIVO', 'RECUPERO'].includes(t.tipo);
               if (ferieLike) continue;
               try {
-                const email = utenti.find(u => u.id === t.user_id)?.email || '';
+                const nome =
+                  utenti.find(u => u.id === t.user_id)?.nome ||
+                  stripDomain(utenti.find(u => u.id === t.user_id)?.email || '');
                 const shift: ShiftData = {
-                  userEmail: email,
+                  nome,
                   giorno: t.giorno.format('YYYY-MM-DD'),
                   note: t.note,
                 };
@@ -314,9 +316,11 @@ export default function SchedulePage() {
     let eventIds = editing?.eventIds;
       if (signedIn && !ferieLike) {
         try {
-          const email = utenti.find(u => u.id === data.user_id)?.email || '';
+          const nome =
+            utenti.find(u => u.id === data.user_id)?.nome ||
+            stripDomain(utenti.find(u => u.id === data.user_id)?.email || '');
           const shift: ShiftData = {
-            userEmail: email,
+            nome,
             giorno: data.giorno.format('YYYY-MM-DD'),
             note: data.note,
           };
@@ -342,7 +346,7 @@ export default function SchedulePage() {
           const slots = [shift.slot1, shift.slot2, shift.slot3].filter(Boolean) as any[];
           for (let i = 0; i < Math.min(eventIds.length, slots.length); i++) {
             await updateEvent(calendarId, eventIds[i], {
-              summary: shift.userEmail,
+              summary: `turno ${shift.nome}`,
               description: shift.note,
               start: {
                 dateTime: new Date(

--- a/src/pages/__tests__/SchedulePage.test.tsx
+++ b/src/pages/__tests__/SchedulePage.test.tsx
@@ -233,7 +233,7 @@ describe('SchedulePage', () => {
     })
     expect((inputs[0] as HTMLInputElement).value).toBe('')
     expect(mockedGcApi.createShiftEvents).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
-      userEmail: 'u@e',
+      nome: 'u',
       giorno: '2023-05-02',
     }))
   })


### PR DESCRIPTION
## Summary
- use `nome` in `ShiftData` and prefix `turno` in event summaries
- propagate the `nome` field when creating or updating shift events
- update tests accordingly

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687030724bf48323bd9818e3d384d612