### PR TITLE
Switch to TikTok Sans for global fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,9 +24,9 @@
       href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap"
       rel="stylesheet"
     />
-    <!-- Roboto Mono font for numbers -->
+    <!-- TikTok Sans font -->
     <link
-      href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap"
+      href="https://sf16-sg.tiktokcdn.com/obj/eden-sg/tiktok-site/font/TikTokSans.css"
       rel="stylesheet"
     />
 

--- a/src/index.css
+++ b/src/index.css
@@ -7,22 +7,22 @@
 
 body {
   margin: 0;
-  font-family: 'Cormorant Garamond', serif;
+  font-family: 'TikTok Sans', sans-serif;
   font-weight: bold;
   color: #333;
   background: url('/Login.png') no-repeat center/cover fixed;
 }
 body.login-bg {
   background-size: contain;
-  font-family: 'Almendra SC', serif;
+  font-family: 'TikTok Sans', sans-serif;
 }
 
-/* Use Cormorant Garamond for all input elements */
+/* Use TikTok Sans for all input elements */
 input,
 textarea,
 select,
 button {
-  font-family: 'Cormorant Garamond', serif;
+  font-family: 'TikTok Sans', sans-serif;
 }
 
 
@@ -180,12 +180,12 @@ label {
 .digit-font,
 input[type="number"],
 input[type="datetime-local"] {
-  font-family: 'Roboto Mono', monospace;
+  font-family: 'TikTok Sans', sans-serif;
 }
 
 /* Override font for date inputs */
 input[type="date"] {
-  font-family: 'Cormorant Garamond', serif;
+  font-family: 'TikTok Sans', sans-serif;
 }
 
 .desc-cell {

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -1,3 +1,8 @@
+.dashboard,
+.dashboard * {
+  font-family: 'Cormorant Garamond', serif;
+}
+
 .dashboard {
   display: flex;
   flex-direction: column;

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -525,7 +525,7 @@ export default function SchedulePage() {
         {deleteError && <p className="error">{deleteError}</p>}
         <table className="item-table">
           <thead>
-            <tr style={{ fontFamily: 'Cormorant Garamond, serif', color: '#000' }}>
+            <tr style={{ fontFamily: 'TikTok Sans, sans-serif', color: '#000' }}>
               <th>Utente</th>
               <th>Data</th>
               <th>Mattino (inizio)</th>


### PR DESCRIPTION
## Summary
- remove Roboto Mono font link
- load TikTok Sans font from TikTok CDN
- use TikTok Sans globally in `index.css`
- keep dashboard using Cormorant Garamond
- update schedule table style to use TikTok Sans

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_687032311e5c8323afcc99b9a397da53