### PR TITLE
Sort tasks and events by due date

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -326,7 +326,12 @@ export default function EventsPage() {
           </tr>
         </thead>
         <tbody>
-          {events.filter(ev => ev.source === 'db').map(ev => (
+          {events
+            .filter(ev => ev.source === 'db')
+            .sort((a, b) =>
+              new Date(a.dateTime).getTime() - new Date(b.dateTime).getTime(),
+            )
+            .map(ev => (
             <tr key={`${ev.source}-${ev.id}`}>
               <td>{ev.title}</td>
               <td className="digit-font">{new Date(ev.dateTime).toLocaleString()}</td>

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -160,7 +160,11 @@ export default function TodoPage() {
           </tr>
         </thead>
         <tbody>
-          {todos.map(t => (
+          {[...todos]
+            .sort((a, b) =>
+              new Date(a.due).getTime() - new Date(b.due).getTime(),
+            )
+            .map(t => (
             <tr key={t.id}>
               <td className="desc-cell">{t.text}</td>
               <td className="digit-font">{new Date(t.due).toLocaleDateString()}</td>


### PR DESCRIPTION
## Summary
- order todos by `due` date ascending
- order events by `dateTime` ascending

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870bd3c1f888323bd2e165378c49cc0