### PR TITLE
Add agent color mapping for Google Calendar events

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -80,6 +80,26 @@ describe('createShiftEvents', () => {
       }),
     )
   })
+
+  it('maps nome to colorId', async () => {
+    fetchMock.mockResolvedValueOnce({ json: () => Promise.resolve({ id: '1' }) })
+
+    await createShiftEvents('cal', {
+      nome: 'Ag.Sc. Fenaroli Marco',
+      giorno: '2023-05-04',
+      slot1: { inizio: '08:00', fine: '09:00' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.googleapis.com/calendar/v3/calendars/cal/events',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(
+          expect.objectContaining({ colorId: '10' })
+        ),
+      }),
+    )
+  })
 })
 
 describe('signIn', () => {

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -17,6 +17,12 @@ const COLOR_MAP: Record<TipoTurno, string> = {
   RECUPERO: '6',
 }
 
+const AGENT_COLOR_MAP: Record<string, string> = {
+  'Ag.Sc. Fenaroli Marco': '10',
+  'Ag.Sc. Danesi Mattia': '6',
+  'Sovr. Licini Rossella': '1',
+}
+
 const getStoredToken = (): string | null => {
   if (typeof localStorage === 'undefined') return null
   const token = localStorage.getItem(ACCESS_TOKEN_KEY)
@@ -180,7 +186,10 @@ export const createShiftEvents = async (
     fine: string
   }[]
   const ids: string[] = []
-  const colorId = turno.colorId ?? (turno.tipo ? COLOR_MAP[turno.tipo] : undefined)
+  const colorId =
+    turno.colorId ??
+    AGENT_COLOR_MAP[turno.nome] ??
+    (turno.tipo ? COLOR_MAP[turno.tipo] : undefined)
 
   for (const slot of slots) {
     const res = await createEvent(calendarId, {


### PR DESCRIPTION
## Summary
- map specific agent names to static Google Calendar colorIds
- prefer mapped colorId when creating shift events
- test new mapping logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871568f60dc83238acc9b87b9eb5ce3