### PR TITLE
Display calendar colors on dashboard

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,16 @@
 export const DEFAULT_CALENDAR_ID = '9b868ea25bcd2be6f72fc415d45753a30abcc651070802054d21cfa9f5f97559@group.calendar.google.com';
 
+export const GOOGLE_COLOR_MAP: Record<string, string> = {
+  '1': '#a4bdfc',
+  '2': '#7ae7bf',
+  '3': '#dbadff',
+  '4': '#ff887c',
+  '5': '#fbd75b',
+  '6': '#ffb878',
+  '7': '#46d6db',
+  '8': '#e1e1e1',
+  '9': '#5484ed',
+  '10': '#51b749',
+  '11': '#dc2127',
+};
+

--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -48,6 +48,15 @@
   align-items: center;
 }
 
+.event-color-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid #ccc;
+  margin-right: 0.5rem;
+}
+
 .notifications li button {
   margin-left: 0.5rem;
   background: #A52019;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ import {
   endOfWeek,
   isWithinInterval,
 } from 'date-fns';
-import { DEFAULT_CALENDAR_ID } from '../constants';
+import { DEFAULT_CALENDAR_ID, GOOGLE_COLOR_MAP } from '../constants';
 
 interface EventItem {
   id: string;
@@ -19,6 +19,7 @@ interface EventItem {
   dateTime: string;
   isPublic: boolean;
   source?: 'gc' | 'db';
+  colorId?: string;
 }
 interface TodoItem { id: string; text: string; due: string; }
 
@@ -83,6 +84,12 @@ export default function Dashboard() {
             <ul>
               {upcomingEvents.map(e => (
                 <li key={e.id}>
+                  <span
+                    className="event-color-dot"
+                    style={{
+                      backgroundColor: e.colorId ? GOOGLE_COLOR_MAP[e.colorId] : 'transparent',
+                    }}
+                  />
                   Evento: {e.title} – {new Date(e.dateTime).toLocaleDateString()}
                 </li>
               ))}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -99,6 +99,7 @@ export default function EventsPage() {
             isPublic: ev.visibility === 'public',
             owner_id: currentUserId || undefined,
             source: 'gc',
+            colorId: ev.colorId,
           }));
           const dbEvents: UnifiedEvent[] = db
             .filter(ev =>


### PR DESCRIPTION
## Summary
- map google calendar color IDs to hex codes
- keep google colorId when loading events
- show colored dots in dashboard upcoming events
- style color dots

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715730eee88323b73b266eea4b6dd4