### PR TITLE
Support event colors

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -6,6 +6,7 @@ export interface DbEvent {
   titolo: string
   descrizione?: string
   data_ora: string
+  colorId?: string
   is_public?: boolean
   owner_id: string | null
 }

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -114,6 +114,7 @@ export default function EventsPage() {
               endDateTime: ev.data_ora,
               isPublic: !!ev.is_public,
               owner_id: ev.owner_id || undefined,
+              colorId: ev.colorId,
               source: 'db',
             }));
           const all = [...gcEvents, ...dbEvents];
@@ -161,12 +162,13 @@ export default function EventsPage() {
               end: { dateTime: endDateTime || dateTime },
             });
           } else {
-            await updateDbEvent(id, {
-              titolo: title,
-              descrizione: description,
-              data_ora: dateTime,
-              is_public: isPublic,
-            });
+          await updateDbEvent(id, {
+            titolo: title,
+            descrizione: description,
+            data_ora: dateTime,
+            is_public: isPublic,
+            ...(form.colorId ? { colorId: form.colorId } : {}),
+          });
           }
         } catch {
           if (source === 'gc') setCalendarError('Errore di accesso al calendario');
@@ -210,6 +212,7 @@ export default function EventsPage() {
             descrizione: description,
             data_ora: dateTime,
             is_public: isPublic,
+            ...(form.colorId ? { colorId: form.colorId } : {}),
           });
           dbEvent = {
             id: res.id,


### PR DESCRIPTION
## Summary
- add optional `colorId` to database events API
- propagate `colorId` when fetching and saving events

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716130f3908323a87a1eff841e6477