### PR TITLE
Fix dashboard events key

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -29,7 +29,15 @@ export default function Dashboard() {
     () => getUserStorageKey('todos', token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null)),
     [token]
   );
-  const [events] = useLocalStorage<EventItem[]>('events', []);
+  const eventsKey = useMemo(
+    () =>
+      getUserStorageKey(
+        'events',
+        token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null),
+      ),
+    [token],
+  );
+  const [events] = useLocalStorage<EventItem[]>(eventsKey, []);
   const [todos, setTodos] = useLocalStorage<TodoItem[]>(todoKey, []);
   const CALENDAR_ID =
     import.meta.env.VITE_DASHBOARD_CALENDAR_ID ||


### PR DESCRIPTION
## Summary
- synchronize Dashboard events with the same storage key used by the Events page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871687225a08323ac7ab57a2af9d2bf