### PR TITLE
Add timezone offset for Google Calendar events

### DIFF
--- a/src/api/__tests__/googleCalendar.test.ts
+++ b/src/api/__tests__/googleCalendar.test.ts
@@ -1,4 +1,4 @@
-import { createShiftEvents, signIn } from '../googleCalendar'
+import { createShiftEvents, signIn, formatDateTime } from '../googleCalendar'
 
 describe('createShiftEvents', () => {
   const fetchMock = jest.fn()
@@ -26,8 +26,8 @@ describe('createShiftEvents', () => {
         body: JSON.stringify({
           summary: 'turno u',
           description: 'note',
-          start: { dateTime: new Date('2023-05-01T08:00:00').toISOString() },
-          end: { dateTime: new Date('2023-05-01T09:00:00').toISOString() },
+          start: { dateTime: formatDateTime('2023-05-01T08:00:00') },
+          end: { dateTime: formatDateTime('2023-05-01T09:00:00') },
           colorId: '5',
         }),
       }),
@@ -52,8 +52,8 @@ describe('createShiftEvents', () => {
         body: JSON.stringify({
           summary: 'turno u',
           description: undefined,
-          start: { dateTime: new Date('2023-05-02T10:00:00').toISOString() },
-          end: { dateTime: new Date('2023-05-02T11:00:00').toISOString() },
+          start: { dateTime: formatDateTime('2023-05-02T10:00:00') },
+          end: { dateTime: formatDateTime('2023-05-02T11:00:00') },
         }),
       }),
     )

--- a/src/api/googleCalendar.ts
+++ b/src/api/googleCalendar.ts
@@ -23,6 +23,21 @@ const AGENT_COLOR_MAP: Record<string, string> = {
   'Sovr. Licini Rossella': '1',
 }
 
+export const formatDateTime = (local: string): string => {
+  const d = new Date(local)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const h = String(d.getHours()).padStart(2, '0')
+  const min = String(d.getMinutes()).padStart(2, '0')
+  const s = String(d.getSeconds()).padStart(2, '0')
+  const off = -d.getTimezoneOffset()
+  const sign = off >= 0 ? '+' : '-'
+  const offH = String(Math.floor(Math.abs(off) / 60)).padStart(2, '0')
+  const offM = String(Math.abs(off) % 60).padStart(2, '0')
+  return `${y}-${m}-${day}T${h}:${min}:${s}${sign}${offH}:${offM}`
+}
+
 const getStoredToken = (): string | null => {
   if (typeof localStorage === 'undefined') return null
   const token = localStorage.getItem(ACCESS_TOKEN_KEY)
@@ -196,10 +211,10 @@ export const createShiftEvents = async (
       summary: `turno ${turno.nome}`,
       description: turno.note,
       start: {
-        dateTime: new Date(`${turno.giorno}T${slot.inizio}:00`).toISOString(),
+        dateTime: formatDateTime(`${turno.giorno}T${slot.inizio}:00`),
       },
       end: {
-        dateTime: new Date(`${turno.giorno}T${slot.fine}:00`).toISOString(),
+        dateTime: formatDateTime(`${turno.giorno}T${slot.fine}:00`),
       },
       ...(colorId ? { colorId } : {}),
     })

--- a/src/pages/SchedulePage.tsx
+++ b/src/pages/SchedulePage.tsx
@@ -11,6 +11,7 @@ import {
   createShiftEvents,
   updateEvent,
   deleteEvent,
+  formatDateTime,
   ShiftData,
   signIn,
 } from '../api/googleCalendar';
@@ -351,14 +352,14 @@ export default function SchedulePage() {
               summary: `turno ${shift.nome}`,
               description: shift.note,
               start: {
-                dateTime: new Date(
+                dateTime: formatDateTime(
                   `${shift.giorno}T${slots[i].inizio}:00`,
-                ).toISOString(),
+                ),
               },
               end: {
-                dateTime: new Date(
+                dateTime: formatDateTime(
                   `${shift.giorno}T${slots[i].fine}:00`,
-                ).toISOString(),
+                ),
               },
             });
           }


### PR DESCRIPTION
## Summary
- export `formatDateTime` helper for producing timezone-aware date strings
- send shift events to Google Calendar using this new format
- update schedule page to call `formatDateTime` when editing shifts
- adjust calendar API unit tests to expect the new format

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687169c2830c8323ae65f706d0923b27