### PR TITLE
Handle numeric user ids

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -81,8 +81,10 @@ export default function EventsPage() {
       const rawToken =
         token || (typeof localStorage !== 'undefined' ? localStorage.getItem('token') : null);
       const decoded = rawToken ? decodeToken(rawToken) : null;
+      const rawCurrentUserId =
+        decoded?.sub ?? decoded?.user_id ?? decoded?.id ?? decoded?.email ?? null;
       const currentUserId =
-        decoded?.sub || decoded?.user_id || decoded?.id || decoded?.email || null;
+        rawCurrentUserId != null ? String(rawCurrentUserId) : null;
       if (navigator.onLine) {
         try {
           await signIn();
@@ -104,7 +106,9 @@ export default function EventsPage() {
           const dbEvents: UnifiedEvent[] = db
             .filter(ev =>
               ev.is_public === true ||
-              (currentUserId ? ev.owner_id === currentUserId : false)
+              (currentUserId
+                ? String(ev.owner_id) === String(currentUserId)
+                : false)
             )
             .map((ev: DbEvent) => ({
               id: ev.id,
@@ -130,7 +134,10 @@ export default function EventsPage() {
         try {
           const parsed = JSON.parse(stored) as UnifiedEvent[];
           const filtered = parsed.filter(ev =>
-            ev.isPublic || (currentUserId ? ev.owner_id === currentUserId : false)
+            ev.isPublic ||
+            (currentUserId
+              ? String(ev.owner_id) === String(currentUserId)
+              : false)
           );
           setEvents(filtered);
         } catch {

--- a/src/pages/__tests__/EventsPage.test.tsx
+++ b/src/pages/__tests__/EventsPage.test.tsx
@@ -97,6 +97,33 @@ describe('EventsPage', () => {
     expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
 
+  it('handles numeric owner_id values', async () => {
+    const header = Buffer.from('{}').toString('base64');
+    const payload = Buffer.from(JSON.stringify({ sub: 123 })).toString('base64');
+    const token = `${header}.${payload}.sig`;
+    localStorage.setItem('token', token);
+    localStorage.setItem(
+      getUserStorageKey('events', token),
+      JSON.stringify([
+        { id: '1', title: 'Mine', description: '', dateTime: '2023-01-01T10:00', isPublic: false, owner_id: 123, source: 'db' },
+        { id: '2', title: 'Other', description: '', dateTime: '2023-01-02T10:00', isPublic: false, owner_id: 999, source: 'db' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/events']}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/events" element={<EventsPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Mine')).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
+  });
+
   it('adds new event offline', async () => {
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 

--- a/src/utils/__tests__/auth.test.ts
+++ b/src/utils/__tests__/auth.test.ts
@@ -51,4 +51,11 @@ describe('getUserId', () => {
     const token = `${header}.${payload}.sig`;
     expect(getUserId(token)).toBe('me@example.com');
   });
+
+  it('returns string when id is numeric', () => {
+    const header = Buffer.from('{}').toString('base64');
+    const payload = Buffer.from(JSON.stringify({ sub: 42 })).toString('base64');
+    const token = `${header}.${payload}.sig`;
+    expect(getUserId(token)).toBe('42');
+  });
 });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -22,12 +22,12 @@ export function getUserId(token: string | null): string | null {
   if (!token) return null;
   const decoded = decodeToken(token);
   const id = decoded?.sub ?? decoded?.user_id ?? decoded?.id ?? decoded?.email;
-  return id ?? null;
+  return id == null ? null : String(id);
 }
 
 export function getUserStorageKey(prefix: string, token: string | null): string {
   if (!token) return prefix;
   const decoded = decodeToken(token);
   const id = decoded?.sub ?? decoded?.user_id ?? decoded?.id ?? decoded?.email;
-  return id ? `${prefix}_${id}` : prefix;
+  return id != null ? `${prefix}_${String(id)}` : prefix;
 }


### PR DESCRIPTION
## Summary
- handle numeric ids in `getUserId` and `getUserStorageKey`
- filter events using stringified ids
- test numeric IDs in auth utils
- test numeric owner_id on EventsPage

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876796619bc8323a83423a951e8a87a