### PR TITLE
Add inventory management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ value entered must be a valid time string or the backend will reject that row.
 The dashboard calendar shows Google Calendar events for the current week only.
 Events are fetched from the ID defined in `VITE_DASHBOARD_CALENDAR_ID`.
 
+## Inventory
+
+Visit `/inventario` to manage devices and road signage. The page lets you
+create, edit and search devices, temporary signage and vertical/horizontal
+signage. Horizontal signage includes a **PDF anno** button that calls
+`/inventario/signage-horizontal/pdf?year=YYYY` and downloads the generated PDF.
+
 ## Testing
 
 Before running tests, install dependencies if you haven't already:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ const DeterminationsPage = React.lazy(() => import("./pages/DeterminationsPage")
 const UtilitaPage = React.lazy(() => import("./pages/UtilitaPage"));
 const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
 const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
+const InventoryPage = React.lazy(() => import("./pages/InventoryPage"));
 
 
 const App: React.FC = () => {
@@ -45,6 +46,7 @@ const App: React.FC = () => {
           <Route path="/pdfs" element={<PdfFilesPage />} />
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
+          <Route path="/inventario" element={<InventoryPage />} />
         </Route>
 
         {/* Qualunque altra rotta redirige alla dashboard */}

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -1,0 +1,22 @@
+import api from './axios'
+
+export interface Device {
+  id: string
+  nome: string
+  note?: string
+}
+
+export const listDevices = (): Promise<Device[]> =>
+  api.get<Device[]>('/inventario/devices').then(r => r.data)
+
+export const createDevice = (data: Omit<Device, 'id'>): Promise<Device> =>
+  api.post<Device>('/inventario/devices', data).then(r => r.data)
+
+export const updateDevice = (
+  id: string,
+  data: Partial<Omit<Device, 'id'>>,
+): Promise<Device> =>
+  api.put<Device>(`/inventario/devices/${id}`, data).then(r => r.data)
+
+export const deleteDevice = (id: string): Promise<void> =>
+  api.delete(`/inventario/devices/${id}`).then(() => undefined)

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -1,0 +1,30 @@
+import api from './axios'
+
+export interface HorizontalSign {
+  id: string
+  luogo: string
+  data: string
+  descrizione?: string
+}
+
+export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
+  api.get<HorizontalSign[]>('/inventario/signage-horizontal').then(r => r.data)
+
+export const createHorizontalSignage = (
+  data: Omit<HorizontalSign, 'id'>,
+): Promise<HorizontalSign> =>
+  api.post<HorizontalSign>('/inventario/signage-horizontal', data).then(r => r.data)
+
+export const updateHorizontalSignage = (
+  id: string,
+  data: Partial<Omit<HorizontalSign, 'id'>>,
+): Promise<HorizontalSign> =>
+  api.put<HorizontalSign>(`/inventario/signage-horizontal/${id}`, data).then(r => r.data)
+
+export const deleteHorizontalSignage = (id: string): Promise<void> =>
+  api.delete(`/inventario/signage-horizontal/${id}`).then(() => undefined)
+
+export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
+  api
+    .get('/inventario/signage-horizontal/pdf', { params: { year }, responseType: 'blob' })
+    .then(r => r.data)

--- a/src/api/temporarySignage.ts
+++ b/src/api/temporarySignage.ts
@@ -1,0 +1,25 @@
+import api from './axios'
+
+export interface TemporarySign {
+  id: string
+  luogo: string
+  fine_validita: string
+  note?: string
+}
+
+export const listTemporarySignage = (): Promise<TemporarySign[]> =>
+  api.get<TemporarySign[]>('/inventario/signage-temp').then(r => r.data)
+
+export const createTemporarySignage = (
+  data: Omit<TemporarySign, 'id'>,
+): Promise<TemporarySign> =>
+  api.post<TemporarySign>('/inventario/signage-temp', data).then(r => r.data)
+
+export const updateTemporarySignage = (
+  id: string,
+  data: Partial<Omit<TemporarySign, 'id'>>,
+): Promise<TemporarySign> =>
+  api.put<TemporarySign>(`/inventario/signage-temp/${id}`, data).then(r => r.data)
+
+export const deleteTemporarySignage = (id: string): Promise<void> =>
+  api.delete(`/inventario/signage-temp/${id}`).then(() => undefined)

--- a/src/api/verticalSignage.ts
+++ b/src/api/verticalSignage.ts
@@ -1,0 +1,24 @@
+import api from './axios'
+
+export interface VerticalSign {
+  id: string
+  luogo: string
+  descrizione: string
+}
+
+export const listVerticalSignage = (): Promise<VerticalSign[]> =>
+  api.get<VerticalSign[]>('/inventario/signage-vertical').then(r => r.data)
+
+export const createVerticalSignage = (
+  data: Omit<VerticalSign, 'id'>,
+): Promise<VerticalSign> =>
+  api.post<VerticalSign>('/inventario/signage-vertical', data).then(r => r.data)
+
+export const updateVerticalSignage = (
+  id: string,
+  data: Partial<Omit<VerticalSign, 'id'>>,
+): Promise<VerticalSign> =>
+  api.put<VerticalSign>(`/inventario/signage-vertical/${id}`, data).then(r => r.data)
+
+export const deleteVerticalSignage = (id: string): Promise<void> =>
+  api.delete(`/inventario/signage-vertical/${id}`).then(() => undefined)

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,6 +29,7 @@ const Header: React.FC = () => {
           <Link to="/todo">📝 To-Do</Link>
           <Link to="/orari">🕑 Orari</Link>
           <Link to="/determinazioni">📄 Determine</Link>
+          <Link to="/inventario">📦 Inventario</Link>
           <Link to="/utilita">🤝 Riunioni</Link>
           <button onClick={logout} aria-label="Esci">🚪 esci</button>
         </nav>

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState } from 'react'
+import './ListPages.css'
+import {
+  listDevices,
+  createDevice,
+  updateDevice,
+  deleteDevice,
+  Device,
+} from '../api/devices'
+import {
+  listTemporarySignage,
+  createTemporarySignage,
+  updateTemporarySignage,
+  deleteTemporarySignage,
+  TemporarySign,
+} from '../api/temporarySignage'
+import {
+  listVerticalSignage,
+  createVerticalSignage,
+  updateVerticalSignage,
+  deleteVerticalSignage,
+  VerticalSign,
+} from '../api/verticalSignage'
+import {
+  listHorizontalSignage,
+  createHorizontalSignage,
+  updateHorizontalSignage,
+  deleteHorizontalSignage,
+  getHorizontalSignagePdf,
+  HorizontalSign,
+} from '../api/horizontalSignage'
+
+const InventoryPage: React.FC = () => {
+  const [devices, setDevices] = useState<Device[]>([])
+  const [devName, setDevName] = useState('')
+  const [devNotes, setDevNotes] = useState('')
+  const [devSearch, setDevSearch] = useState('')
+  const [devEdit, setDevEdit] = useState<string | null>(null)
+
+  const [temps, setTemps] = useState<TemporarySign[]>([])
+  const [tempLuogo, setTempLuogo] = useState('')
+  const [tempFine, setTempFine] = useState('')
+  const [tempSearch, setTempSearch] = useState('')
+  const [tempEdit, setTempEdit] = useState<string | null>(null)
+
+  const [verticals, setVerticals] = useState<VerticalSign[]>([])
+  const [vertLuogo, setVertLuogo] = useState('')
+  const [vertDesc, setVertDesc] = useState('')
+  const [vertSearch, setVertSearch] = useState('')
+  const [vertEdit, setVertEdit] = useState<string | null>(null)
+
+  const [horizontals, setHorizontals] = useState<HorizontalSign[]>([])
+  const [horLuogo, setHorLuogo] = useState('')
+  const [horData, setHorData] = useState('')
+  const [horSearch, setHorSearch] = useState('')
+  const [horEdit, setHorEdit] = useState<string | null>(null)
+  const [pdfYear, setPdfYear] = useState('')
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        const d = await listDevices()
+        setDevices(d)
+        localStorage.setItem('devices', JSON.stringify(d))
+      } catch {
+        const stored = localStorage.getItem('devices')
+        if (stored) setDevices(JSON.parse(stored))
+      }
+
+      try {
+        const t = await listTemporarySignage()
+        setTemps(t)
+        localStorage.setItem('temps', JSON.stringify(t))
+      } catch {
+        const stored = localStorage.getItem('temps')
+        if (stored) setTemps(JSON.parse(stored))
+      }
+
+      try {
+        const v = await listVerticalSignage()
+        setVerticals(v)
+        localStorage.setItem('verticals', JSON.stringify(v))
+      } catch {
+        const stored = localStorage.getItem('verticals')
+        if (stored) setVerticals(JSON.parse(stored))
+      }
+
+      try {
+        const h = await listHorizontalSignage()
+        setHorizontals(h)
+        localStorage.setItem('horizontals', JSON.stringify(h))
+      } catch {
+        const stored = localStorage.getItem('horizontals')
+        if (stored) setHorizontals(JSON.parse(stored))
+      }
+    }
+    fetchAll()
+  }, [])
+
+  const saveDevices = (d: Device[]) => localStorage.setItem('devices', JSON.stringify(d))
+  const saveTemps = (t: TemporarySign[]) => localStorage.setItem('temps', JSON.stringify(t))
+  const saveVerticals = (v: VerticalSign[]) => localStorage.setItem('verticals', JSON.stringify(v))
+  const saveHorizontals = (h: HorizontalSign[]) => localStorage.setItem('horizontals', JSON.stringify(h))
+
+  const resetDevice = () => { setDevName(''); setDevNotes(''); setDevEdit(null) }
+  const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempEdit(null) }
+  const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertEdit(null) }
+  const resetHor = () => { setHorLuogo(''); setHorData(''); setHorEdit(null) }
+
+  const submitDevice = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!devName) return
+    if (devEdit) {
+      const res = await updateDevice(devEdit, { nome: devName, note: devNotes })
+      const updated = devices.map(d => d.id === devEdit ? res : d)
+      setDevices(updated)
+      saveDevices(updated)
+    } else {
+      const res = await createDevice({ nome: devName, note: devNotes })
+      const updated = [...devices, res]
+      setDevices(updated)
+      saveDevices(updated)
+    }
+    resetDevice()
+  }
+
+  const submitTemp = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!tempLuogo || !tempFine) return
+    if (tempEdit) {
+      const res = await updateTemporarySignage(tempEdit, { luogo: tempLuogo, fine_validita: tempFine, note: '' })
+      const updated = temps.map(t => t.id === tempEdit ? res : t)
+      setTemps(updated)
+      saveTemps(updated)
+    } else {
+      const res = await createTemporarySignage({ luogo: tempLuogo, fine_validita: tempFine, note: '' })
+      const updated = [...temps, res]
+      setTemps(updated)
+      saveTemps(updated)
+    }
+    resetTemp()
+  }
+
+  const submitVert = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!vertLuogo || !vertDesc) return
+    if (vertEdit) {
+      const res = await updateVerticalSignage(vertEdit, { luogo: vertLuogo, descrizione: vertDesc })
+      const updated = verticals.map(v => v.id === vertEdit ? res : v)
+      setVerticals(updated)
+      saveVerticals(updated)
+    } else {
+      const res = await createVerticalSignage({ luogo: vertLuogo, descrizione: vertDesc })
+      const updated = [...verticals, res]
+      setVerticals(updated)
+      saveVerticals(updated)
+    }
+    resetVert()
+  }
+
+  const submitHor = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!horLuogo || !horData) return
+    if (horEdit) {
+      const res = await updateHorizontalSignage(horEdit, { luogo: horLuogo, data: horData })
+      const updated = horizontals.map(h => h.id === horEdit ? res : h)
+      setHorizontals(updated)
+      saveHorizontals(updated)
+    } else {
+      const res = await createHorizontalSignage({ luogo: horLuogo, data: horData })
+      const updated = [...horizontals, res]
+      setHorizontals(updated)
+      saveHorizontals(updated)
+    }
+    resetHor()
+  }
+
+  const onPdf = async () => {
+    if (!pdfYear) return
+    const blob = await getHorizontalSignagePdf(Number(pdfYear))
+    const url = URL.createObjectURL(blob)
+    window.open(url, '_blank')
+  }
+
+  return (
+    <div className="list-page">
+      <div>
+        <h2>Dispositivi</h2>
+        <form onSubmit={submitDevice} className="item-form">
+          <input data-testid="dev-name" placeholder="Nome" value={devName} onChange={e => setDevName(e.target.value)} />
+          <input data-testid="dev-notes" placeholder="Note" value={devNotes} onChange={e => setDevNotes(e.target.value)} />
+          <button data-testid="dev-submit" type="submit">{devEdit ? 'Salva' : 'Aggiungi'}</button>
+          {devEdit && <button data-testid="dev-cancel" type="button" onClick={resetDevice}>Annulla</button>}
+        </form>
+        <input placeholder="Cerca" value={devSearch} onChange={e => setDevSearch(e.target.value)} />
+        <table className="item-table">
+          <thead>
+            <tr><th>Nome</th><th>Note</th><th></th></tr>
+          </thead>
+          <tbody>
+            {devices.filter(d => d.nome.toLowerCase().includes(devSearch.toLowerCase())).map(d => (
+              <tr key={d.id}>
+                <td>{d.nome}</td>
+                <td>{d.note}</td>
+                <td>
+                  <button onClick={() => { setDevEdit(d.id); setDevName(d.nome); setDevNotes(d.note || '') }}>Modifica</button>
+                  <button onClick={async () => { await deleteDevice(d.id); const u = devices.filter(x => x.id !== d.id); setDevices(u); saveDevices(u) }}>Elimina</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h2>Segnaletica Temporanea</h2>
+        <form onSubmit={submitTemp} className="item-form">
+          <input data-testid="temp-luogo" placeholder="Luogo" value={tempLuogo} onChange={e => setTempLuogo(e.target.value)} />
+          <input data-testid="temp-fine" type="date" value={tempFine} onChange={e => setTempFine(e.target.value)} />
+          <button data-testid="temp-submit" type="submit">{tempEdit ? 'Salva' : 'Aggiungi'}</button>
+          {tempEdit && <button data-testid="temp-cancel" type="button" onClick={resetTemp}>Annulla</button>}
+        </form>
+        <input placeholder="Cerca" value={tempSearch} onChange={e => setTempSearch(e.target.value)} />
+        <table className="item-table">
+          <thead>
+            <tr><th>Luogo</th><th>Fine validità</th><th></th></tr>
+          </thead>
+          <tbody>
+            {temps.filter(t => t.luogo.toLowerCase().includes(tempSearch.toLowerCase())).map(t => (
+              <tr key={t.id}>
+                <td>{t.luogo}</td>
+                <td>{t.fine_validita}</td>
+                <td>
+                  <button onClick={() => { setTempEdit(t.id); setTempLuogo(t.luogo); setTempFine(t.fine_validita) }}>Modifica</button>
+                  <button onClick={async () => { await deleteTemporarySignage(t.id); const u = temps.filter(x => x.id !== t.id); setTemps(u); saveTemps(u) }}>Elimina</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h2>Segnaletica Verticale</h2>
+        <form onSubmit={submitVert} className="item-form">
+          <input data-testid="vert-luogo" placeholder="Luogo" value={vertLuogo} onChange={e => setVertLuogo(e.target.value)} />
+          <input data-testid="vert-desc" placeholder="Descrizione" value={vertDesc} onChange={e => setVertDesc(e.target.value)} />
+          <button data-testid="vert-submit" type="submit">{vertEdit ? 'Salva' : 'Aggiungi'}</button>
+          {vertEdit && <button data-testid="vert-cancel" type="button" onClick={resetVert}>Annulla</button>}
+        </form>
+        <input placeholder="Cerca" value={vertSearch} onChange={e => setVertSearch(e.target.value)} />
+        <table className="item-table">
+          <thead>
+            <tr><th>Luogo</th><th>Descrizione</th><th></th></tr>
+          </thead>
+          <tbody>
+            {verticals.filter(v => v.luogo.toLowerCase().includes(vertSearch.toLowerCase())).map(v => (
+              <tr key={v.id}>
+                <td>{v.luogo}</td>
+                <td>{v.descrizione}</td>
+                <td>
+                  <button onClick={() => { setVertEdit(v.id); setVertLuogo(v.luogo); setVertDesc(v.descrizione) }}>Modifica</button>
+                  <button onClick={async () => { await deleteVerticalSignage(v.id); const u = verticals.filter(x => x.id !== v.id); setVerticals(u); saveVerticals(u) }}>Elimina</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <h2>Segnaletica Orizzontale</h2>
+        <form onSubmit={submitHor} className="item-form">
+          <input data-testid="hor-luogo" placeholder="Luogo" value={horLuogo} onChange={e => setHorLuogo(e.target.value)} />
+          <input data-testid="hor-data" type="date" value={horData} onChange={e => setHorData(e.target.value)} />
+          <button data-testid="hor-submit" type="submit">{horEdit ? 'Salva' : 'Aggiungi'}</button>
+          {horEdit && <button data-testid="hor-cancel" type="button" onClick={resetHor}>Annulla</button>}
+        </form>
+        <input placeholder="Cerca" value={horSearch} onChange={e => setHorSearch(e.target.value)} />
+        <table className="item-table">
+          <thead>
+            <tr><th>Luogo</th><th>Data</th><th></th></tr>
+          </thead>
+          <tbody>
+            {horizontals.filter(h => h.luogo.toLowerCase().includes(horSearch.toLowerCase())).map(h => (
+              <tr key={h.id}>
+                <td>{h.luogo}</td>
+                <td>{h.data}</td>
+                <td>
+                  <button onClick={() => { setHorEdit(h.id); setHorLuogo(h.luogo); setHorData(h.data) }}>Modifica</button>
+                  <button onClick={async () => { await deleteHorizontalSignage(h.id); const u = horizontals.filter(x => x.id !== h.id); setHorizontals(u); saveHorizontals(u) }}>Elimina</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="pdf-controls">
+          <input data-testid="hor-year" placeholder="Anno" value={pdfYear} onChange={e => setPdfYear(e.target.value)} />
+          <button data-testid="hor-pdf" type="button" onClick={onPdf}>PDF anno</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default InventoryPage

--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import InventoryPage from '../InventoryPage'
+import PageTemplate from '../../components/PageTemplate'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+
+describe('InventoryPage', () => {
+  it('renders forms', () => {
+    render(
+      <MemoryRouter initialEntries={["/inventario"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/inventario" element={<InventoryPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('dev-name')).toBeInTheDocument()
+    expect(screen.getByTestId('temp-luogo')).toBeInTheDocument()
+    expect(screen.getByText(/Segnaletica Verticale/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add API modules for inventory endpoints
- create InventoryPage with forms and PDF download
- register new `/inventario` route and navigation link
- document inventory feature
- add basic InventoryPage test

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768e888d3c83239cdac7b40927e595