### PR TITLE
Update signage endpoints and forms

### DIFF
--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -5,26 +5,27 @@ export interface HorizontalSign {
   luogo: string
   data: string
   descrizione?: string
+  quantita?: number
 }
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
-  api.get<HorizontalSign[]>('/inventario/signage-horizontal').then(r => r.data)
+  api.get<HorizontalSign[]>('/segnaletica-orizzontale').then(r => r.data)
 
 export const createHorizontalSignage = (
   data: Omit<HorizontalSign, 'id'>,
 ): Promise<HorizontalSign> =>
-  api.post<HorizontalSign>('/inventario/signage-horizontal', data).then(r => r.data)
+  api.post<HorizontalSign>('/segnaletica-orizzontale', data).then(r => r.data)
 
 export const updateHorizontalSignage = (
   id: string,
   data: Partial<Omit<HorizontalSign, 'id'>>,
 ): Promise<HorizontalSign> =>
-  api.put<HorizontalSign>(`/inventario/signage-horizontal/${id}`, data).then(r => r.data)
+  api.put<HorizontalSign>(`/segnaletica-orizzontale/${id}`, data).then(r => r.data)
 
 export const deleteHorizontalSignage = (id: string): Promise<void> =>
-  api.delete(`/inventario/signage-horizontal/${id}`).then(() => undefined)
+  api.delete(`/segnaletica-orizzontale/${id}`).then(() => undefined)
 
 export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
   api
-    .get('/inventario/signage-horizontal/pdf', { params: { year }, responseType: 'blob' })
+    .get('/segnaletica-orizzontale/pdf', { params: { year }, responseType: 'blob' })
     .then(r => r.data)

--- a/src/api/temporarySignage.ts
+++ b/src/api/temporarySignage.ts
@@ -4,22 +4,24 @@ export interface TemporarySign {
   id: string
   luogo: string
   fine_validita: string
+  descrizione?: string
+  quantita?: number
   note?: string
 }
 
 export const listTemporarySignage = (): Promise<TemporarySign[]> =>
-  api.get<TemporarySign[]>('/inventario/signage-temp').then(r => r.data)
+  api.get<TemporarySign[]>('/segnaletica-temporanea').then(r => r.data)
 
 export const createTemporarySignage = (
   data: Omit<TemporarySign, 'id'>,
 ): Promise<TemporarySign> =>
-  api.post<TemporarySign>('/inventario/signage-temp', data).then(r => r.data)
+  api.post<TemporarySign>('/segnaletica-temporanea', data).then(r => r.data)
 
 export const updateTemporarySignage = (
   id: string,
   data: Partial<Omit<TemporarySign, 'id'>>,
 ): Promise<TemporarySign> =>
-  api.put<TemporarySign>(`/inventario/signage-temp/${id}`, data).then(r => r.data)
+  api.put<TemporarySign>(`/segnaletica-temporanea/${id}`, data).then(r => r.data)
 
 export const deleteTemporarySignage = (id: string): Promise<void> =>
-  api.delete(`/inventario/signage-temp/${id}`).then(() => undefined)
+  api.delete(`/segnaletica-temporanea/${id}`).then(() => undefined)

--- a/src/api/verticalSignage.ts
+++ b/src/api/verticalSignage.ts
@@ -4,21 +4,23 @@ export interface VerticalSign {
   id: string
   luogo: string
   descrizione: string
+  anno?: number
+  quantita?: number
 }
 
 export const listVerticalSignage = (): Promise<VerticalSign[]> =>
-  api.get<VerticalSign[]>('/inventario/signage-vertical').then(r => r.data)
+  api.get<VerticalSign[]>('/segnaletica-verticale').then(r => r.data)
 
 export const createVerticalSignage = (
   data: Omit<VerticalSign, 'id'>,
 ): Promise<VerticalSign> =>
-  api.post<VerticalSign>('/inventario/signage-vertical', data).then(r => r.data)
+  api.post<VerticalSign>('/segnaletica-verticale', data).then(r => r.data)
 
 export const updateVerticalSignage = (
   id: string,
   data: Partial<Omit<VerticalSign, 'id'>>,
 ): Promise<VerticalSign> =>
-  api.put<VerticalSign>(`/inventario/signage-vertical/${id}`, data).then(r => r.data)
+  api.put<VerticalSign>(`/segnaletica-verticale/${id}`, data).then(r => r.data)
 
 export const deleteVerticalSignage = (id: string): Promise<void> =>
-  api.delete(`/inventario/signage-vertical/${id}`).then(() => undefined)
+  api.delete(`/segnaletica-verticale/${id}`).then(() => undefined)

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -40,18 +40,24 @@ const InventoryPage: React.FC = () => {
   const [temps, setTemps] = useState<TemporarySign[]>([])
   const [tempLuogo, setTempLuogo] = useState('')
   const [tempFine, setTempFine] = useState('')
+  const [tempDesc, setTempDesc] = useState('')
+  const [tempQuant, setTempQuant] = useState('')
   const [tempSearch, setTempSearch] = useState('')
   const [tempEdit, setTempEdit] = useState<string | null>(null)
 
   const [verticals, setVerticals] = useState<VerticalSign[]>([])
   const [vertLuogo, setVertLuogo] = useState('')
   const [vertDesc, setVertDesc] = useState('')
+  const [vertAnno, setVertAnno] = useState('')
+  const [vertQuant, setVertQuant] = useState('')
   const [vertSearch, setVertSearch] = useState('')
   const [vertEdit, setVertEdit] = useState<string | null>(null)
 
   const [horizontals, setHorizontals] = useState<HorizontalSign[]>([])
   const [horLuogo, setHorLuogo] = useState('')
   const [horData, setHorData] = useState('')
+  const [horDesc, setHorDesc] = useState('')
+  const [horQuant, setHorQuant] = useState('')
   const [horSearch, setHorSearch] = useState('')
   const [horEdit, setHorEdit] = useState<string | null>(null)
   const [pdfYear, setPdfYear] = useState('')
@@ -103,9 +109,9 @@ const InventoryPage: React.FC = () => {
   const saveHorizontals = (h: HorizontalSign[]) => localStorage.setItem('horizontals', JSON.stringify(h))
 
   const resetDevice = () => { setDevName(''); setDevNotes(''); setDevEdit(null) }
-  const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempEdit(null) }
-  const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertEdit(null) }
-  const resetHor = () => { setHorLuogo(''); setHorData(''); setHorEdit(null) }
+  const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempDesc(''); setTempQuant(''); setTempEdit(null) }
+  const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertAnno(''); setVertQuant(''); setVertEdit(null) }
+  const resetHor = () => { setHorLuogo(''); setHorData(''); setHorDesc(''); setHorQuant(''); setHorEdit(null) }
 
   const submitDevice = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -128,12 +134,24 @@ const InventoryPage: React.FC = () => {
     e.preventDefault()
     if (!tempLuogo || !tempFine) return
     if (tempEdit) {
-      const res = await updateTemporarySignage(tempEdit, { luogo: tempLuogo, fine_validita: tempFine, note: '' })
+      const res = await updateTemporarySignage(tempEdit, {
+        luogo: tempLuogo,
+        fine_validita: tempFine,
+        descrizione: tempDesc,
+        quantita: tempQuant ? Number(tempQuant) : undefined,
+        note: ''
+      })
       const updated = temps.map(t => t.id === tempEdit ? res : t)
       setTemps(updated)
       saveTemps(updated)
     } else {
-      const res = await createTemporarySignage({ luogo: tempLuogo, fine_validita: tempFine, note: '' })
+      const res = await createTemporarySignage({
+        luogo: tempLuogo,
+        fine_validita: tempFine,
+        descrizione: tempDesc,
+        quantita: tempQuant ? Number(tempQuant) : undefined,
+        note: ''
+      })
       const updated = [...temps, res]
       setTemps(updated)
       saveTemps(updated)
@@ -145,12 +163,22 @@ const InventoryPage: React.FC = () => {
     e.preventDefault()
     if (!vertLuogo || !vertDesc) return
     if (vertEdit) {
-      const res = await updateVerticalSignage(vertEdit, { luogo: vertLuogo, descrizione: vertDesc })
+      const res = await updateVerticalSignage(vertEdit, {
+        luogo: vertLuogo,
+        descrizione: vertDesc,
+        anno: vertAnno ? Number(vertAnno) : undefined,
+        quantita: vertQuant ? Number(vertQuant) : undefined
+      })
       const updated = verticals.map(v => v.id === vertEdit ? res : v)
       setVerticals(updated)
       saveVerticals(updated)
     } else {
-      const res = await createVerticalSignage({ luogo: vertLuogo, descrizione: vertDesc })
+      const res = await createVerticalSignage({
+        luogo: vertLuogo,
+        descrizione: vertDesc,
+        anno: vertAnno ? Number(vertAnno) : undefined,
+        quantita: vertQuant ? Number(vertQuant) : undefined
+      })
       const updated = [...verticals, res]
       setVerticals(updated)
       saveVerticals(updated)
@@ -162,12 +190,22 @@ const InventoryPage: React.FC = () => {
     e.preventDefault()
     if (!horLuogo || !horData) return
     if (horEdit) {
-      const res = await updateHorizontalSignage(horEdit, { luogo: horLuogo, data: horData })
+      const res = await updateHorizontalSignage(horEdit, {
+        luogo: horLuogo,
+        data: horData,
+        descrizione: horDesc,
+        quantita: horQuant ? Number(horQuant) : undefined
+      })
       const updated = horizontals.map(h => h.id === horEdit ? res : h)
       setHorizontals(updated)
       saveHorizontals(updated)
     } else {
-      const res = await createHorizontalSignage({ luogo: horLuogo, data: horData })
+      const res = await createHorizontalSignage({
+        luogo: horLuogo,
+        data: horData,
+        descrizione: horDesc,
+        quantita: horQuant ? Number(horQuant) : undefined
+      })
       const updated = [...horizontals, res]
       setHorizontals(updated)
       saveHorizontals(updated)
@@ -217,21 +255,25 @@ const InventoryPage: React.FC = () => {
         <form onSubmit={submitTemp} className="item-form">
           <input data-testid="temp-luogo" placeholder="Luogo" value={tempLuogo} onChange={e => setTempLuogo(e.target.value)} />
           <input data-testid="temp-fine" type="date" value={tempFine} onChange={e => setTempFine(e.target.value)} />
+          <input data-testid="temp-desc" placeholder="Descrizione" value={tempDesc} onChange={e => setTempDesc(e.target.value)} />
+          <input data-testid="temp-quant" type="number" placeholder="Quantità" value={tempQuant} onChange={e => setTempQuant(e.target.value)} />
           <button data-testid="temp-submit" type="submit">{tempEdit ? 'Salva' : 'Aggiungi'}</button>
           {tempEdit && <button data-testid="temp-cancel" type="button" onClick={resetTemp}>Annulla</button>}
         </form>
         <input placeholder="Cerca" value={tempSearch} onChange={e => setTempSearch(e.target.value)} />
         <table className="item-table">
           <thead>
-            <tr><th>Luogo</th><th>Fine validità</th><th></th></tr>
+            <tr><th>Luogo</th><th>Fine validità</th><th>Descrizione</th><th>Quantità</th><th></th></tr>
           </thead>
           <tbody>
             {temps.filter(t => t.luogo.toLowerCase().includes(tempSearch.toLowerCase())).map(t => (
               <tr key={t.id}>
                 <td>{t.luogo}</td>
                 <td>{t.fine_validita}</td>
+                <td>{t.descrizione}</td>
+                <td>{t.quantita}</td>
                 <td>
-                  <button onClick={() => { setTempEdit(t.id); setTempLuogo(t.luogo); setTempFine(t.fine_validita) }}>Modifica</button>
+                  <button onClick={() => { setTempEdit(t.id); setTempLuogo(t.luogo); setTempFine(t.fine_validita); setTempDesc(t.descrizione || ''); setTempQuant(t.quantita?.toString() || '') }}>Modifica</button>
                   <button onClick={async () => { await deleteTemporarySignage(t.id); const u = temps.filter(x => x.id !== t.id); setTemps(u); saveTemps(u) }}>Elimina</button>
                 </td>
               </tr>
@@ -245,21 +287,25 @@ const InventoryPage: React.FC = () => {
         <form onSubmit={submitVert} className="item-form">
           <input data-testid="vert-luogo" placeholder="Luogo" value={vertLuogo} onChange={e => setVertLuogo(e.target.value)} />
           <input data-testid="vert-desc" placeholder="Descrizione" value={vertDesc} onChange={e => setVertDesc(e.target.value)} />
+          <input data-testid="vert-anno" type="number" placeholder="Anno" value={vertAnno} onChange={e => setVertAnno(e.target.value)} />
+          <input data-testid="vert-quant" type="number" placeholder="Quantità" value={vertQuant} onChange={e => setVertQuant(e.target.value)} />
           <button data-testid="vert-submit" type="submit">{vertEdit ? 'Salva' : 'Aggiungi'}</button>
           {vertEdit && <button data-testid="vert-cancel" type="button" onClick={resetVert}>Annulla</button>}
         </form>
         <input placeholder="Cerca" value={vertSearch} onChange={e => setVertSearch(e.target.value)} />
         <table className="item-table">
           <thead>
-            <tr><th>Luogo</th><th>Descrizione</th><th></th></tr>
+            <tr><th>Luogo</th><th>Descrizione</th><th>Anno</th><th>Quantità</th><th></th></tr>
           </thead>
           <tbody>
             {verticals.filter(v => v.luogo.toLowerCase().includes(vertSearch.toLowerCase())).map(v => (
               <tr key={v.id}>
                 <td>{v.luogo}</td>
                 <td>{v.descrizione}</td>
+                <td>{v.anno}</td>
+                <td>{v.quantita}</td>
                 <td>
-                  <button onClick={() => { setVertEdit(v.id); setVertLuogo(v.luogo); setVertDesc(v.descrizione) }}>Modifica</button>
+                  <button onClick={() => { setVertEdit(v.id); setVertLuogo(v.luogo); setVertDesc(v.descrizione); setVertAnno(v.anno?.toString() || ''); setVertQuant(v.quantita?.toString() || '') }}>Modifica</button>
                   <button onClick={async () => { await deleteVerticalSignage(v.id); const u = verticals.filter(x => x.id !== v.id); setVerticals(u); saveVerticals(u) }}>Elimina</button>
                 </td>
               </tr>
@@ -271,21 +317,25 @@ const InventoryPage: React.FC = () => {
         <form onSubmit={submitHor} className="item-form">
           <input data-testid="hor-luogo" placeholder="Luogo" value={horLuogo} onChange={e => setHorLuogo(e.target.value)} />
           <input data-testid="hor-data" type="date" value={horData} onChange={e => setHorData(e.target.value)} />
+          <input data-testid="hor-desc" placeholder="Descrizione" value={horDesc} onChange={e => setHorDesc(e.target.value)} />
+          <input data-testid="hor-quant" type="number" placeholder="Quantità" value={horQuant} onChange={e => setHorQuant(e.target.value)} />
           <button data-testid="hor-submit" type="submit">{horEdit ? 'Salva' : 'Aggiungi'}</button>
           {horEdit && <button data-testid="hor-cancel" type="button" onClick={resetHor}>Annulla</button>}
         </form>
         <input placeholder="Cerca" value={horSearch} onChange={e => setHorSearch(e.target.value)} />
         <table className="item-table">
           <thead>
-            <tr><th>Luogo</th><th>Data</th><th></th></tr>
+            <tr><th>Luogo</th><th>Data</th><th>Descrizione</th><th>Quantità</th><th></th></tr>
           </thead>
           <tbody>
             {horizontals.filter(h => h.luogo.toLowerCase().includes(horSearch.toLowerCase())).map(h => (
               <tr key={h.id}>
                 <td>{h.luogo}</td>
                 <td>{h.data}</td>
+                <td>{h.descrizione}</td>
+                <td>{h.quantita}</td>
                 <td>
-                  <button onClick={() => { setHorEdit(h.id); setHorLuogo(h.luogo); setHorData(h.data) }}>Modifica</button>
+                  <button onClick={() => { setHorEdit(h.id); setHorLuogo(h.luogo); setHorData(h.data); setHorDesc(h.descrizione || ''); setHorQuant(h.quantita?.toString() || '') }}>Modifica</button>
                   <button onClick={async () => { await deleteHorizontalSignage(h.id); const u = horizontals.filter(x => x.id !== h.id); setHorizontals(u); saveHorizontals(u) }}>Elimina</button>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- use new Italian signage API endpoints
- extend signage interfaces with additional info
- include description, year and quantity fields in inventory forms

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687901acba38832382febc5f8e5bdf6c