### PR TITLE
Add horizontal plan management

### DIFF
--- a/src/api/horizontalPlans.ts
+++ b/src/api/horizontalPlans.ts
@@ -1,0 +1,26 @@
+import api from './axios'
+
+export interface HorizontalPlan {
+  id: string
+  descrizione: string
+  anno: number
+}
+
+export const listHorizontalPlans = (): Promise<HorizontalPlan[]> =>
+  api.get<HorizontalPlan[]>('/inventario/horizontal-plans').then(r => r.data)
+
+export const createHorizontalPlan = (
+  data: Omit<HorizontalPlan, 'id'>,
+): Promise<HorizontalPlan> =>
+  api.post<HorizontalPlan>('/inventario/horizontal-plans', data).then(r => r.data)
+
+export const updateHorizontalPlan = (
+  id: string,
+  data: Partial<Omit<HorizontalPlan, 'id'>>,
+): Promise<HorizontalPlan> =>
+  api
+    .put<HorizontalPlan>(`/inventario/horizontal-plans/${id}`, data)
+    .then(r => r.data)
+
+export const deleteHorizontalPlan = (id: string): Promise<void> =>
+  api.delete(`/inventario/horizontal-plans/${id}`).then(() => undefined)

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -7,8 +7,14 @@ export interface HorizontalSign {
   descrizione?: string
 }
 
-export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
-  api.get<HorizontalSign[]>('/inventario/signage-horizontal').then(r => r.data)
+export const listHorizontalSignage = (
+  planId?: string,
+): Promise<HorizontalSign[]> =>
+  api
+    .get<HorizontalSign[]>('/inventario/signage-horizontal', {
+      params: planId ? { planId } : undefined,
+    })
+    .then(r => r.data)
 
 export const createHorizontalSignage = (
   data: Omit<HorizontalSign, 'id'>,


### PR DESCRIPTION
## Summary
- create API helpers for horizontal plans
- expand horizontal signage API to filter by plan
- switch inventory page to manage plans instead of interventions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687901ae51f88323883001dcc0395f29