### PR TITLE
Add horizontal plan management

### DIFF
--- a/src/api/horizontalPlans.ts
+++ b/src/api/horizontalPlans.ts
@@ -1,0 +1,25 @@
+import api from './axios'
+
+export interface HorizontalPlan {
+  id: string
+  descrizione: string
+  anno: number
+}
+
+export const listHorizontalPlans = (): Promise<HorizontalPlan[]> =>
+  api.get<HorizontalPlan[]>('/piani-orizzontali').then(r => r.data)
+
+export const createHorizontalPlan = (
+  data: Omit<HorizontalPlan, 'id'>,
+): Promise<HorizontalPlan> =>
+  api.post<HorizontalPlan>('/piani-orizzontali', data).then(r => r.data)
+
+export const updateHorizontalPlan = (
+  id: string,
+  data: Partial<Omit<HorizontalPlan, 'id'>>,
+): Promise<HorizontalPlan> =>
+  api.put<HorizontalPlan>(`/piani-orizzontali/${id}`, data).then(r => r.data)
+
+export const deleteHorizontalPlan = (id: string): Promise<void> =>
+  api.delete(`/piani-orizzontali/${id}`).then(() => undefined)
+

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -6,6 +6,7 @@ export interface HorizontalSign {
   data: string
   descrizione?: string
   quantita?: number
+  piano_id?: string
 }
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>


### PR DESCRIPTION
## Summary
- add new `horizontalPlans` API module for CRUD operations on plans
- include optional `piano_id` field in `horizontalSignage` interface
- update `InventoryPage` to manage horizontal plans and display their interventions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687906ae90fc8323afd60645ead6bafe