### PR TITLE
Use Google-hosted TikTok Sans

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,11 @@
       href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond&display=swap"
       rel="stylesheet"
     />
-    <!-- TikTok Sans font -->
-    <link href="/fonts/tiktok/TikTokSans.css" rel="stylesheet" />
+    <!-- TikTok Sans font from Google Fonts -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=TikTok+Sans:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
 
 
   </head>


### PR DESCRIPTION
## Summary
- load TikTok Sans from Google Fonts instead of shipping empty font files

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find plugin `@typescript-eslint/eslint-plugin`)*

------
https://chatgpt.com/codex/tasks/task_e_68790037e0dc8323afb740cd2d5fc40e