### PR TITLE
Aggiunge descrizione e anno al form dispositivi

### DIFF
--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -3,6 +3,8 @@ import api from './axios'
 export interface Device {
   id: string
   nome: string
+  descrizione?: string
+  anno?: number
   note?: string
 }
 

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -38,6 +38,8 @@ import {
 const InventoryPage: React.FC = () => {
   const [devices, setDevices] = useState<Device[]>([])
   const [devName, setDevName] = useState('')
+  const [devDesc, setDevDesc] = useState('')
+  const [devYear, setDevYear] = useState('')
   const [devNotes, setDevNotes] = useState('')
   const [devSearch, setDevSearch] = useState('')
   const [devEdit, setDevEdit] = useState<string | null>(null)
@@ -120,7 +122,14 @@ const InventoryPage: React.FC = () => {
   const saveVerticals = (v: VerticalSign[]) => localStorage.setItem('verticals', JSON.stringify(v))
   const savePlans = (p: HorizontalPlan[]) => localStorage.setItem('horizontalPlans', JSON.stringify(p))
 
-  const resetDevice = () => { setDevName(''); setDevNotes(''); setDevEdit(null); setDevOpen(false) }
+  const resetDevice = () => {
+    setDevName('');
+    setDevDesc('');
+    setDevYear('');
+    setDevNotes('');
+    setDevEdit(null);
+    setDevOpen(false);
+  }
   const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempDesc(''); setTempQuant(''); setTempEdit(null); setTempOpen(false) }
   const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertAnno(''); setVertQuant(''); setVertEdit(null); setVertOpen(false) }
   const resetPlan = () => { setPlanDesc(''); setPlanAnno(''); setPlanEdit(null); setPlanOpen(false) }
@@ -128,13 +137,19 @@ const InventoryPage: React.FC = () => {
   const submitDevice = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!devName) return
+    const payload = {
+      nome: devName,
+      descrizione: devDesc || undefined,
+      anno: devYear ? Number(devYear) : undefined,
+      note: devNotes,
+    }
     if (devEdit) {
-      const res = await updateDevice(devEdit, { nome: devName, note: devNotes })
+      const res = await updateDevice(devEdit, payload)
       const updated = devices.map(d => d.id === devEdit ? res : d)
       setDevices(updated)
       saveDevices(updated)
     } else {
-      const res = await createDevice({ nome: devName, note: devNotes })
+      const res = await createDevice(payload)
       const updated = [...devices, res]
       setDevices(updated)
       saveDevices(updated)
@@ -240,6 +255,8 @@ const InventoryPage: React.FC = () => {
         <Modal open={devOpen} onClose={resetDevice} title={devEdit ? 'Modifica dispositivo' : 'Nuovo dispositivo'}>
           <form onSubmit={submitDevice} className="item-form">
             <input data-testid="dev-name" placeholder="Nome" value={devName} onChange={e => setDevName(e.target.value)} />
+            <input data-testid="dev-desc" placeholder="Descrizione" value={devDesc} onChange={e => setDevDesc(e.target.value)} />
+            <input data-testid="dev-year" type="number" placeholder="Anno" value={devYear} onChange={e => setDevYear(e.target.value)} />
             <input data-testid="dev-notes" placeholder="Note" value={devNotes} onChange={e => setDevNotes(e.target.value)} />
             <button data-testid="dev-submit" type="submit">{devEdit ? 'Salva' : 'Aggiungi'}</button>
             <button data-testid="dev-cancel" type="button" onClick={resetDevice}>Annulla</button>
@@ -248,15 +265,24 @@ const InventoryPage: React.FC = () => {
         <input placeholder="Cerca" value={devSearch} onChange={e => setDevSearch(e.target.value)} />
         <table className="item-table">
           <thead>
-            <tr><th>Nome</th><th>Note</th><th></th></tr>
+            <tr><th>Nome</th><th>Descrizione</th><th>Anno</th><th>Note</th><th></th></tr>
           </thead>
           <tbody>
             {devices.filter(d => d.nome.toLowerCase().includes(devSearch.toLowerCase())).map(d => (
               <tr key={d.id}>
                 <td>{d.nome}</td>
+                <td>{d.descrizione}</td>
+                <td>{d.anno}</td>
                 <td>{d.note}</td>
                 <td>
-                  <button onClick={() => { setDevEdit(d.id); setDevName(d.nome); setDevNotes(d.note || ''); setDevOpen(true) }}>Modifica</button>
+                  <button onClick={() => {
+                    setDevEdit(d.id);
+                    setDevName(d.nome);
+                    setDevDesc(d.descrizione || '');
+                    setDevYear(d.anno?.toString() || '');
+                    setDevNotes(d.note || '');
+                    setDevOpen(true);
+                  }}>Modifica</button>
                   <button onClick={async () => { await deleteDevice(d.id); const u = devices.filter(x => x.id !== d.id); setDevices(u); saveDevices(u) }}>Elimina</button>
                 </td>
               </tr>

--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -78,6 +78,8 @@ describe('InventoryPage', () => {
 
     expect(dialog).toHaveAttribute('open')
     expect(screen.getByTestId('dev-name')).toBeInTheDocument()
+    expect(screen.getByTestId('dev-desc')).toBeInTheDocument()
+    expect(screen.getByTestId('dev-year')).toBeInTheDocument()
   })
 
   it('saves and cancels via modal', async () => {
@@ -87,14 +89,23 @@ describe('InventoryPage', () => {
 
     await userEvent.click(addButtons[0])
     await userEvent.type(screen.getByTestId('dev-name'), 'Device 1')
+    await userEvent.type(screen.getByTestId('dev-desc'), 'Desc')
+    await userEvent.type(screen.getByTestId('dev-year'), '2024')
     await userEvent.click(screen.getByTestId('dev-submit'))
 
-    expect(mockedDevices.createDevice).toHaveBeenCalled()
+    expect(mockedDevices.createDevice).toHaveBeenCalledWith({
+      nome: 'Device 1',
+      descrizione: 'Desc',
+      anno: 2024,
+      note: '',
+    })
     await screen.findByText('Device 1')
     expect(dialog).not.toHaveAttribute('open')
 
     await userEvent.click(addButtons[0])
     await userEvent.type(screen.getByTestId('dev-name'), 'Device 2')
+    await userEvent.type(screen.getByTestId('dev-desc'), 'Desc')
+    await userEvent.type(screen.getByTestId('dev-year'), '2024')
     await userEvent.click(screen.getByTestId('dev-cancel'))
 
     expect(mockedDevices.createDevice).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary
- completa il modello Device con `descrizione` e `anno`
- estende il form della pagina Inventario con i nuovi campi
- aggiorna le funzioni di creazione/modifica dispositivi
- adatta i test dell'inventario ai nuovi campi

## Testing
- `npm test` *(fallito: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687919519bec8323993634f587dc6472