### PR TITLE
Update horizontal signage API paths

### DIFF
--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -10,23 +10,34 @@ export interface HorizontalSign {
 }
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
-  api.get<HorizontalSign[]>('/segnaletica-orizzontale').then(r => r.data)
+  api
+    .get<HorizontalSign[]>('/inventario/signage-horizontal')
+    .then(r => r.data)
 
 export const createHorizontalSignage = (
   data: Omit<HorizontalSign, 'id'>,
 ): Promise<HorizontalSign> =>
-  api.post<HorizontalSign>('/segnaletica-orizzontale', data).then(r => r.data)
+  api
+    .post<HorizontalSign>('/inventario/signage-horizontal', data)
+    .then(r => r.data)
 
 export const updateHorizontalSignage = (
   id: string,
   data: Partial<Omit<HorizontalSign, 'id'>>,
 ): Promise<HorizontalSign> =>
-  api.put<HorizontalSign>(`/segnaletica-orizzontale/${id}`, data).then(r => r.data)
+  api
+    .put<HorizontalSign>(`/inventario/signage-horizontal/${id}`, data)
+    .then(r => r.data)
 
 export const deleteHorizontalSignage = (id: string): Promise<void> =>
-  api.delete(`/segnaletica-orizzontale/${id}`).then(() => undefined)
+  api
+    .delete(`/inventario/signage-horizontal/${id}`)
+    .then(() => undefined)
 
 export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
   api
-    .get('/segnaletica-orizzontale/pdf', { params: { year }, responseType: 'blob' })
+    .get('/inventario/signage-horizontal/pdf', {
+      params: { year },
+      responseType: 'blob',
+    })
     .then(r => r.data)


### PR DESCRIPTION
## Summary
- update endpoints in `horizontalSignage` API
- query new `/inventario/signage-horizontal/pdf` endpoint for PDF generation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791c199ee48323a79d90f5158c3227