### PR TITLE
Add horizontal signage interventions modal

### DIFF
--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -30,3 +30,12 @@ export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
   api
     .get('/segnaletica-orizzontale/pdf', { params: { year }, responseType: 'blob' })
     .then(r => r.data)
+
+export const listHorizontalSignageByPlan = (
+  planId: string,
+): Promise<HorizontalSign[]> =>
+  api
+    .get<HorizontalSign[]>('/inventario/signage-horizontal', {
+      params: { plan: planId },
+    })
+    .then(r => r.data)


### PR DESCRIPTION
## Summary
- add API helper to fetch horizontal signage for a specific plan
- extend InventoryPage with modal to manage interventions
- load interventions via the new helper when selecting "Vedi interventi"

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791c1a9f048323bc6c062987d6ae48