### PR TITLE
Add horizontal signage tests

### DIFF
--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -7,6 +7,7 @@ import * as devicesApi from '../../api/devices'
 import * as tempApi from '../../api/temporarySignage'
 import * as vertApi from '../../api/verticalSignage'
 import * as planApi from '../../api/horizontalPlans'
+import * as horApi from '../../api/horizontalSignage'
 
 jest.mock('../../api/devices', () => ({
   __esModule: true,
@@ -40,10 +41,17 @@ jest.mock('../../api/horizontalPlans', () => ({
   deleteHorizontalPlan: jest.fn(),
 }))
 
+jest.mock('../../api/horizontalSignage', () => ({
+  __esModule: true,
+  listHorizontalSignage: jest.fn(),
+  getHorizontalSignagePdf: jest.fn(),
+}))
+
 const mockedDevices = devicesApi as jest.Mocked<typeof devicesApi>
 const mockedTemps = tempApi as jest.Mocked<typeof tempApi>
 const mockedVerts = vertApi as jest.Mocked<typeof vertApi>
 const mockedPlans = planApi as jest.Mocked<typeof planApi>
+const mockedHoriz = horApi as jest.Mocked<typeof horApi>
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -52,6 +60,8 @@ beforeEach(() => {
   mockedTemps.listTemporarySignage.mockResolvedValue([])
   mockedVerts.listVerticalSignage.mockResolvedValue([])
   mockedPlans.listHorizontalPlans.mockResolvedValue([])
+  mockedHoriz.listHorizontalSignage.mockResolvedValue([])
+  mockedHoriz.getHorizontalSignagePdf.mockResolvedValue(new Blob())
   mockedDevices.createDevice.mockResolvedValue({ id: '1', nome: 'Device 1' } as any)
 })
 
@@ -111,5 +121,59 @@ describe('InventoryPage', () => {
     expect(mockedDevices.createDevice).toHaveBeenCalledTimes(1)
     expect(dialog).not.toHaveAttribute('open')
     expect(screen.queryByText('Device 2')).not.toBeInTheDocument()
+  })
+
+  it('adds a new horizontal plan', async () => {
+    mockedPlans.createHorizontalPlan.mockResolvedValue({ id: 'p1', descrizione: 'Plan 1', anno: 2024 } as any)
+
+    renderPage()
+
+    const addButtons = screen.getAllByRole('button', { name: /aggiungi/i })
+    const dialog = screen.getAllByRole('dialog')[3]
+
+    await userEvent.click(addButtons[3])
+    await userEvent.type(screen.getByTestId('plan-desc'), 'Plan 1')
+    await userEvent.type(screen.getByTestId('plan-anno'), '2024')
+    await userEvent.click(screen.getByTestId('plan-submit'))
+
+    expect(mockedPlans.createHorizontalPlan).toHaveBeenCalledWith({ descrizione: 'Plan 1', anno: 2024 })
+    await screen.findByText('Plan 1')
+    expect(dialog).not.toHaveAttribute('open')
+  })
+
+  it('opens interventions modal', async () => {
+    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([{ id: 'p1', descrizione: 'Plan 1', anno: 2024 }])
+    mockedHoriz.listHorizontalSignage.mockResolvedValueOnce([
+      { id: 'h1', luogo: 'Via Roma', data: '2024-01-01', descrizione: 'Segn', quantita: 1, piano_id: 'p1' },
+    ])
+
+    renderPage()
+
+    await screen.findByText('Plan 1')
+
+    const dialog = screen.getAllByRole('dialog')[4]
+    expect(dialog).not.toHaveAttribute('open')
+
+    await userEvent.click(screen.getByRole('button', { name: /vedi interventi/i }))
+
+    expect(mockedHoriz.listHorizontalSignage).toHaveBeenCalled()
+    expect(dialog).toHaveAttribute('open')
+    expect(await screen.findByText('Via Roma')).toBeInTheDocument()
+  })
+
+  it('downloads PDF for horizontal signage', async () => {
+    renderPage()
+
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+    const urlSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:1')
+
+    await userEvent.type(screen.getByTestId('hor-year'), '2024')
+    await userEvent.click(screen.getByTestId('hor-pdf'))
+
+    expect(mockedHoriz.getHorizontalSignagePdf).toHaveBeenCalledWith(2024)
+    expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank')
+
+    openSpy.mockRestore()
+    urlSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- test horizontal plan creation and viewing interventions
- test PDF download for horizontal signage
- mock signage-horizontal API

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791c1bd52883239db20c1c5720a7d8