### PR TITLE
Add InventoryPage intervention tests

### DIFF
--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import InventoryPage from '../InventoryPage'
 import PageTemplate from '../../components/PageTemplate'
@@ -7,6 +7,7 @@ import * as devicesApi from '../../api/devices'
 import * as tempApi from '../../api/temporarySignage'
 import * as vertApi from '../../api/verticalSignage'
 import * as planApi from '../../api/horizontalPlans'
+import * as horizApi from '../../api/horizontalSignage'
 
 jest.mock('../../api/devices', () => ({
   __esModule: true,
@@ -40,10 +41,21 @@ jest.mock('../../api/horizontalPlans', () => ({
   deleteHorizontalPlan: jest.fn(),
 }))
 
+jest.mock('../../api/horizontalSignage', () => ({
+  __esModule: true,
+  listHorizontalSignage: jest.fn(),
+  createHorizontalSignage: jest.fn(),
+  updateHorizontalSignage: jest.fn(),
+  deleteHorizontalSignage: jest.fn(),
+  getHorizontalSignagePdf: jest.fn(),
+  listHorizontalSignageByPlan: jest.fn(),
+}))
+
 const mockedDevices = devicesApi as jest.Mocked<typeof devicesApi>
 const mockedTemps = tempApi as jest.Mocked<typeof tempApi>
 const mockedVerts = vertApi as jest.Mocked<typeof vertApi>
 const mockedPlans = planApi as jest.Mocked<typeof planApi>
+const mockedHoriz = horizApi as jest.Mocked<typeof horizApi>
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -52,11 +64,19 @@ beforeEach(() => {
   mockedTemps.listTemporarySignage.mockResolvedValue([])
   mockedVerts.listVerticalSignage.mockResolvedValue([])
   mockedPlans.listHorizontalPlans.mockResolvedValue([])
+  mockedHoriz.listHorizontalSignage.mockResolvedValue([])
+  mockedHoriz.listHorizontalSignageByPlan.mockResolvedValue([])
+  mockedHoriz.getHorizontalSignagePdf.mockResolvedValue(new Blob())
   mockedDevices.createDevice.mockResolvedValue({ id: '1', nome: 'Device 1' } as any)
   mockedTemps.createTemporarySignage.mockResolvedValue({
     id: 't1',
     luogo: 'Luogo',
     fine_validita: '2024-01-01',
+  } as any)
+  mockedHoriz.createHorizontalSignage.mockResolvedValue({
+    id: 'h1',
+    luogo: 'Luogo',
+    data: '2024-01-01',
   } as any)
 })
 
@@ -137,5 +157,68 @@ describe('InventoryPage', () => {
       anno: 2024,
       quantita: 3,
     })
+  })
+
+  it('opens interventions modal', async () => {
+    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([
+      { id: 'p1', descrizione: 'Piano 1', anno: 2024 } as any,
+    ])
+    renderPage()
+
+    const row = await screen.findByRole('row', { name: /piano 1/i })
+    const seeBtn = within(row).getByRole('button', { name: /vedi interventi/i })
+    const dialogs = screen.getAllByRole('dialog')
+    expect(dialogs[4]).not.toHaveAttribute('open')
+
+    await userEvent.click(seeBtn)
+
+    expect(dialogs[4]).toHaveAttribute('open')
+    expect(mockedHoriz.listHorizontalSignageByPlan).toHaveBeenCalledWith('p1')
+  })
+
+  it('adds horizontal intervention', async () => {
+    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([
+      { id: 'p1', descrizione: 'Piano 1', anno: 2024 } as any,
+    ])
+    renderPage()
+
+    const row = await screen.findByRole('row', { name: /piano 1/i })
+    const seeBtn = within(row).getByRole('button', { name: /vedi interventi/i })
+    await userEvent.click(seeBtn)
+
+    const interventions = screen.getAllByRole('dialog')[4]
+    await userEvent.click(within(interventions).getByRole('button', { name: /aggiungi/i }))
+
+    const horizDialog = screen.getAllByRole('dialog')[5]
+    const withinHoriz = within(horizDialog)
+    const [luogoInput, dateInput, descInput] = withinHoriz.getAllByRole('textbox')
+    await userEvent.type(luogoInput, 'Luogo')
+    await userEvent.type(dateInput, '2024-01-01')
+    await userEvent.type(descInput, 'Desc')
+    await userEvent.type(withinHoriz.getByPlaceholderText('Quantità'), '2')
+    await userEvent.click(withinHoriz.getByRole('button', { name: /aggiungi/i }))
+
+    expect(mockedHoriz.createHorizontalSignage).toHaveBeenCalledWith({
+      luogo: 'Luogo',
+      data: '2024-01-01',
+      descrizione: 'Desc',
+      quantita: 2,
+      piano_id: 'p1',
+    })
+  })
+
+  it('downloads PDF by year', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+    const urlSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:1')
+
+    renderPage()
+    await userEvent.type(screen.getByTestId('hor-year'), '2023')
+    await userEvent.click(screen.getByTestId('hor-pdf'))
+
+    expect(mockedHoriz.getHorizontalSignagePdf).toHaveBeenCalledWith(2023)
+    expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank')
+
+    openSpy.mockRestore()
+    urlSpy.mockRestore()
   })
 })


### PR DESCRIPTION
## Summary
- extend InventoryPage tests with additional mocks for horizontal signage
- cover intervention modal, item creation, and PDF download

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791e120d8c8323a31c9970984db8c4