### PR TITLE
Fix signage endpoints

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,10 +2,7 @@ import axios from 'axios';
 import { useAuthStore } from '../store/auth';
 
 const api = axios.create({
-  baseURL: (import.meta.env.VITE_API_URL ?? 'http://localhost:8000').replace(
-    /\/+$/,
-    ''
-  ),
+  baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:8000',
 });
 
 api.interceptors.request.use((config) => {

--- a/src/api/horizontalPlans.ts
+++ b/src/api/horizontalPlans.ts
@@ -7,19 +7,19 @@ export interface HorizontalPlan {
 }
 
 export const listHorizontalPlans = (): Promise<HorizontalPlan[]> =>
-  api.get<HorizontalPlan[]>('/piani-orizzontali').then(r => r.data)
+  api.get<HorizontalPlan[]>('/piani-orizzontali/').then(r => r.data)
 
 export const createHorizontalPlan = (
   data: Omit<HorizontalPlan, 'id'>,
 ): Promise<HorizontalPlan> =>
-  api.post<HorizontalPlan>('/piani-orizzontali', data).then(r => r.data)
+  api.post<HorizontalPlan>('/piani-orizzontali/', data).then(r => r.data)
 
 export const updateHorizontalPlan = (
   id: string,
   data: Partial<Omit<HorizontalPlan, 'id'>>,
 ): Promise<HorizontalPlan> =>
-  api.put<HorizontalPlan>(`/piani-orizzontali/${id}`, data).then(r => r.data)
+  api.put<HorizontalPlan>(`/piani-orizzontali/${id}/`, data).then(r => r.data)
 
 export const deleteHorizontalPlan = (id: string): Promise<void> =>
-  api.delete(`/piani-orizzontali/${id}`).then(() => undefined)
+  api.delete(`/piani-orizzontali/${id}/`).then(() => undefined)
 

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -11,14 +11,14 @@ export interface HorizontalSign {
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
   api
-    .get<HorizontalSign[]>('/inventario/signage-horizontal')
+    .get<HorizontalSign[]>('/inventario/signage-horizontal/')
     .then(r => r.data)
 
 export const createHorizontalSignage = (
   data: Omit<HorizontalSign, 'id'>,
 ): Promise<HorizontalSign> =>
   api
-    .post<HorizontalSign>('/inventario/signage-horizontal', data)
+    .post<HorizontalSign>('/inventario/signage-horizontal/', data)
     .then(r => r.data)
 
 export const updateHorizontalSignage = (
@@ -26,17 +26,17 @@ export const updateHorizontalSignage = (
   data: Partial<Omit<HorizontalSign, 'id'>>,
 ): Promise<HorizontalSign> =>
   api
-    .put<HorizontalSign>(`/inventario/signage-horizontal/${id}`, data)
+    .put<HorizontalSign>(`/inventario/signage-horizontal/${id}/`, data)
     .then(r => r.data)
 
 export const deleteHorizontalSignage = (id: string): Promise<void> =>
   api
-    .delete(`/inventario/signage-horizontal/${id}`)
+    .delete(`/inventario/signage-horizontal/${id}/`)
     .then(() => undefined)
 
 export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
   api
-    .get('/inventario/signage-horizontal/pdf', {
+    .get('/inventario/signage-horizontal/pdf/', {
       params: { year },
       responseType: 'blob',
     })
@@ -46,7 +46,7 @@ export const listHorizontalSignageByPlan = (
   planId: string,
 ): Promise<HorizontalSign[]> =>
   api
-    .get<HorizontalSign[]>('/inventario/signage-horizontal', {
+    .get<HorizontalSign[]>('/inventario/signage-horizontal/', {
       params: { plan: planId },
     })
     .then(r => r.data)

--- a/src/api/temporarySignage.ts
+++ b/src/api/temporarySignage.ts
@@ -10,18 +10,18 @@ export interface TemporarySign {
 }
 
 export const listTemporarySignage = (): Promise<TemporarySign[]> =>
-  api.get<TemporarySign[]>('/segnaletica-temporanea').then(r => r.data)
+  api.get<TemporarySign[]>('/segnaletica-temporanea/').then(r => r.data)
 
 export const createTemporarySignage = (
   data: Omit<TemporarySign, 'id'>,
 ): Promise<TemporarySign> =>
-  api.post<TemporarySign>('/segnaletica-temporanea', data).then(r => r.data)
+  api.post<TemporarySign>('/segnaletica-temporanea/', data).then(r => r.data)
 
 export const updateTemporarySignage = (
   id: string,
   data: Partial<Omit<TemporarySign, 'id'>>,
 ): Promise<TemporarySign> =>
-  api.put<TemporarySign>(`/segnaletica-temporanea/${id}`, data).then(r => r.data)
+  api.put<TemporarySign>(`/segnaletica-temporanea/${id}/`, data).then(r => r.data)
 
 export const deleteTemporarySignage = (id: string): Promise<void> =>
-  api.delete(`/segnaletica-temporanea/${id}`).then(() => undefined)
+  api.delete(`/segnaletica-temporanea/${id}/`).then(() => undefined)

--- a/src/api/verticalSignage.ts
+++ b/src/api/verticalSignage.ts
@@ -10,18 +10,18 @@ export interface VerticalSign {
 }
 
 export const listVerticalSignage = (): Promise<VerticalSign[]> =>
-  api.get<VerticalSign[]>('/segnaletica-verticale').then(r => r.data)
+  api.get<VerticalSign[]>('/segnaletica-verticale/').then(r => r.data)
 
 export const createVerticalSignage = (
   data: Omit<VerticalSign, 'id'>,
 ): Promise<VerticalSign> =>
-  api.post<VerticalSign>('/segnaletica-verticale', data).then(r => r.data)
+  api.post<VerticalSign>('/segnaletica-verticale/', data).then(r => r.data)
 
 export const updateVerticalSignage = (
   id: string,
   data: Partial<Omit<VerticalSign, 'id'>>,
 ): Promise<VerticalSign> =>
-  api.put<VerticalSign>(`/segnaletica-verticale/${id}`, data).then(r => r.data)
+  api.put<VerticalSign>(`/segnaletica-verticale/${id}/`, data).then(r => r.data)
 
 export const deleteVerticalSignage = (id: string): Promise<void> =>
-  api.delete(`/segnaletica-verticale/${id}`).then(() => undefined)
+  api.delete(`/segnaletica-verticale/${id}/`).then(() => undefined)


### PR DESCRIPTION
## Summary
- keep `VITE_API_URL` unchanged when setting axios baseURL
- add trailing slashes to signage-related endpoints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687925e480048323b90bbef52d862825