### PR TITLE
Add segnalazioni page with map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This project contains the React front end of **Segretaria Digitale**, a simple a
 
 ```bash
 npm install
+# install mapping dependencies
+npm install leaflet react-leaflet
 # Dependencies are locked via `package-lock.json`
 # If you see 404 errors for `@tanstack/react-query`,
 # update the dependency to a recent release (>=4.36.1).
@@ -162,6 +164,15 @@ exposes Italian endpoint paths such as `/inventario/devices`,
 `/inventario/signage-horizontal`. Horizontal signage offers a **PDF anno** button
 that calls `/inventario/signage-horizontal/pdf?year=YYYY` to download the annual
 plan.
+
+## Segnalazioni
+
+The `/segnalazioni` page lets users report issues on a map. Click anywhere on the
+map to place a marker, fill in the tipo, priorità, data and descrizione fields
+and submit the form. Existing segnalazioni are shown as markers with a popup
+containing the details.
+
+Leaflet's default CSS is imported in `src/main.tsx` so the map renders correctly.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "react-calendar": "^6.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.0",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
     "@tanstack/query-core": "^4.36.1",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const UtilitaPage = React.lazy(() => import("./pages/UtilitaPage"));
 const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
 const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 const InventoryPage = React.lazy(() => import("./pages/InventoryPage"));
+const SegnalazioniPage = React.lazy(() => import("./pages/SegnalazioniPage"));
 
 
 const App: React.FC = () => {
@@ -47,6 +48,7 @@ const App: React.FC = () => {
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
           <Route path="/inventario" element={<InventoryPage />} />
+          <Route path="/segnalazioni" element={<SegnalazioniPage />} />
         </Route>
 
         {/* Qualunque altra rotta redirige alla dashboard */}

--- a/src/api/segnalazioni.ts
+++ b/src/api/segnalazioni.ts
@@ -1,0 +1,19 @@
+import api from './axios'
+
+export interface Segnalazione {
+  id: string
+  tipo: string
+  priorita: string
+  data: string
+  descrizione: string
+  lat: number
+  lng: number
+}
+
+export const listSegnalazioni = (): Promise<Segnalazione[]> =>
+  api.get<Segnalazione[]>('/segnalazioni').then(r => r.data)
+
+export const createSegnalazione = (
+  data: Omit<Segnalazione, 'id'>
+): Promise<Segnalazione> =>
+  api.post<Segnalazione>('/segnalazioni', data).then(r => r.data)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import App from './App';
 import './index.css';
+import 'leaflet/dist/leaflet.css';
 
 const queryClient = new QueryClient();
 

--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react'
+import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet'
+import { createSegnalazione, listSegnalazioni, Segnalazione } from '../api/segnalazioni'
+import './ListPages.css'
+
+const ClickMarker: React.FC<{ position: [number, number] | null; onChange: (p: [number, number]) => void }> = ({ position, onChange }) => {
+  useMapEvents({
+    click(e) {
+      onChange([e.latlng.lat, e.latlng.lng])
+    }
+  })
+  return position ? <Marker position={position} /> : null
+}
+
+const SegnalazioniPage: React.FC = () => {
+  const [items, setItems] = useState<Segnalazione[]>([])
+  const [tipo, setTipo] = useState('')
+  const [priorita, setPriorita] = useState('')
+  const [data, setData] = useState('')
+  const [descrizione, setDescrizione] = useState('')
+  const [pos, setPos] = useState<[number, number] | null>(null)
+
+  useEffect(() => {
+    listSegnalazioni().then(setItems).catch(() => {})
+  }, [])
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!pos) return
+    const res = await createSegnalazione({
+      tipo,
+      priorita,
+      data,
+      descrizione,
+      lat: pos[0],
+      lng: pos[1]
+    })
+    setItems([...items, res])
+  }
+
+  return (
+    <div className="list-page">
+      <h2>Segnalazioni</h2>
+      <form onSubmit={onSubmit} className="item-form">
+        <input placeholder="Tipo" value={tipo} onChange={e => setTipo(e.target.value)} />
+        <input placeholder="Priorità" value={priorita} onChange={e => setPriorita(e.target.value)} />
+        <label htmlFor="data">Data</label>
+        <input id="data" type="date" value={data} onChange={e => setData(e.target.value)} />
+        <textarea placeholder="Descrizione" value={descrizione} onChange={e => setDescrizione(e.target.value)} />
+        <button type="submit">Invia</button>
+      </form>
+      <MapContainer center={[45.07, 7.69]} zoom={13} style={{ height: '400px', width: '100%' }} data-testid="map">
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
+        <ClickMarker position={pos} onChange={setPos} />
+        {items.map(s => (
+          <Marker key={s.id} position={[s.lat, s.lng]}>
+            <Popup>
+              <strong>{s.tipo}</strong>
+              <br />
+              {s.descrizione}
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  )
+}
+
+export default SegnalazioniPage

--- a/src/pages/__tests__/SegnalazioniPage.test.tsx
+++ b/src/pages/__tests__/SegnalazioniPage.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import SegnalazioniPage from '../SegnalazioniPage'
+import PageTemplate from '../../components/PageTemplate'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import * as api from '../../api/segnalazioni'
+
+jest.mock('../../api/segnalazioni', () => ({
+  __esModule: true,
+  listSegnalazioni: jest.fn(),
+  createSegnalazione: jest.fn(),
+}))
+
+const mockedApi = api as jest.Mocked<typeof api>
+
+beforeEach(() => {
+  mockedApi.listSegnalazioni.mockResolvedValue([])
+})
+
+describe('SegnalazioniPage', () => {
+  it('lists segnalazioni from api', async () => {
+    mockedApi.listSegnalazioni.mockResolvedValue([
+      { id: '1', tipo: 'Buco', priorita: 'Alta', data: '2024-01-01', descrizione: 'desc', lat: 0, lng: 0 }
+    ])
+
+    render(
+      <MemoryRouter initialEntries={["/segnalazioni"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/segnalazioni" element={<SegnalazioniPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByText('Buco')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- install Leaflet deps in docs and import CSS globally
- implement API helpers for segnalazioni
- create SegnalazioniPage using react‑leaflet map
- register new route
- test listing segnalazioni
- document new page and map setup

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793e9db2248323a9067a10e1ba7ead