### PR TITLE
Add note about Jest prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ npm test
 
 The tests use Jest together with React Testing Library.
 
+### Jest not found
+
+Running `npm test` before installing dependencies will fail because Jest is
+missing. Execute `npm install` or `./scripts/setup.sh` first so that the local
+`node_modules/.bin/jest` binary is available.
+
 
 ## Backend API
 


### PR DESCRIPTION
## Summary
- document that `npm install` or `./scripts/setup.sh` must run before `npm test`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68793e850d408323a02a2a01e1ea93bb