### PR TITLE
Dashboard default month view; weekly calendar on events page

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,9 @@ value entered must be a valid time string or the backend will reject that row.
 
 ## Dashboard
 
-The dashboard calendar shows Google Calendar events for the current week only.
+The dashboard calendar defaults to the **month** view of Google Calendar.
 Events are fetched from the ID defined in `VITE_DASHBOARD_CALENDAR_ID`.
+The `/events` page shows the same calendar in **week** view.
 
 ## Inventory
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -115,7 +115,7 @@ export default function Dashboard() {
               key={String(refreshCal)}
               src={`https://calendar.google.com/calendar/embed?src=${encodeURIComponent(
                 CALENDAR_ID
-              )}&mode=WEEK&ctz=Europe/Rome`}
+              )}&mode=MONTH&ctz=Europe/Rome`}
               title="Calendario"
               style={{ border: 0, width: '100%', height: '600px' }}
               frameBorder={0}

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -58,6 +58,7 @@ export default function EventsPage() {
     import.meta.env.VITE_DASHBOARD_CALENDAR_ID ||
     import.meta.env.VITE_SCHEDULE_CALENDAR_IDS?.split(',')[0] ||
     DEFAULT_CALENDAR_ID;
+  const [refreshCal, setRefreshCal] = useState(false);
   const storageKey = useMemo(
     () =>
       getUserStorageKey(
@@ -361,6 +362,19 @@ export default function EventsPage() {
         </tbody>
       </table>
       </details>
+      <div style={{ marginTop: '1.5rem' }}>
+        <iframe
+          key={String(refreshCal)}
+          src={`https://calendar.google.com/calendar/embed?src=${encodeURIComponent(CALENDAR_ID)}&mode=WEEK&ctz=Europe/Rome`}
+          title="Calendario"
+          style={{ border: 0, width: '100%', height: '600px' }}
+          frameBorder={0}
+          scrolling="no"
+        />
+        <button onClick={() => setRefreshCal(prev => !prev)}>
+          Aggiorna calendario
+        </button>
+      </div>
       </div>
   );
 }


### PR DESCRIPTION
## Summary
- show month view calendar on the Dashboard
- add Google Calendar iframe to the events page
- document the new views in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879574f6c4483239438803e4cd90926