### PR TITLE
Update device endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Events are fetched from the ID defined in `VITE_DASHBOARD_CALENDAR_ID`.
 
 Visit `/inventario` to manage devices and road signage. Items open in modal
 dialogs for editing and each record includes a **quantità** field. The backend
-exposes Italian endpoint paths such as `/inventario/devices`,
+exposes Italian endpoint paths such as `/dispositivi`,
 `/inventario/signage-temp`, `/inventario/signage-vertical` and
 `/inventario/signage-horizontal`. Horizontal signage offers a **PDF anno** button
 that calls `/inventario/signage-horizontal/pdf?year=YYYY` to download the annual

--- a/src/api/devices.ts
+++ b/src/api/devices.ts
@@ -9,16 +9,16 @@ export interface Device {
 }
 
 export const listDevices = (): Promise<Device[]> =>
-  api.get<Device[]>('/inventario/devices').then(r => r.data)
+  api.get<Device[]>('/dispositivi').then(r => r.data)
 
 export const createDevice = (data: Omit<Device, 'id'>): Promise<Device> =>
-  api.post<Device>('/inventario/devices', data).then(r => r.data)
+  api.post<Device>('/dispositivi', data).then(r => r.data)
 
 export const updateDevice = (
   id: string,
   data: Partial<Omit<Device, 'id'>>,
 ): Promise<Device> =>
-  api.put<Device>(`/inventario/devices/${id}`, data).then(r => r.data)
+  api.put<Device>(`/dispositivi/${id}`, data).then(r => r.data)
 
 export const deleteDevice = (id: string): Promise<void> =>
-  api.delete(`/inventario/devices/${id}`).then(() => undefined)
+  api.delete(`/dispositivi/${id}`).then(() => undefined)


### PR DESCRIPTION
## Summary
- switch device API endpoints to `/dispositivi`
- document the new path in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687958de6cf483238eb40b479f8075e6