### PR TITLE
Add basic FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,10 @@ Example JSON response:
 
 ## Backend Setup
 
-The API used by the frontend resides in a separate backend repository. Clone
-the backend and follow its README to install Python dependencies and start the
-server. The backend expects a few environment variables to be configured:
+This repository now ships with a minimal FastAPI backend located in the
+`backend/` directory.  Install the Python dependencies and run the API with
+`uvicorn backend.main:app` after configuring the following environment
+variables:
 
 - `DATABASE_URL` – connection string for the persistent database.
 - `ALGORITHM` – algorithm used for signing JWT access tokens.
@@ -238,8 +239,9 @@ server. The backend expects a few environment variables to be configured:
 
 The backend must send an `Access-Control-Allow-Origin` header allowing the frontend's domain (or `*`) so that features like the Excel import work. You can enable a CORS middleware or configure your framework to add this header.
 
-Once the environment variables are set you can run `uvicorn main:app` to launch
-the API.
+After applying the Alembic migrations
+(`alembic -c backend/alembic.ini upgrade head`) you can start the API with
+`uvicorn backend.main:app`.
 
 
 ## License

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,26 @@
+[alembic]
+script_location = backend/alembic
+sqlalchemy.url = %(DATABASE_URL)s
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname = root
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,42 @@
+import os
+from logging.config import fileConfig
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+from alembic import context
+
+from backend import models
+from backend.database import DATABASE_URL
+
+config = context.config
+fileConfig(config.config_file_name)
+
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = models.Base.metadata
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/0001_create_segnalazioni.py
+++ b/backend/alembic/versions/0001_create_segnalazioni.py
@@ -1,0 +1,25 @@
+"""create segnalazioni table"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_table(
+        "segnalazioni",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("tipo", sa.String, nullable=False),
+        sa.Column("priorita", sa.String, nullable=False),
+        sa.Column("stato", sa.String, nullable=False),
+        sa.Column("data", sa.DateTime, nullable=True),
+        sa.Column("descrizione", sa.String, nullable=True),
+        sa.Column("lat", sa.Float, nullable=True),
+        sa.Column("lng", sa.Float, nullable=True),
+    )
+
+def downgrade():
+    op.drop_table("segnalazioni")

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+from . import models, schemas
+
+
+def get_segnalazioni(db: Session, skip: int = 0, limit: int = 100):
+    return db.query(models.Segnalazione).offset(skip).limit(limit).all()
+
+
+def create_segnalazione(db: Session, segnalazione: schemas.SegnalazioneCreate):
+    db_segnalazione = models.Segnalazione(**segnalazione.dict())
+    db.add(db_segnalazione)
+    db.commit()
+    db.refresh(db_segnalazione)
+    return db_segnalazione

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,11 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,54 @@
+import os
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session
+import jwt
+from . import models, schemas, crud
+from .database import SessionLocal, engine
+from fastapi.middleware.cors import CORSMiddleware
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+security = HTTPBearer()
+
+SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+ALGORITHM = os.getenv("ALGORITHM", "HS256")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    token = credentials.credentials
+    try:
+        jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+    except jwt.PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        )
+
+
+@app.post("/segnalazioni", response_model=schemas.Segnalazione, dependencies=[Depends(get_current_user)])
+def create_segnalazione(segnalazione: schemas.SegnalazioneCreate, db: Session = Depends(get_db)):
+    return crud.create_segnalazione(db, segnalazione)
+
+
+@app.get("/segnalazioni", response_model=list[schemas.Segnalazione])
+def read_segnalazioni(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return crud.get_segnalazioni(db, skip=skip, limit=limit)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String, DateTime, Float
+from .database import Base
+import datetime
+
+class Segnalazione(Base):
+    __tablename__ = "segnalazioni"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tipo = Column(String, nullable=False)
+    priorita = Column(String, nullable=False)
+    stato = Column(String, nullable=False)
+    data = Column(DateTime, default=datetime.datetime.utcnow)
+    descrizione = Column(String, nullable=True)
+    lat = Column(Float, nullable=True)
+    lng = Column(Float, nullable=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+PyJWT
+alembic

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+class SegnalazioneBase(BaseModel):
+    tipo: str
+    priorita: str
+    stato: str
+    descrizione: str | None = None
+    lat: float | None = None
+    lng: float | None = None
+
+class SegnalazioneCreate(SegnalazioneBase):
+    pass
+
+class Segnalazione(SegnalazioneBase):
+    id: int
+    data: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- implement simple FastAPI backend with JWT auth
- add SQLAlchemy models, CRUD helpers and Alembic migrations
- document backend usage in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68795e863cb88323998bbd634c33eea7