### PR TITLE
Add stato field for segnalazioni

### DIFF
--- a/src/api/segnalazioni.ts
+++ b/src/api/segnalazioni.ts
@@ -6,6 +6,8 @@ export interface Segnalazione {
   priorita: string
   data: string
   descrizione: string
+  /** Current status, may be omitted if the backend does not return it */
+  stato?: string
   lat: number
   lng: number
 }

--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -25,6 +25,7 @@ const SegnalazioniPage: React.FC = () => {
   const [priorita, setPriorita] = useState('')
   const [data, setData] = useState(() => new Date().toISOString().slice(0, 16))
   const [descrizione, setDescrizione] = useState('')
+  const [stato, setStato] = useState('')
   const [pos, setPos] = useState<[number, number] | null>(null)
 
   useEffect(() => {
@@ -39,6 +40,7 @@ const SegnalazioniPage: React.FC = () => {
       priorita,
       data,
       descrizione,
+      stato,
       lat: pos[0],
       lng: pos[1]
     })
@@ -47,6 +49,7 @@ const SegnalazioniPage: React.FC = () => {
     setPriorita('')
     setData(new Date().toISOString().slice(0, 16))
     setDescrizione('')
+    setStato('')
     setPos(null)
   }
 
@@ -76,6 +79,11 @@ const SegnalazioniPage: React.FC = () => {
           value={data}
           onChange={e => setData(e.target.value)}
         />
+        <input
+          placeholder="Stato"
+          value={stato}
+          onChange={e => setStato(e.target.value)}
+        />
         <textarea placeholder="Descrizione" value={descrizione} onChange={e => setDescrizione(e.target.value)} />
         <button type="submit">Invia</button>
       </form>
@@ -85,9 +93,12 @@ const SegnalazioniPage: React.FC = () => {
         {items.map(s => (
           <Marker key={s.id} position={[s.lat, s.lng]}>
             <Popup>
-              <strong>{s.tipo}</strong>
-              <br />
-              {s.descrizione}
+              <div>
+                <strong>{s.tipo}</strong>
+              </div>
+              {s.stato && <div>Stato: {s.stato}</div>}
+              <div>{new Date(s.data).toLocaleString()}</div>
+              <div>{s.descrizione}</div>
             </Popup>
           </Marker>
         ))}

--- a/src/pages/__tests__/SegnalazioniPage.test.tsx
+++ b/src/pages/__tests__/SegnalazioniPage.test.tsx
@@ -19,7 +19,16 @@ beforeEach(() => {
 describe('SegnalazioniPage', () => {
   it('lists segnalazioni from api', async () => {
     mockedApi.listSegnalazioni.mockResolvedValue([
-      { id: '1', tipo: 'Buco', priorita: 'Alta', data: '2024-01-01', descrizione: 'desc', lat: 0, lng: 0 }
+      {
+        id: '1',
+        tipo: 'Buco',
+        priorita: 'Alta',
+        data: '2024-01-01',
+        descrizione: 'desc',
+        stato: 'aperta',
+        lat: 0,
+        lng: 0,
+      }
     ])
 
     render(
@@ -48,6 +57,7 @@ describe('SegnalazioniPage', () => {
 
     const selects = screen.getAllByRole('combobox')
     expect(selects).toHaveLength(2)
+    expect(screen.getByPlaceholderText(/stato/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/data/i)).toHaveAttribute('type', 'datetime-local')
   })
 })


### PR DESCRIPTION
## Summary
- extend `Segnalazione` type with optional `stato`
- support `stato` in SegnalazioniPage form and markers
- show full info (tipo, stato, data, descrizione) in popup
- update segnalazioni page tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795e84f03c83238ce8c0e97d16e602