### PR TITLE
Add /users/me API

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -33,15 +33,22 @@ def get_db():
         db.close()
 
 
-def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> schemas.User:
     token = credentials.credentials
     try:
-        jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
     except jwt.PyJWTError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
         )
+    return schemas.User(
+        id=str(payload.get("sub", "")),
+        email=str(payload.get("email", "")),
+        nome=str(payload.get("nome", "")),
+    )
 
 
 @app.post("/segnalazioni", response_model=schemas.Segnalazione, dependencies=[Depends(get_current_user)])
@@ -52,3 +59,8 @@ def create_segnalazione(segnalazione: schemas.SegnalazioneCreate, db: Session = 
 @app.get("/segnalazioni", response_model=list[schemas.Segnalazione])
 def read_segnalazioni(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
     return crud.get_segnalazioni(db, skip=skip, limit=limit)
+
+
+@app.get("/users/me", response_model=schemas.User)
+def read_users_me(current_user: schemas.User = Depends(get_current_user)):
+    return current_user

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -18,3 +18,9 @@ class Segnalazione(SegnalazioneBase):
 
     class Config:
         orm_mode = True
+
+
+class User(BaseModel):
+    id: str
+    email: str
+    nome: str


### PR DESCRIPTION
## Summary
- create `User` schema
- decode JWT in `get_current_user`
- add `/users/me` endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796373a7308323927b0500caa7482a