### PR TITLE
Add HorizontalSignagePage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const UtilitaPage = React.lazy(() => import("./pages/UtilitaPage"));
 const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
 const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 const InventoryPage = React.lazy(() => import("./pages/InventoryPage"));
+const HorizontalSignagePage = React.lazy(() => import("./pages/HorizontalSignagePage"));
 const SegnalazioniPage = React.lazy(() => import("./pages/SegnalazioniPage"));
 
 
@@ -48,6 +49,7 @@ const App: React.FC = () => {
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
           <Route path="/inventario" element={<InventoryPage />} />
+          <Route path="/segnaletica-orizzontale" element={<HorizontalSignagePage />} />
           <Route path="/segnalazioni" element={<SegnalazioniPage />} />
         </Route>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,6 +30,7 @@ const Header: React.FC = () => {
           <Link to="/orari">🕑 Orari</Link>
           <Link to="/determinazioni">📄 Determine</Link>
           <Link to="/inventario">📦 Inventario</Link>
+          <Link to="/segnaletica-orizzontale">🚧 Orizzontale</Link>
           <Link to="/segnalazioni">🚨 Segnalazioni</Link>
           <Link to="/utilita">🤝 Riunioni</Link>
           <button onClick={logout} aria-label="Esci">🚪 esci</button>

--- a/src/pages/HorizontalSignagePage.tsx
+++ b/src/pages/HorizontalSignagePage.tsx
@@ -1,0 +1,316 @@
+import React, { useEffect, useState } from 'react'
+import './ListPages.css'
+import Modal from '../components/ui/Modal'
+import {
+  listHorizontalPlans,
+  createHorizontalPlan,
+  updateHorizontalPlan,
+  deleteHorizontalPlan,
+  HorizontalPlan,
+} from '../api/horizontalPlans'
+import {
+  listHorizontalSignageByPlan,
+  createHorizontalSignage,
+  updateHorizontalSignage,
+  getHorizontalSignagePdf,
+  HorizontalSign,
+} from '../api/horizontalSignage'
+
+const HorizontalSignagePage: React.FC = () => {
+  const [plans, setPlans] = useState<HorizontalPlan[]>([])
+  const [planDesc, setPlanDesc] = useState('')
+  const [planAnno, setPlanAnno] = useState('')
+  const [planSearch, setPlanSearch] = useState('')
+  const [planEdit, setPlanEdit] = useState<string | null>(null)
+  const [planOpen, setPlanOpen] = useState(false)
+
+  const [horizontals, setHorizontals] = useState<HorizontalSign[]>([])
+  const [showPlan, setShowPlan] = useState<string | null>(null)
+  const [horizLuogo, setHorizLuogo] = useState('')
+  const [horizData, setHorizData] = useState('')
+  const [horizDesc, setHorizDesc] = useState('')
+  const [horizQuant, setHorizQuant] = useState('')
+  const [horizEdit, setHorizEdit] = useState<string | null>(null)
+  const [horizOpen, setHorizOpen] = useState(false)
+  const [interventionsOpen, setInterventionsOpen] = useState(false)
+  const [pdfYear, setPdfYear] = useState('')
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        const p = await listHorizontalPlans()
+        setPlans(p)
+        localStorage.setItem('horizontalPlans', JSON.stringify(p))
+      } catch {
+        const stored = localStorage.getItem('horizontalPlans')
+        if (stored) setPlans(JSON.parse(stored))
+      }
+    }
+    fetchAll()
+  }, [])
+
+  const savePlans = (p: HorizontalPlan[]) =>
+    localStorage.setItem('horizontalPlans', JSON.stringify(p))
+
+  const resetPlan = () => {
+    setPlanDesc('')
+    setPlanAnno('')
+    setPlanEdit(null)
+    setPlanOpen(false)
+  }
+  const resetHoriz = () => {
+    setHorizLuogo('')
+    setHorizData('')
+    setHorizDesc('')
+    setHorizQuant('')
+    setHorizEdit(null)
+    setHorizOpen(false)
+  }
+
+  const submitPlan = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!planDesc) return
+    if (planEdit) {
+      const res = await updateHorizontalPlan(planEdit, {
+        descrizione: planDesc,
+        anno: planAnno ? Number(planAnno) : undefined,
+      })
+      const updated = plans.map(p => (p.id === planEdit ? res : p))
+      setPlans(updated)
+      savePlans(updated)
+    } else {
+      const res = await createHorizontalPlan({
+        descrizione: planDesc,
+        anno: planAnno ? Number(planAnno) : undefined,
+      })
+      const updated = [...plans, res]
+      setPlans(updated)
+      savePlans(updated)
+    }
+    resetPlan()
+    setPlanOpen(false)
+  }
+
+  const submitHoriz = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!horizLuogo || !horizData || !showPlan) return
+    const payload = {
+      luogo: horizLuogo,
+      data: horizData,
+      descrizione: horizDesc || undefined,
+      quantita: horizQuant ? Number(horizQuant) : undefined,
+      piano_id: showPlan,
+    }
+    if (horizEdit) {
+      const res = await updateHorizontalSignage(horizEdit, payload)
+      const updated = horizontals.map(h => (h.id === horizEdit ? res : h))
+      setHorizontals(updated)
+    } else {
+      const res = await createHorizontalSignage(payload)
+      setHorizontals([...horizontals, res])
+    }
+    resetHoriz()
+  }
+
+  const onPdf = async () => {
+    if (!pdfYear) return
+    const blob = await getHorizontalSignagePdf(Number(pdfYear))
+    const url = URL.createObjectURL(blob)
+    window.open(url, '_blank')
+  }
+
+  return (
+    <div className="list-page">
+      <div>
+        <h2>Segnaletica Orizzontale</h2>
+        <button type="button" onClick={() => { resetPlan(); setPlanOpen(true) }}>
+          Aggiungi
+        </button>
+        <Modal
+          open={planOpen}
+          onClose={resetPlan}
+          title={planEdit ? 'Modifica piano' : 'Nuovo piano'}
+        >
+          <form onSubmit={submitPlan} className="item-form">
+            <input
+              data-testid="plan-desc"
+              placeholder="Descrizione"
+              value={planDesc}
+              onChange={e => setPlanDesc(e.target.value)}
+            />
+            <input
+              data-testid="plan-anno"
+              type="number"
+              placeholder="Anno"
+              value={planAnno}
+              onChange={e => setPlanAnno(e.target.value)}
+            />
+            <button data-testid="plan-submit" type="submit">
+              {planEdit ? 'Salva' : 'Aggiungi'}
+            </button>
+            <button data-testid="plan-cancel" type="button" onClick={resetPlan}>
+              Annulla
+            </button>
+          </form>
+        </Modal>
+        <Modal
+          open={interventionsOpen}
+          onClose={() => {
+            setInterventionsOpen(false)
+            resetHoriz()
+          }}
+          title="Interventi"
+        >
+          <button
+            type="button"
+            onClick={() => {
+              resetHoriz()
+              setHorizOpen(true)
+            }}
+          >
+            Aggiungi
+          </button>
+          <table className="item-table">
+            <thead>
+              <tr>
+                <th>Luogo</th>
+                <th>Data</th>
+                <th>Descrizione</th>
+                <th>Quantità</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {horizontals.map(h => (
+                <tr key={h.id}>
+                  <td>{h.luogo}</td>
+                  <td>{h.data}</td>
+                  <td>{h.descrizione}</td>
+                  <td>{h.quantita}</td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        setHorizEdit(h.id)
+                        setHorizLuogo(h.luogo)
+                        setHorizData(h.data)
+                        setHorizDesc(h.descrizione || '')
+                        setHorizQuant(h.quantita?.toString() || '')
+                        setHorizOpen(true)
+                      }}
+                    >
+                      Modifica
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Modal>
+        <Modal
+          open={horizOpen}
+          onClose={resetHoriz}
+          title={horizEdit ? 'Modifica intervento' : 'Nuovo intervento'}
+        >
+          <form onSubmit={submitHoriz} className="item-form">
+            <input
+              placeholder="Luogo"
+              value={horizLuogo}
+              onChange={e => setHorizLuogo(e.target.value)}
+            />
+            <input
+              type="date"
+              value={horizData}
+              onChange={e => setHorizData(e.target.value)}
+            />
+            <input
+              placeholder="Descrizione"
+              value={horizDesc}
+              onChange={e => setHorizDesc(e.target.value)}
+            />
+            <input
+              type="number"
+              placeholder="Quantità"
+              value={horizQuant}
+              onChange={e => setHorizQuant(e.target.value)}
+            />
+            <button type="submit">{horizEdit ? 'Salva' : 'Aggiungi'}</button>
+            <button type="button" onClick={resetHoriz}>
+              Annulla
+            </button>
+          </form>
+        </Modal>
+        <input
+          placeholder="Cerca"
+          value={planSearch}
+          onChange={e => setPlanSearch(e.target.value)}
+        />
+        <table className="item-table">
+          <thead>
+            <tr>
+              <th>Descrizione</th>
+              <th>Anno</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {plans
+              .filter(p =>
+                p.descrizione.toLowerCase().includes(planSearch.toLowerCase())
+              )
+              .map(p => (
+                <tr key={p.id}>
+                  <td>{p.descrizione}</td>
+                  <td>{p.anno}</td>
+                  <td>
+                    <button
+                      onClick={() => {
+                        setPlanEdit(p.id)
+                        setPlanDesc(p.descrizione)
+                        setPlanAnno(p.anno.toString())
+                        setPlanOpen(true)
+                      }}
+                    >
+                      Modifica
+                    </button>
+                    <button
+                      onClick={async () => {
+                        await deleteHorizontalPlan(p.id)
+                        const u = plans.filter(x => x.id !== p.id)
+                        setPlans(u)
+                        savePlans(u)
+                      }}
+                    >
+                      Elimina
+                    </button>
+                    <button
+                      onClick={async () => {
+                        setShowPlan(p.id)
+                        const res = await listHorizontalSignageByPlan(p.id)
+                        setHorizontals(res)
+                        setInterventionsOpen(true)
+                      }}
+                    >
+                      Vedi interventi
+                    </button>
+                  </td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+        <div className="pdf-controls">
+          <input
+            data-testid="hor-year"
+            placeholder="Anno"
+            value={pdfYear}
+            onChange={e => setPdfYear(e.target.value)}
+          />
+          <button data-testid="hor-pdf" type="button" onClick={onPdf}>
+            PDF anno
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default HorizontalSignagePage

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -22,21 +22,6 @@ import {
   deleteVerticalSignage,
   VerticalSign,
 } from '../api/verticalSignage'
-import {
-  listHorizontalSignage,
-  getHorizontalSignagePdf,
-  createHorizontalSignage,
-  updateHorizontalSignage,
-  listHorizontalSignageByPlan,
-  HorizontalSign,
-} from '../api/horizontalSignage'
-import {
-  listHorizontalPlans,
-  createHorizontalPlan,
-  updateHorizontalPlan,
-  deleteHorizontalPlan,
-  HorizontalPlan,
-} from '../api/horizontalPlans'
 
 const InventoryPage: React.FC = () => {
   const [devices, setDevices] = useState<Device[]>([])
@@ -68,24 +53,6 @@ const InventoryPage: React.FC = () => {
   const [devOpen, setDevOpen] = useState(false)
   const [tempOpen, setTempOpen] = useState(false)
   const [vertOpen, setVertOpen] = useState(false)
-  const [planOpen, setPlanOpen] = useState(false)
-
-  const [plans, setPlans] = useState<HorizontalPlan[]>([])
-  const [planDesc, setPlanDesc] = useState('')
-  const [planAnno, setPlanAnno] = useState('')
-  const [planSearch, setPlanSearch] = useState('')
-  const [planEdit, setPlanEdit] = useState<string | null>(null)
-
-  const [horizontals, setHorizontals] = useState<HorizontalSign[]>([])
-  const [showPlan, setShowPlan] = useState<string | null>(null)
-  const [horizLuogo, setHorizLuogo] = useState('')
-  const [horizData, setHorizData] = useState('')
-  const [horizDesc, setHorizDesc] = useState('')
-  const [horizQuant, setHorizQuant] = useState('')
-  const [horizEdit, setHorizEdit] = useState<string | null>(null)
-  const [horizOpen, setHorizOpen] = useState(false)
-  const [interventionsOpen, setInterventionsOpen] = useState(false)
-  const [pdfYear, setPdfYear] = useState('')
 
   useEffect(() => {
     const fetchAll = async () => {
@@ -116,14 +83,6 @@ const InventoryPage: React.FC = () => {
         if (stored) setVerticals(JSON.parse(stored))
       }
 
-      try {
-        const p = await listHorizontalPlans()
-        setPlans(p)
-        localStorage.setItem('horizontalPlans', JSON.stringify(p))
-      } catch {
-        const stored = localStorage.getItem('horizontalPlans')
-        if (stored) setPlans(JSON.parse(stored))
-      }
     }
     fetchAll()
   }, [])
@@ -131,7 +90,6 @@ const InventoryPage: React.FC = () => {
   const saveDevices = (d: Device[]) => localStorage.setItem('devices', JSON.stringify(d))
   const saveTemps = (t: TemporarySign[]) => localStorage.setItem('temps', JSON.stringify(t))
   const saveVerticals = (v: VerticalSign[]) => localStorage.setItem('verticals', JSON.stringify(v))
-  const savePlans = (p: HorizontalPlan[]) => localStorage.setItem('horizontalPlans', JSON.stringify(p))
 
   const resetDevice = () => {
     setDevName('');
@@ -143,15 +101,6 @@ const InventoryPage: React.FC = () => {
   }
   const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempDesc(''); setTempAnno(''); setTempQuant(''); setTempEdit(null); setTempOpen(false) }
   const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertTipo(''); setVertAnno(''); setVertQuant(''); setVertEdit(null); setVertOpen(false) }
-  const resetPlan = () => { setPlanDesc(''); setPlanAnno(''); setPlanEdit(null); setPlanOpen(false) }
-  const resetHoriz = () => {
-    setHorizLuogo('')
-    setHorizData('')
-    setHorizDesc('')
-    setHorizQuant('')
-    setHorizEdit(null)
-    setHorizOpen(false)
-  }
 
   const submitDevice = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -237,57 +186,7 @@ const InventoryPage: React.FC = () => {
     setVertOpen(false)
   }
 
-  const submitPlan = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!planDesc) return
-    if (planEdit) {
-      const res = await updateHorizontalPlan(planEdit, {
-        descrizione: planDesc,
-        anno: planAnno ? Number(planAnno) : undefined,
-      })
-      const updated = plans.map(p => p.id === planEdit ? res : p)
-      setPlans(updated)
-      savePlans(updated)
-    } else {
-      const res = await createHorizontalPlan({
-        descrizione: planDesc,
-        anno: planAnno ? Number(planAnno) : undefined,
-      })
-      const updated = [...plans, res]
-      setPlans(updated)
-      savePlans(updated)
-    }
-    resetPlan()
-    setPlanOpen(false)
-  }
 
-  const submitHoriz = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!horizLuogo || !horizData || !showPlan) return
-    const payload = {
-      luogo: horizLuogo,
-      data: horizData,
-      descrizione: horizDesc || undefined,
-      quantita: horizQuant ? Number(horizQuant) : undefined,
-      piano_id: showPlan,
-    }
-    if (horizEdit) {
-      const res = await updateHorizontalSignage(horizEdit, payload)
-      const updated = horizontals.map(h => (h.id === horizEdit ? res : h))
-      setHorizontals(updated)
-    } else {
-      const res = await createHorizontalSignage(payload)
-      setHorizontals([...horizontals, res])
-    }
-    resetHoriz()
-  }
-
-  const onPdf = async () => {
-    if (!pdfYear) return
-    const blob = await getHorizontalSignagePdf(Number(pdfYear))
-    const url = URL.createObjectURL(blob)
-    window.open(url, '_blank')
-  }
 
   return (
     <div className="list-page">
@@ -407,82 +306,6 @@ const InventoryPage: React.FC = () => {
           </tbody>
         </table>
 
-        <h2>Segnaletica Orizzontale</h2>
-        <button type="button" onClick={() => { resetPlan(); setPlanOpen(true); }}>Aggiungi</button>
-        <Modal open={planOpen} onClose={resetPlan} title={planEdit ? 'Modifica piano' : 'Nuovo piano'}>
-          <form onSubmit={submitPlan} className="item-form">
-            <input data-testid="plan-desc" placeholder="Descrizione" value={planDesc} onChange={e => setPlanDesc(e.target.value)} />
-            <input data-testid="plan-anno" type="number" placeholder="Anno" value={planAnno} onChange={e => setPlanAnno(e.target.value)} />
-            <button data-testid="plan-submit" type="submit">{planEdit ? 'Salva' : 'Aggiungi'}</button>
-            <button data-testid="plan-cancel" type="button" onClick={resetPlan}>Annulla</button>
-          </form>
-        </Modal>
-        <Modal open={interventionsOpen} onClose={() => { setInterventionsOpen(false); resetHoriz() }} title="Interventi">
-          <button type="button" onClick={() => { resetHoriz(); setHorizOpen(true) }}>Aggiungi</button>
-          <table className="item-table">
-            <thead>
-              <tr><th>Luogo</th><th>Data</th><th>Descrizione</th><th>Quantità</th><th></th></tr>
-            </thead>
-            <tbody>
-              {horizontals.map(h => (
-                <tr key={h.id}>
-                  <td>{h.luogo}</td>
-                  <td>{h.data}</td>
-                  <td>{h.descrizione}</td>
-                  <td>{h.quantita}</td>
-                  <td>
-                    <button onClick={() => {
-                      setHorizEdit(h.id)
-                      setHorizLuogo(h.luogo)
-                      setHorizData(h.data)
-                      setHorizDesc(h.descrizione || '')
-                      setHorizQuant(h.quantita?.toString() || '')
-                      setHorizOpen(true)
-                    }}>Modifica</button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </Modal>
-        <Modal open={horizOpen} onClose={resetHoriz} title={horizEdit ? 'Modifica intervento' : 'Nuovo intervento'}>
-          <form onSubmit={submitHoriz} className="item-form">
-            <input placeholder="Luogo" value={horizLuogo} onChange={e => setHorizLuogo(e.target.value)} />
-            <input type="date" value={horizData} onChange={e => setHorizData(e.target.value)} />
-            <input placeholder="Descrizione" value={horizDesc} onChange={e => setHorizDesc(e.target.value)} />
-            <input type="number" placeholder="Quantità" value={horizQuant} onChange={e => setHorizQuant(e.target.value)} />
-            <button type="submit">{horizEdit ? 'Salva' : 'Aggiungi'}</button>
-            <button type="button" onClick={resetHoriz}>Annulla</button>
-          </form>
-        </Modal>
-        <input placeholder="Cerca" value={planSearch} onChange={e => setPlanSearch(e.target.value)} />
-        <table className="item-table">
-          <thead>
-            <tr><th>Descrizione</th><th>Anno</th><th></th></tr>
-          </thead>
-          <tbody>
-            {plans.filter(p => p.descrizione.toLowerCase().includes(planSearch.toLowerCase())).map(p => (
-              <tr key={p.id}>
-                <td>{p.descrizione}</td>
-                <td>{p.anno}</td>
-                <td>
-                  <button onClick={() => { setPlanEdit(p.id); setPlanDesc(p.descrizione); setPlanAnno(p.anno.toString()); setPlanOpen(true) }}>Modifica</button>
-                  <button onClick={async () => { await deleteHorizontalPlan(p.id); const u = plans.filter(x => x.id !== p.id); setPlans(u); savePlans(u) }}>Elimina</button>
-                  <button onClick={async () => {
-                    setShowPlan(p.id)
-                    const res = await listHorizontalSignageByPlan(p.id)
-                    setHorizontals(res)
-                    setInterventionsOpen(true)
-                  }}>Vedi interventi</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <div className="pdf-controls">
-          <input data-testid="hor-year" placeholder="Anno" value={pdfYear} onChange={e => setPdfYear(e.target.value)} />
-          <button data-testid="hor-pdf" type="button" onClick={onPdf}>PDF anno</button>
-        </div>
       </div>
     </div>
   )

--- a/src/pages/__tests__/HorizontalSignagePage.test.tsx
+++ b/src/pages/__tests__/HorizontalSignagePage.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import HorizontalSignagePage from '../HorizontalSignagePage'
+import PageTemplate from '../../components/PageTemplate'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import * as planApi from '../../api/horizontalPlans'
+import * as horizApi from '../../api/horizontalSignage'
+
+jest.mock('../../api/horizontalPlans', () => ({
+  __esModule: true,
+  listHorizontalPlans: jest.fn(),
+  createHorizontalPlan: jest.fn(),
+  updateHorizontalPlan: jest.fn(),
+  deleteHorizontalPlan: jest.fn(),
+}))
+
+jest.mock('../../api/horizontalSignage', () => ({
+  __esModule: true,
+  listHorizontalSignage: jest.fn(),
+  createHorizontalSignage: jest.fn(),
+  updateHorizontalSignage: jest.fn(),
+  deleteHorizontalSignage: jest.fn(),
+  getHorizontalSignagePdf: jest.fn(),
+  listHorizontalSignageByPlan: jest.fn(),
+}))
+
+const mockedPlans = planApi as jest.Mocked<typeof planApi>
+const mockedHoriz = horizApi as jest.Mocked<typeof horizApi>
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockedPlans.listHorizontalPlans.mockResolvedValue([])
+  mockedHoriz.listHorizontalSignage.mockResolvedValue([])
+  mockedHoriz.listHorizontalSignageByPlan.mockResolvedValue([])
+  mockedHoriz.getHorizontalSignagePdf.mockResolvedValue(new Blob())
+  mockedHoriz.createHorizontalSignage.mockResolvedValue({
+    id: 'h1',
+    luogo: 'Luogo',
+    data: '2024-01-01',
+  } as any)
+})
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/segnaletica-orizzontale']}>
+      <Routes>
+        <Route element={<PageTemplate />}>
+          <Route path="/segnaletica-orizzontale" element={<HorizontalSignagePage />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('HorizontalSignagePage', () => {
+  it('opens interventions modal', async () => {
+    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([
+      { id: 'p1', descrizione: 'Piano 1', anno: 2024 } as any,
+    ])
+    renderPage()
+
+    const row = await screen.findByRole('row', { name: /piano 1/i })
+    const seeBtn = within(row).getByRole('button', { name: /vedi interventi/i })
+    const dialogs = screen.getAllByRole('dialog')
+    expect(dialogs[1]).not.toHaveAttribute('open')
+
+    await userEvent.click(seeBtn)
+
+    expect(dialogs[1]).toHaveAttribute('open')
+    expect(mockedHoriz.listHorizontalSignageByPlan).toHaveBeenCalledWith('p1')
+  })
+
+  it('adds horizontal intervention', async () => {
+    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([
+      { id: 'p1', descrizione: 'Piano 1', anno: 2024 } as any,
+    ])
+    renderPage()
+
+    const row = await screen.findByRole('row', { name: /piano 1/i })
+    const seeBtn = within(row).getByRole('button', { name: /vedi interventi/i })
+    await userEvent.click(seeBtn)
+
+    const interventions = screen.getAllByRole('dialog')[1]
+    await userEvent.click(within(interventions).getByRole('button', { name: /aggiungi/i }))
+
+    const horizDialog = screen.getAllByRole('dialog')[2]
+    const withinHoriz = within(horizDialog)
+    const [luogoInput, dateInput, descInput] = withinHoriz.getAllByRole('textbox')
+    await userEvent.type(luogoInput, 'Luogo')
+    await userEvent.type(dateInput, '2024-01-01')
+    await userEvent.type(descInput, 'Desc')
+    await userEvent.type(withinHoriz.getByPlaceholderText('Quantità'), '2')
+    await userEvent.click(withinHoriz.getByRole('button', { name: /aggiungi/i }))
+
+    expect(mockedHoriz.createHorizontalSignage).toHaveBeenCalledWith({
+      luogo: 'Luogo',
+      data: '2024-01-01',
+      descrizione: 'Desc',
+      quantita: 2,
+      piano_id: 'p1',
+    })
+  })
+
+  it('downloads PDF by year', async () => {
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
+    const urlSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:1')
+
+    renderPage()
+    await userEvent.type(screen.getByTestId('hor-year'), '2023')
+    await userEvent.click(screen.getByTestId('hor-pdf'))
+
+    expect(mockedHoriz.getHorizontalSignagePdf).toHaveBeenCalledWith(2023)
+    expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank')
+
+    openSpy.mockRestore()
+    urlSpy.mockRestore()
+  })
+})

--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -6,8 +6,6 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import * as devicesApi from '../../api/devices'
 import * as tempApi from '../../api/temporarySignage'
 import * as vertApi from '../../api/verticalSignage'
-import * as planApi from '../../api/horizontalPlans'
-import * as horizApi from '../../api/horizontalSignage'
 
 jest.mock('../../api/devices', () => ({
   __esModule: true,
@@ -33,29 +31,11 @@ jest.mock('../../api/verticalSignage', () => ({
   deleteVerticalSignage: jest.fn(),
 }))
 
-jest.mock('../../api/horizontalPlans', () => ({
-  __esModule: true,
-  listHorizontalPlans: jest.fn(),
-  createHorizontalPlan: jest.fn(),
-  updateHorizontalPlan: jest.fn(),
-  deleteHorizontalPlan: jest.fn(),
-}))
-
-jest.mock('../../api/horizontalSignage', () => ({
-  __esModule: true,
-  listHorizontalSignage: jest.fn(),
-  createHorizontalSignage: jest.fn(),
-  updateHorizontalSignage: jest.fn(),
-  deleteHorizontalSignage: jest.fn(),
-  getHorizontalSignagePdf: jest.fn(),
-  listHorizontalSignageByPlan: jest.fn(),
-}))
 
 const mockedDevices = devicesApi as jest.Mocked<typeof devicesApi>
 const mockedTemps = tempApi as jest.Mocked<typeof tempApi>
 const mockedVerts = vertApi as jest.Mocked<typeof vertApi>
-const mockedPlans = planApi as jest.Mocked<typeof planApi>
-const mockedHoriz = horizApi as jest.Mocked<typeof horizApi>
+
 
 beforeEach(() => {
   jest.resetAllMocks()
@@ -63,20 +43,12 @@ beforeEach(() => {
   mockedDevices.listDevices.mockResolvedValue([])
   mockedTemps.listTemporarySignage.mockResolvedValue([])
   mockedVerts.listVerticalSignage.mockResolvedValue([])
-  mockedPlans.listHorizontalPlans.mockResolvedValue([])
-  mockedHoriz.listHorizontalSignage.mockResolvedValue([])
-  mockedHoriz.listHorizontalSignageByPlan.mockResolvedValue([])
-  mockedHoriz.getHorizontalSignagePdf.mockResolvedValue(new Blob())
+
   mockedDevices.createDevice.mockResolvedValue({ id: '1', nome: 'Device 1' } as any)
   mockedTemps.createTemporarySignage.mockResolvedValue({
     id: 't1',
     luogo: 'Luogo',
     fine_validita: '2024-01-01',
-  } as any)
-  mockedHoriz.createHorizontalSignage.mockResolvedValue({
-    id: 'h1',
-    luogo: 'Luogo',
-    data: '2024-01-01',
   } as any)
 })
 
@@ -159,66 +131,4 @@ describe('InventoryPage', () => {
     })
   })
 
-  it('opens interventions modal', async () => {
-    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([
-      { id: 'p1', descrizione: 'Piano 1', anno: 2024 } as any,
-    ])
-    renderPage()
-
-    const row = await screen.findByRole('row', { name: /piano 1/i })
-    const seeBtn = within(row).getByRole('button', { name: /vedi interventi/i })
-    const dialogs = screen.getAllByRole('dialog')
-    expect(dialogs[4]).not.toHaveAttribute('open')
-
-    await userEvent.click(seeBtn)
-
-    expect(dialogs[4]).toHaveAttribute('open')
-    expect(mockedHoriz.listHorizontalSignageByPlan).toHaveBeenCalledWith('p1')
-  })
-
-  it('adds horizontal intervention', async () => {
-    mockedPlans.listHorizontalPlans.mockResolvedValueOnce([
-      { id: 'p1', descrizione: 'Piano 1', anno: 2024 } as any,
-    ])
-    renderPage()
-
-    const row = await screen.findByRole('row', { name: /piano 1/i })
-    const seeBtn = within(row).getByRole('button', { name: /vedi interventi/i })
-    await userEvent.click(seeBtn)
-
-    const interventions = screen.getAllByRole('dialog')[4]
-    await userEvent.click(within(interventions).getByRole('button', { name: /aggiungi/i }))
-
-    const horizDialog = screen.getAllByRole('dialog')[5]
-    const withinHoriz = within(horizDialog)
-    const [luogoInput, dateInput, descInput] = withinHoriz.getAllByRole('textbox')
-    await userEvent.type(luogoInput, 'Luogo')
-    await userEvent.type(dateInput, '2024-01-01')
-    await userEvent.type(descInput, 'Desc')
-    await userEvent.type(withinHoriz.getByPlaceholderText('Quantità'), '2')
-    await userEvent.click(withinHoriz.getByRole('button', { name: /aggiungi/i }))
-
-    expect(mockedHoriz.createHorizontalSignage).toHaveBeenCalledWith({
-      luogo: 'Luogo',
-      data: '2024-01-01',
-      descrizione: 'Desc',
-      quantita: 2,
-      piano_id: 'p1',
-    })
-  })
-
-  it('downloads PDF by year', async () => {
-    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null)
-    const urlSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:1')
-
-    renderPage()
-    await userEvent.type(screen.getByTestId('hor-year'), '2023')
-    await userEvent.click(screen.getByTestId('hor-pdf'))
-
-    expect(mockedHoriz.getHorizontalSignagePdf).toHaveBeenCalledWith(2023)
-    expect(openSpy).toHaveBeenCalledWith('blob:1', '_blank')
-
-    openSpy.mockRestore()
-    urlSpy.mockRestore()
-  })
 })


### PR DESCRIPTION
## Summary
- move horizontal signage management off Inventory page
- add HorizontalSignagePage and route
- link new page from header
- update tests for InventoryPage
- add tests for HorizontalSignagePage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687965bba8988323bc71dc2224209c7a