### PR TITLE
Add WIP banner to horizontal signage page

### DIFF
--- a/src/pages/HorizontalSignagePage.tsx
+++ b/src/pages/HorizontalSignagePage.tsx
@@ -121,6 +121,7 @@ const HorizontalSignagePage: React.FC = () => {
 
   return (
     <div className="list-page">
+      <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
       <div>
         <h2>Segnaletica Orizzontale</h2>
         <button type="button" onClick={() => { resetPlan(); setPlanOpen(true) }}>


### PR DESCRIPTION
## Summary
- show the same 'lavori in corso' banner used on the Inventory page on the Horizontal Signage page

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: ESLint couldn't find plugin @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6879684755188323a29b289448aa0305