### PR TITLE
Reorder inventory sections

### DIFF
--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -292,7 +292,8 @@ const InventoryPage: React.FC = () => {
   return (
     <div className="list-page">
       <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
-      <div>
+      <div className="inventory-wrapper">
+        <div className="devices-section">
         <h2>Dispositivi</h2>
         <button type="button" onClick={() => { resetDevice(); setDevOpen(true); }}>Aggiungi</button>
         <Modal open={devOpen} onClose={resetDevice} title={devEdit ? 'Modifica dispositivo' : 'Nuovo dispositivo'}>
@@ -334,7 +335,7 @@ const InventoryPage: React.FC = () => {
         </table>
       </div>
 
-      <div>
+      <div className="temp-section">
         <h2>Segnaletica Temporanea</h2>
         <button type="button" onClick={() => { resetTemp(); setTempOpen(true); }}>Aggiungi</button>
         <Modal open={tempOpen} onClose={resetTemp} title={tempEdit ? 'Modifica temporanea' : 'Nuova segnaletica'}>
@@ -371,7 +372,7 @@ const InventoryPage: React.FC = () => {
         </table>
       </div>
 
-      <div>
+      <div className="vertical-section">
         <h2>Segnaletica Verticale</h2>
         <button type="button" onClick={() => { resetVert(); setVertOpen(true); }}>Aggiungi</button>
         <Modal open={vertOpen} onClose={resetVert} title={vertEdit ? 'Modifica verticale' : 'Nuova segnaletica'}>
@@ -485,6 +486,7 @@ const InventoryPage: React.FC = () => {
         </div>
       </div>
     </div>
+  </div>
   )
 }
 

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -242,3 +242,18 @@
   margin-bottom: 0.5rem;
   border-radius: 4px;
 }
+
+/* Inventory layout */
+.inventory-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.inventory-wrapper > .temp-section,
+.inventory-wrapper > .vertical-section {
+  flex: 1;
+}
+.inventory-wrapper > .devices-section {
+  order: 2;
+  flex-basis: 100%;
+}


### PR DESCRIPTION
## Summary
- align temporary and vertical signage sections side-by-side
- move devices section below signage
- style new layout via `inventory-wrapper`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_687967f1d6788323912de8336a53f23c