### PR TITLE
Update segnalazioni tests

### DIFF
--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet'
 import { createSegnalazione, listSegnalazioni, Segnalazione } from '../api/segnalazioni'
 import './ListPages.css'
+import Modal from '../components/ui/Modal'
 
 const LocationMarker: React.FC<{
   position: [number, number] | null
@@ -28,6 +29,7 @@ const SegnalazioniPage: React.FC = () => {
   const [stato, setStato] = useState('')
   const [pos, setPos] = useState<[number, number] | null>(null)
   const [error, setError] = useState('')
+  const [showCompleted, setShowCompleted] = useState(false)
 
   useEffect(() => {
     const fetch = async () => {
@@ -94,18 +96,24 @@ const SegnalazioniPage: React.FC = () => {
           value={data}
           onChange={e => setData(e.target.value)}
         />
-        <input
-          placeholder="Stato"
+        <label htmlFor="stato">Stato</label>
+        <select
+          id="stato"
           value={stato}
           onChange={e => setStato(e.target.value)}
-        />
+        >
+          <option value="">Stato</option>
+          <option value="Aperta">Aperta</option>
+          <option value="In corso">In corso</option>
+          <option value="Chiusa">Chiusa</option>
+        </select>
         <textarea placeholder="Descrizione" value={descrizione} onChange={e => setDescrizione(e.target.value)} />
         <button type="submit">Invia</button>
       </form>
       <MapContainer center={[45.9229, 10.0644]} zoom={13} style={{ height: '400px', width: '100%' }} data-testid="map">
         <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
         <LocationMarker position={pos} onChange={setPos} />
-        {items.map((item, idx) => (
+        {items.filter(item => item.stato !== 'Chiusa').map((item, idx) => (
           <Marker key={idx} position={[item.latitudine, item.longitudine]}>
             <Popup>
               <strong>{item.tipo}</strong>
@@ -121,6 +129,22 @@ const SegnalazioniPage: React.FC = () => {
           </Marker>
         ))}
       </MapContainer>
+      <button type="button" onClick={() => setShowCompleted(true)}>
+        Completate
+      </button>
+      <Modal
+        open={showCompleted}
+        onClose={() => setShowCompleted(false)}
+        title="Segnalazioni completate"
+      >
+        <ul>
+          {items
+            .filter(item => item.stato === 'Chiusa')
+            .map(item => (
+              <li key={item.id}>{item.tipo}</li>
+            ))}
+        </ul>
+      </Modal>
     </div>
   )
 }

--- a/src/pages/__tests__/SegnalazioniPage.test.tsx
+++ b/src/pages/__tests__/SegnalazioniPage.test.tsx
@@ -57,8 +57,10 @@ describe('SegnalazioniPage', () => {
     )
 
     const selects = screen.getAllByRole('combobox')
-    expect(selects).toHaveLength(2)
-    expect(screen.getByPlaceholderText(/stato/i)).toBeInTheDocument()
+    expect(selects).toHaveLength(3)
+    expect(
+      screen.getByRole('combobox', { name: /stato/i })
+    ).toBeInTheDocument()
     expect(screen.getByLabelText(/data/i)).toHaveAttribute('type', 'datetime-local')
   })
 
@@ -94,5 +96,47 @@ describe('SegnalazioniPage', () => {
 
     expect(mockedApi.createSegnalazione).toHaveBeenCalled()
     expect(map.querySelectorAll('.leaflet-marker-icon')).toHaveLength(1)
+  })
+
+  it('handles closed segnalazioni', async () => {
+    mockedApi.listSegnalazioni.mockResolvedValue([
+      {
+        id: '1',
+        tipo: 'Buco',
+        priorita: 'Alta',
+        data: '2024-01-01',
+        descrizione: 'desc',
+        stato: 'Aperta',
+        latitudine: 0,
+        longitudine: 0,
+      },
+      {
+        id: '2',
+        tipo: 'Rifiuti',
+        priorita: 'Bassa',
+        data: '2024-01-02',
+        descrizione: 'desc2',
+        stato: 'Chiusa',
+        latitudine: 1,
+        longitudine: 1,
+      },
+    ])
+
+    render(
+      <MemoryRouter initialEntries={["/segnalazioni"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/segnalazioni" element={<SegnalazioniPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    const map = await screen.findByTestId('map')
+    expect(map.querySelectorAll('.leaflet-marker-icon')).toHaveLength(1)
+
+    await userEvent.click(screen.getByRole('button', { name: /completate/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('Rifiuti')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- update Segnalazioni page with status combobox and completed modal
- adjust "shows form fields" test
- add regression test for completed segnalazioni

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: missing @typescript-eslint/eslint-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e9091ac832389d88e36cf8b14cd