### PR TITLE
Add closed segnalazioni modal

### DIFF
--- a/src/pages/__tests__/SegnalazioniPage.test.tsx
+++ b/src/pages/__tests__/SegnalazioniPage.test.tsx
@@ -57,8 +57,8 @@ describe('SegnalazioniPage', () => {
     )
 
     const selects = screen.getAllByRole('combobox')
-    expect(selects).toHaveLength(2)
-    expect(screen.getByPlaceholderText(/stato/i)).toBeInTheDocument()
+    expect(selects).toHaveLength(3)
+    expect(screen.getByLabelText(/stato/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/data/i)).toHaveAttribute('type', 'datetime-local')
   })
 


### PR DESCRIPTION
## Summary
- show marker state with a select input for `stato`
- compute and display completed segnalazioni in a modal
- filter closed segnalazioni from the map
- adapt SegnalazioniPage test for new select

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e8e0a588323921bbd7a4b9cc1f4