### PR TITLE
Sposta segnaletica in pagina dedicata

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ The `/events` page shows the same calendar in **week** view.
 
 ## Inventory
 
-Visit `/inventario` to manage devices and road signage. Items open in modal
-dialogs for editing and each record includes a **quantità** field. The backend
-exposes Italian endpoint paths such as `/dispositivi`,
-`/inventario/signage-temp`, `/inventario/signage-vertical` and
-`/inventario/signage-horizontal`. Horizontal signage offers a **PDF anno** button
-that calls `/inventario/signage-horizontal/pdf?year=YYYY` to download the annual
-plan.
+Visit `/inventario` to manage only the available devices. Temporary and vertical
+signage have moved to the `/segnaletica` page. Items open in modal dialogs for
+editing and each record includes a **quantità** field. The backend exposes
+Italian endpoint paths such as `/dispositivi`, `/segnaletica-temporanea`,
+`/segnaletica-verticale` and `/inventario/signage-horizontal`. Horizontal
+signage offers a **PDF anno** button that calls
+`/inventario/signage-horizontal/pdf?year=YYYY` to download the annual plan.
 
 ## Segnalazioni
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
 const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 const InventoryPage = React.lazy(() => import("./pages/InventoryPage"));
 const HorizontalSignagePage = React.lazy(() => import("./pages/HorizontalSignagePage"));
+const SignagePage = React.lazy(() => import("./pages/SignagePage"));
 const SegnalazioniPage = React.lazy(() => import("./pages/SegnalazioniPage"));
 
 
@@ -49,6 +50,7 @@ const App: React.FC = () => {
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
           <Route path="/inventario" element={<InventoryPage />} />
+          <Route path="/segnaletica" element={<SignagePage />} />
           <Route path="/segnaletica-orizzontale" element={<HorizontalSignagePage />} />
           <Route path="/segnalazioni" element={<SegnalazioniPage />} />
         </Route>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,6 +30,7 @@ const Header: React.FC = () => {
           <Link to="/orari">🕑 Orari</Link>
           <Link to="/determinazioni">📄 Determine</Link>
           <Link to="/inventario">📦 Inventario</Link>
+          <Link to="/segnaletica">🚦 Segnaletica</Link>
           <Link to="/segnaletica-orizzontale">🚧 Orizzontale</Link>
           <Link to="/segnalazioni">🚨 Segnalazioni</Link>
           <Link to="/utilita">🤝 Riunioni</Link>

--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -8,20 +8,6 @@ import {
   deleteDevice,
   Device,
 } from '../api/devices'
-import {
-  listTemporarySignage,
-  createTemporarySignage,
-  updateTemporarySignage,
-  deleteTemporarySignage,
-  TemporarySign,
-} from '../api/temporarySignage'
-import {
-  listVerticalSignage,
-  createVerticalSignage,
-  updateVerticalSignage,
-  deleteVerticalSignage,
-  VerticalSign,
-} from '../api/verticalSignage'
 
 const InventoryPage: React.FC = () => {
   const [devices, setDevices] = useState<Device[]>([])
@@ -32,27 +18,7 @@ const InventoryPage: React.FC = () => {
   const [devSearch, setDevSearch] = useState('')
   const [devEdit, setDevEdit] = useState<string | null>(null)
 
-  const [temps, setTemps] = useState<TemporarySign[]>([])
-  const [tempLuogo, setTempLuogo] = useState('')
-  const [tempFine, setTempFine] = useState('')
-  const [tempDesc, setTempDesc] = useState('')
-  const [tempAnno, setTempAnno] = useState('')
-  const [tempQuant, setTempQuant] = useState('')
-  const [tempSearch, setTempSearch] = useState('')
-  const [tempEdit, setTempEdit] = useState<string | null>(null)
-
-  const [verticals, setVerticals] = useState<VerticalSign[]>([])
-  const [vertLuogo, setVertLuogo] = useState('')
-  const [vertDesc, setVertDesc] = useState('')
-  const [vertTipo, setVertTipo] = useState('')
-  const [vertAnno, setVertAnno] = useState('')
-  const [vertQuant, setVertQuant] = useState('')
-  const [vertSearch, setVertSearch] = useState('')
-  const [vertEdit, setVertEdit] = useState<string | null>(null)
-
   const [devOpen, setDevOpen] = useState(false)
-  const [tempOpen, setTempOpen] = useState(false)
-  const [vertOpen, setVertOpen] = useState(false)
 
   useEffect(() => {
     const fetchAll = async () => {
@@ -65,31 +31,13 @@ const InventoryPage: React.FC = () => {
         if (stored) setDevices(JSON.parse(stored))
       }
 
-      try {
-        const t = await listTemporarySignage()
-        setTemps(t)
-        localStorage.setItem('temps', JSON.stringify(t))
-      } catch {
-        const stored = localStorage.getItem('temps')
-        if (stored) setTemps(JSON.parse(stored))
-      }
 
-      try {
-        const v = await listVerticalSignage()
-        setVerticals(v)
-        localStorage.setItem('verticals', JSON.stringify(v))
-      } catch {
-        const stored = localStorage.getItem('verticals')
-        if (stored) setVerticals(JSON.parse(stored))
-      }
 
     }
     fetchAll()
   }, [])
 
   const saveDevices = (d: Device[]) => localStorage.setItem('devices', JSON.stringify(d))
-  const saveTemps = (t: TemporarySign[]) => localStorage.setItem('temps', JSON.stringify(t))
-  const saveVerticals = (v: VerticalSign[]) => localStorage.setItem('verticals', JSON.stringify(v))
 
   const resetDevice = () => {
     setDevName('');
@@ -99,8 +47,6 @@ const InventoryPage: React.FC = () => {
     setDevEdit(null);
     setDevOpen(false);
   }
-  const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempDesc(''); setTempAnno(''); setTempQuant(''); setTempEdit(null); setTempOpen(false) }
-  const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertTipo(''); setVertAnno(''); setVertQuant(''); setVertEdit(null); setVertOpen(false) }
 
   const submitDevice = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -126,65 +72,7 @@ const InventoryPage: React.FC = () => {
     setDevOpen(false)
   }
 
-  const submitTemp = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!tempLuogo || !tempFine) return
-    if (tempEdit) {
-      const res = await updateTemporarySignage(tempEdit, {
-        luogo: tempLuogo,
-        fine_validita: tempFine,
-        descrizione: tempDesc,
-        quantita: tempQuant ? Number(tempQuant) : undefined,
-        anno: tempAnno ? Number(tempAnno) : undefined,
-      })
-      const updated = temps.map(t => t.id === tempEdit ? res : t)
-      setTemps(updated)
-      saveTemps(updated)
-    } else {
-      const res = await createTemporarySignage({
-        luogo: tempLuogo,
-        fine_validita: tempFine,
-        descrizione: tempDesc,
-        quantita: tempQuant ? Number(tempQuant) : undefined,
-        anno: tempAnno ? Number(tempAnno) : undefined,
-      })
-      const updated = [...temps, res]
-      setTemps(updated)
-      saveTemps(updated)
-    }
-    resetTemp()
-    setTempOpen(false)
-  }
 
-  const submitVert = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!vertLuogo || !vertDesc) return
-    if (vertEdit) {
-      const res = await updateVerticalSignage(vertEdit, {
-        luogo: vertLuogo,
-        descrizione: vertDesc,
-        tipo: vertTipo,
-        anno: vertAnno ? Number(vertAnno) : undefined,
-        quantita: vertQuant ? Number(vertQuant) : undefined
-      })
-      const updated = verticals.map(v => v.id === vertEdit ? res : v)
-      setVerticals(updated)
-      saveVerticals(updated)
-    } else {
-      const res = await createVerticalSignage({
-        luogo: vertLuogo,
-        descrizione: vertDesc,
-        tipo: vertTipo,
-        anno: vertAnno ? Number(vertAnno) : undefined,
-        quantita: vertQuant ? Number(vertQuant) : undefined
-      })
-      const updated = [...verticals, res]
-      setVerticals(updated)
-      saveVerticals(updated)
-    }
-    resetVert()
-    setVertOpen(false)
-  }
 
 
 
@@ -234,80 +122,6 @@ const InventoryPage: React.FC = () => {
         </table>
       </div>
 
-      <div className="temp-section">
-        <h2>Segnaletica Temporanea</h2>
-        <button type="button" onClick={() => { resetTemp(); setTempOpen(true); }}>Aggiungi</button>
-        <Modal open={tempOpen} onClose={resetTemp} title={tempEdit ? 'Modifica temporanea' : 'Nuova segnaletica'}>
-          <form onSubmit={submitTemp} className="item-form">
-            <input data-testid="temp-luogo" placeholder="Luogo" value={tempLuogo} onChange={e => setTempLuogo(e.target.value)} />
-            <input data-testid="temp-fine" type="date" value={tempFine} onChange={e => setTempFine(e.target.value)} />
-            <input data-testid="temp-desc" placeholder="Descrizione" value={tempDesc} onChange={e => setTempDesc(e.target.value)} />
-            <input data-testid="temp-anno" type="number" placeholder="Anno" value={tempAnno} onChange={e => setTempAnno(e.target.value)} />
-            <input data-testid="temp-quant" type="number" placeholder="Quantità" value={tempQuant} onChange={e => setTempQuant(e.target.value)} />
-            <button data-testid="temp-submit" type="submit">{tempEdit ? 'Salva' : 'Aggiungi'}</button>
-            <button data-testid="temp-cancel" type="button" onClick={resetTemp}>Annulla</button>
-          </form>
-        </Modal>
-        <input placeholder="Cerca" value={tempSearch} onChange={e => setTempSearch(e.target.value)} />
-        <table className="item-table">
-          <thead>
-            <tr><th>Luogo</th><th>Fine validità</th><th>Descrizione</th><th>Anno</th><th>Quantità</th><th></th></tr>
-          </thead>
-          <tbody>
-            {temps.filter(t => t.luogo.toLowerCase().includes(tempSearch.toLowerCase())).map(t => (
-              <tr key={t.id}>
-                <td>{t.luogo}</td>
-                <td>{t.fine_validita}</td>
-                <td>{t.descrizione}</td>
-                <td>{t.anno}</td>
-                <td>{t.quantita}</td>
-                <td>
-                  <button onClick={() => { setTempEdit(t.id); setTempLuogo(t.luogo); setTempFine(t.fine_validita); setTempDesc(t.descrizione || ''); setTempAnno(t.anno?.toString() || ''); setTempQuant(t.quantita?.toString() || ''); setTempOpen(true) }}>Modifica</button>
-                  <button onClick={async () => { await deleteTemporarySignage(t.id); const u = temps.filter(x => x.id !== t.id); setTemps(u); saveTemps(u) }}>Elimina</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="vertical-section">
-        <h2>Segnaletica Verticale</h2>
-        <button type="button" onClick={() => { resetVert(); setVertOpen(true); }}>Aggiungi</button>
-        <Modal open={vertOpen} onClose={resetVert} title={vertEdit ? 'Modifica verticale' : 'Nuova segnaletica'}>
-          <form onSubmit={submitVert} className="item-form">
-            <input data-testid="vert-luogo" placeholder="Luogo" value={vertLuogo} onChange={e => setVertLuogo(e.target.value)} />
-            <input data-testid="vert-desc" placeholder="Descrizione" value={vertDesc} onChange={e => setVertDesc(e.target.value)} />
-            <input data-testid="vert-tipo" placeholder="Tipo" value={vertTipo} onChange={e => setVertTipo(e.target.value)} />
-            <input data-testid="vert-anno" type="number" placeholder="Anno" value={vertAnno} onChange={e => setVertAnno(e.target.value)} />
-            <input data-testid="vert-quant" type="number" placeholder="Quantità" value={vertQuant} onChange={e => setVertQuant(e.target.value)} />
-            <button data-testid="vert-submit" type="submit">{vertEdit ? 'Salva' : 'Aggiungi'}</button>
-            <button data-testid="vert-cancel" type="button" onClick={resetVert}>Annulla</button>
-          </form>
-        </Modal>
-        <input placeholder="Cerca" value={vertSearch} onChange={e => setVertSearch(e.target.value)} />
-        <table className="item-table">
-          <thead>
-            <tr><th>Luogo</th><th>Descrizione</th><th>Tipo</th><th>Anno</th><th>Quantità</th><th></th></tr>
-          </thead>
-          <tbody>
-            {verticals.filter(v => v.luogo.toLowerCase().includes(vertSearch.toLowerCase())).map(v => (
-              <tr key={v.id}>
-                <td>{v.luogo}</td>
-                <td>{v.descrizione}</td>
-                <td>{v.tipo}</td>
-                <td>{v.anno}</td>
-                <td>{v.quantita}</td>
-                <td>
-                  <button onClick={() => { setVertEdit(v.id); setVertLuogo(v.luogo); setVertDesc(v.descrizione); setVertTipo(v.tipo || ''); setVertAnno(v.anno?.toString() || ''); setVertQuant(v.quantita?.toString() || ''); setVertOpen(true) }}>Modifica</button>
-                  <button onClick={async () => { await deleteVerticalSignage(v.id); const u = verticals.filter(x => x.id !== v.id); setVerticals(u); saveVerticals(u) }}>Elimina</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-
-      </div>
     </div>
   </div>
   )

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -248,12 +248,12 @@
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
+  justify-content: center;
 }
 .inventory-wrapper > .temp-section,
 .inventory-wrapper > .vertical-section {
   flex: 1;
 }
 .inventory-wrapper > .devices-section {
-  order: 2;
-  flex-basis: 100%;
+  flex-basis: auto;
 }

--- a/src/pages/SignagePage.tsx
+++ b/src/pages/SignagePage.tsx
@@ -1,0 +1,228 @@
+import React, { useEffect, useState } from 'react'
+import './ListPages.css'
+import Modal from '../components/ui/Modal'
+import {
+  listTemporarySignage,
+  createTemporarySignage,
+  updateTemporarySignage,
+  deleteTemporarySignage,
+  TemporarySign,
+} from '../api/temporarySignage'
+import {
+  listVerticalSignage,
+  createVerticalSignage,
+  updateVerticalSignage,
+  deleteVerticalSignage,
+  VerticalSign,
+} from '../api/verticalSignage'
+
+const SignagePage: React.FC = () => {
+  const [temps, setTemps] = useState<TemporarySign[]>([])
+  const [tempLuogo, setTempLuogo] = useState('')
+  const [tempFine, setTempFine] = useState('')
+  const [tempDesc, setTempDesc] = useState('')
+  const [tempAnno, setTempAnno] = useState('')
+  const [tempQuant, setTempQuant] = useState('')
+  const [tempSearch, setTempSearch] = useState('')
+  const [tempEdit, setTempEdit] = useState<string | null>(null)
+
+  const [verticals, setVerticals] = useState<VerticalSign[]>([])
+  const [vertLuogo, setVertLuogo] = useState('')
+  const [vertDesc, setVertDesc] = useState('')
+  const [vertTipo, setVertTipo] = useState('')
+  const [vertAnno, setVertAnno] = useState('')
+  const [vertQuant, setVertQuant] = useState('')
+  const [vertSearch, setVertSearch] = useState('')
+  const [vertEdit, setVertEdit] = useState<string | null>(null)
+
+  const [tempOpen, setTempOpen] = useState(false)
+  const [vertOpen, setVertOpen] = useState(false)
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        const t = await listTemporarySignage()
+        setTemps(t)
+        localStorage.setItem('temps', JSON.stringify(t))
+      } catch {
+        const stored = localStorage.getItem('temps')
+        if (stored) setTemps(JSON.parse(stored))
+      }
+
+      try {
+        const v = await listVerticalSignage()
+        setVerticals(v)
+        localStorage.setItem('verticals', JSON.stringify(v))
+      } catch {
+        const stored = localStorage.getItem('verticals')
+        if (stored) setVerticals(JSON.parse(stored))
+      }
+    }
+    fetchAll()
+  }, [])
+
+  const saveTemps = (t: TemporarySign[]) => localStorage.setItem('temps', JSON.stringify(t))
+  const saveVerticals = (v: VerticalSign[]) => localStorage.setItem('verticals', JSON.stringify(v))
+
+  const resetTemp = () => {
+    setTempLuogo('')
+    setTempFine('')
+    setTempDesc('')
+    setTempAnno('')
+    setTempQuant('')
+    setTempEdit(null)
+    setTempOpen(false)
+  }
+  const resetVert = () => {
+    setVertLuogo('')
+    setVertDesc('')
+    setVertTipo('')
+    setVertAnno('')
+    setVertQuant('')
+    setVertEdit(null)
+    setVertOpen(false)
+  }
+
+  const submitTemp = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!tempLuogo || !tempFine) return
+    if (tempEdit) {
+      const res = await updateTemporarySignage(tempEdit, {
+        luogo: tempLuogo,
+        fine_validita: tempFine,
+        descrizione: tempDesc,
+        quantita: tempQuant ? Number(tempQuant) : undefined,
+        anno: tempAnno ? Number(tempAnno) : undefined,
+      })
+      const updated = temps.map(t => (t.id === tempEdit ? res : t))
+      setTemps(updated)
+      saveTemps(updated)
+    } else {
+      const res = await createTemporarySignage({
+        luogo: tempLuogo,
+        fine_validita: tempFine,
+        descrizione: tempDesc,
+        quantita: tempQuant ? Number(tempQuant) : undefined,
+        anno: tempAnno ? Number(tempAnno) : undefined,
+      })
+      const updated = [...temps, res]
+      setTemps(updated)
+      saveTemps(updated)
+    }
+    resetTemp()
+  }
+
+  const submitVert = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!vertLuogo || !vertDesc) return
+    if (vertEdit) {
+      const res = await updateVerticalSignage(vertEdit, {
+        luogo: vertLuogo,
+        descrizione: vertDesc,
+        tipo: vertTipo,
+        anno: vertAnno ? Number(vertAnno) : undefined,
+        quantita: vertQuant ? Number(vertQuant) : undefined,
+      })
+      const updated = verticals.map(v => (v.id === vertEdit ? res : v))
+      setVerticals(updated)
+      saveVerticals(updated)
+    } else {
+      const res = await createVerticalSignage({
+        luogo: vertLuogo,
+        descrizione: vertDesc,
+        tipo: vertTipo,
+        anno: vertAnno ? Number(vertAnno) : undefined,
+        quantita: vertQuant ? Number(vertQuant) : undefined,
+      })
+      const updated = [...verticals, res]
+      setVerticals(updated)
+      saveVerticals(updated)
+    }
+    resetVert()
+  }
+
+  return (
+    <div className="list-page">
+      <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
+      <div className="inventory-wrapper">
+        <div className="temp-section">
+          <h2>Segnaletica Temporanea</h2>
+          <button type="button" onClick={() => { resetTemp(); setTempOpen(true) }}>Aggiungi</button>
+          <Modal open={tempOpen} onClose={resetTemp} title={tempEdit ? 'Modifica temporanea' : 'Nuova segnaletica'}>
+            <form onSubmit={submitTemp} className="item-form">
+              <input data-testid="temp-luogo" placeholder="Luogo" value={tempLuogo} onChange={e => setTempLuogo(e.target.value)} />
+              <input data-testid="temp-fine" type="date" value={tempFine} onChange={e => setTempFine(e.target.value)} />
+              <input data-testid="temp-desc" placeholder="Descrizione" value={tempDesc} onChange={e => setTempDesc(e.target.value)} />
+              <input data-testid="temp-anno" type="number" placeholder="Anno" value={tempAnno} onChange={e => setTempAnno(e.target.value)} />
+              <input data-testid="temp-quant" type="number" placeholder="Quantità" value={tempQuant} onChange={e => setTempQuant(e.target.value)} />
+              <button data-testid="temp-submit" type="submit">{tempEdit ? 'Salva' : 'Aggiungi'}</button>
+              <button data-testid="temp-cancel" type="button" onClick={resetTemp}>Annulla</button>
+            </form>
+          </Modal>
+          <input placeholder="Cerca" value={tempSearch} onChange={e => setTempSearch(e.target.value)} />
+          <table className="item-table">
+            <thead>
+              <tr><th>Luogo</th><th>Fine validità</th><th>Descrizione</th><th>Anno</th><th>Quantità</th><th></th></tr>
+            </thead>
+            <tbody>
+              {temps.filter(t => t.luogo.toLowerCase().includes(tempSearch.toLowerCase())).map(t => (
+                <tr key={t.id}>
+                  <td>{t.luogo}</td>
+                  <td>{t.fine_validita}</td>
+                  <td>{t.descrizione}</td>
+                  <td>{t.anno}</td>
+                  <td>{t.quantita}</td>
+                  <td>
+                    <button onClick={() => { setTempEdit(t.id); setTempLuogo(t.luogo); setTempFine(t.fine_validita); setTempDesc(t.descrizione || ''); setTempAnno(t.anno?.toString() || ''); setTempQuant(t.quantita?.toString() || ''); setTempOpen(true) }}>Modifica</button>
+                    <button onClick={async () => { await deleteTemporarySignage(t.id); const u = temps.filter(x => x.id !== t.id); setTemps(u); saveTemps(u) }}>Elimina</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="vertical-section">
+          <h2>Segnaletica Verticale</h2>
+          <button type="button" onClick={() => { resetVert(); setVertOpen(true) }}>Aggiungi</button>
+          <Modal open={vertOpen} onClose={resetVert} title={vertEdit ? 'Modifica verticale' : 'Nuova segnaletica'}>
+            <form onSubmit={submitVert} className="item-form">
+              <input data-testid="vert-luogo" placeholder="Luogo" value={vertLuogo} onChange={e => setVertLuogo(e.target.value)} />
+              <input data-testid="vert-desc" placeholder="Descrizione" value={vertDesc} onChange={e => setVertDesc(e.target.value)} />
+              <input data-testid="vert-tipo" placeholder="Tipo" value={vertTipo} onChange={e => setVertTipo(e.target.value)} />
+              <input data-testid="vert-anno" type="number" placeholder="Anno" value={vertAnno} onChange={e => setVertAnno(e.target.value)} />
+              <input data-testid="vert-quant" type="number" placeholder="Quantità" value={vertQuant} onChange={e => setVertQuant(e.target.value)} />
+              <button data-testid="vert-submit" type="submit">{vertEdit ? 'Salva' : 'Aggiungi'}</button>
+              <button data-testid="vert-cancel" type="button" onClick={resetVert}>Annulla</button>
+            </form>
+          </Modal>
+          <input placeholder="Cerca" value={vertSearch} onChange={e => setVertSearch(e.target.value)} />
+          <table className="item-table">
+            <thead>
+              <tr><th>Luogo</th><th>Descrizione</th><th>Tipo</th><th>Anno</th><th>Quantità</th><th></th></tr>
+            </thead>
+            <tbody>
+              {verticals.filter(v => v.luogo.toLowerCase().includes(vertSearch.toLowerCase())).map(v => (
+                <tr key={v.id}>
+                  <td>{v.luogo}</td>
+                  <td>{v.descrizione}</td>
+                  <td>{v.tipo}</td>
+                  <td>{v.anno}</td>
+                  <td>{v.quantita}</td>
+                  <td>
+                    <button onClick={() => { setVertEdit(v.id); setVertLuogo(v.luogo); setVertDesc(v.descrizione); setVertTipo(v.tipo || ''); setVertAnno(v.anno?.toString() || ''); setVertQuant(v.quantita?.toString() || ''); setVertOpen(true) }}>Modifica</button>
+                    <button onClick={async () => { await deleteVerticalSignage(v.id); const u = verticals.filter(x => x.id !== v.id); setVerticals(u); saveVerticals(u) }}>Elimina</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SignagePage
+

--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -4,8 +4,7 @@ import InventoryPage from '../InventoryPage'
 import PageTemplate from '../../components/PageTemplate'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import * as devicesApi from '../../api/devices'
-import * as tempApi from '../../api/temporarySignage'
-import * as vertApi from '../../api/verticalSignage'
+
 
 jest.mock('../../api/devices', () => ({
   __esModule: true,
@@ -15,41 +14,18 @@ jest.mock('../../api/devices', () => ({
   deleteDevice: jest.fn(),
 }))
 
-jest.mock('../../api/temporarySignage', () => ({
-  __esModule: true,
-  listTemporarySignage: jest.fn(),
-  createTemporarySignage: jest.fn(),
-  updateTemporarySignage: jest.fn(),
-  deleteTemporarySignage: jest.fn(),
-}))
 
-jest.mock('../../api/verticalSignage', () => ({
-  __esModule: true,
-  listVerticalSignage: jest.fn(),
-  createVerticalSignage: jest.fn(),
-  updateVerticalSignage: jest.fn(),
-  deleteVerticalSignage: jest.fn(),
-}))
 
 
 const mockedDevices = devicesApi as jest.Mocked<typeof devicesApi>
-const mockedTemps = tempApi as jest.Mocked<typeof tempApi>
-const mockedVerts = vertApi as jest.Mocked<typeof vertApi>
 
 
 beforeEach(() => {
   jest.resetAllMocks()
   localStorage.clear()
   mockedDevices.listDevices.mockResolvedValue([])
-  mockedTemps.listTemporarySignage.mockResolvedValue([])
-  mockedVerts.listVerticalSignage.mockResolvedValue([])
 
   mockedDevices.createDevice.mockResolvedValue({ id: '1', nome: 'Device 1' } as any)
-  mockedTemps.createTemporarySignage.mockResolvedValue({
-    id: 't1',
-    luogo: 'Luogo',
-    fine_validita: '2024-01-01',
-  } as any)
 })
 
 const renderPage = () =>
@@ -110,25 +86,5 @@ describe('InventoryPage', () => {
     expect(screen.queryByText('Device 2')).not.toBeInTheDocument()
   })
 
-  it('creates temporary signage with year', async () => {
-    renderPage()
-    const addButtons = screen.getAllByRole('button', { name: /aggiungi/i })
-
-    await userEvent.click(addButtons[1])
-    await userEvent.type(screen.getByTestId('temp-luogo'), 'Luogo')
-    await userEvent.type(screen.getByTestId('temp-fine'), '2024-01-01')
-    await userEvent.type(screen.getByTestId('temp-desc'), 'Desc')
-    await userEvent.type(screen.getByTestId('temp-anno'), '2024')
-    await userEvent.type(screen.getByTestId('temp-quant'), '3')
-    await userEvent.click(screen.getByTestId('temp-submit'))
-
-    expect(mockedTemps.createTemporarySignage).toHaveBeenCalledWith({
-      luogo: 'Luogo',
-      fine_validita: '2024-01-01',
-      descrizione: 'Desc',
-      anno: 2024,
-      quantita: 3,
-    })
-  })
 
 })

--- a/src/pages/__tests__/SignagePage.test.tsx
+++ b/src/pages/__tests__/SignagePage.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SignagePage from '../SignagePage'
+import PageTemplate from '../../components/PageTemplate'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import * as tempApi from '../../api/temporarySignage'
+import * as vertApi from '../../api/verticalSignage'
+
+jest.mock('../../api/temporarySignage', () => ({
+  __esModule: true,
+  listTemporarySignage: jest.fn(),
+  createTemporarySignage: jest.fn(),
+  updateTemporarySignage: jest.fn(),
+  deleteTemporarySignage: jest.fn(),
+}))
+
+jest.mock('../../api/verticalSignage', () => ({
+  __esModule: true,
+  listVerticalSignage: jest.fn(),
+  createVerticalSignage: jest.fn(),
+  updateVerticalSignage: jest.fn(),
+  deleteVerticalSignage: jest.fn(),
+}))
+
+const mockedTemps = tempApi as jest.Mocked<typeof tempApi>
+const mockedVerts = vertApi as jest.Mocked<typeof vertApi>
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  mockedTemps.listTemporarySignage.mockResolvedValue([])
+  mockedVerts.listVerticalSignage.mockResolvedValue([])
+  mockedTemps.createTemporarySignage.mockResolvedValue({ id: 't1', luogo: 'L1', fine_validita: '2024-01-01' } as any)
+})
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/segnaletica']}>
+      <Routes>
+        <Route element={<PageTemplate />}>
+          <Route path="/segnaletica" element={<SignagePage />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  )
+
+describe('SignagePage', () => {
+  it('adds temporary signage', async () => {
+    renderPage()
+    const addBtns = screen.getAllByRole('button', { name: /aggiungi/i })
+    await userEvent.click(addBtns[0])
+    await userEvent.type(screen.getByTestId('temp-luogo'), 'Luogo')
+    await userEvent.type(screen.getByTestId('temp-fine'), '2024-01-01')
+    await userEvent.click(screen.getByTestId('temp-submit'))
+    expect(mockedTemps.createTemporarySignage).toHaveBeenCalled()
+  })
+})
+


### PR DESCRIPTION
## Summary
- sposta segnaletica temporanea e verticale in una nuova pagina
- centra i dispositivi nella pagina inventario
- aggiorna la navigazione e le route
- adatta i test e aggiunge quelli per la nuova pagina
- aggiorna la documentazione

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a3e57518883238a47efa9a57ff221