### PR TITLE
Remove unused signage sections

### DIFF
--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -8,20 +8,6 @@ import {
   deleteDevice,
   Device,
 } from '../api/devices'
-import {
-  listTemporarySignage,
-  createTemporarySignage,
-  updateTemporarySignage,
-  deleteTemporarySignage,
-  TemporarySign,
-} from '../api/temporarySignage'
-import {
-  listVerticalSignage,
-  createVerticalSignage,
-  updateVerticalSignage,
-  deleteVerticalSignage,
-  VerticalSign,
-} from '../api/verticalSignage'
 
 const InventoryPage: React.FC = () => {
   const [devices, setDevices] = useState<Device[]>([])
@@ -32,30 +18,10 @@ const InventoryPage: React.FC = () => {
   const [devSearch, setDevSearch] = useState('')
   const [devEdit, setDevEdit] = useState<string | null>(null)
 
-  const [temps, setTemps] = useState<TemporarySign[]>([])
-  const [tempLuogo, setTempLuogo] = useState('')
-  const [tempFine, setTempFine] = useState('')
-  const [tempDesc, setTempDesc] = useState('')
-  const [tempAnno, setTempAnno] = useState('')
-  const [tempQuant, setTempQuant] = useState('')
-  const [tempSearch, setTempSearch] = useState('')
-  const [tempEdit, setTempEdit] = useState<string | null>(null)
-
-  const [verticals, setVerticals] = useState<VerticalSign[]>([])
-  const [vertLuogo, setVertLuogo] = useState('')
-  const [vertDesc, setVertDesc] = useState('')
-  const [vertTipo, setVertTipo] = useState('')
-  const [vertAnno, setVertAnno] = useState('')
-  const [vertQuant, setVertQuant] = useState('')
-  const [vertSearch, setVertSearch] = useState('')
-  const [vertEdit, setVertEdit] = useState<string | null>(null)
-
   const [devOpen, setDevOpen] = useState(false)
-  const [tempOpen, setTempOpen] = useState(false)
-  const [vertOpen, setVertOpen] = useState(false)
 
   useEffect(() => {
-    const fetchAll = async () => {
+    const fetchDevicesList = async () => {
       try {
         const d = await listDevices()
         setDevices(d)
@@ -64,32 +30,11 @@ const InventoryPage: React.FC = () => {
         const stored = localStorage.getItem('devices')
         if (stored) setDevices(JSON.parse(stored))
       }
-
-      try {
-        const t = await listTemporarySignage()
-        setTemps(t)
-        localStorage.setItem('temps', JSON.stringify(t))
-      } catch {
-        const stored = localStorage.getItem('temps')
-        if (stored) setTemps(JSON.parse(stored))
-      }
-
-      try {
-        const v = await listVerticalSignage()
-        setVerticals(v)
-        localStorage.setItem('verticals', JSON.stringify(v))
-      } catch {
-        const stored = localStorage.getItem('verticals')
-        if (stored) setVerticals(JSON.parse(stored))
-      }
-
     }
-    fetchAll()
+    fetchDevicesList()
   }, [])
 
   const saveDevices = (d: Device[]) => localStorage.setItem('devices', JSON.stringify(d))
-  const saveTemps = (t: TemporarySign[]) => localStorage.setItem('temps', JSON.stringify(t))
-  const saveVerticals = (v: VerticalSign[]) => localStorage.setItem('verticals', JSON.stringify(v))
 
   const resetDevice = () => {
     setDevName('');
@@ -99,8 +44,6 @@ const InventoryPage: React.FC = () => {
     setDevEdit(null);
     setDevOpen(false);
   }
-  const resetTemp = () => { setTempLuogo(''); setTempFine(''); setTempDesc(''); setTempAnno(''); setTempQuant(''); setTempEdit(null); setTempOpen(false) }
-  const resetVert = () => { setVertLuogo(''); setVertDesc(''); setVertTipo(''); setVertAnno(''); setVertQuant(''); setVertEdit(null); setVertOpen(false) }
 
   const submitDevice = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -126,72 +69,13 @@ const InventoryPage: React.FC = () => {
     setDevOpen(false)
   }
 
-  const submitTemp = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!tempLuogo || !tempFine) return
-    if (tempEdit) {
-      const res = await updateTemporarySignage(tempEdit, {
-        luogo: tempLuogo,
-        fine_validita: tempFine,
-        descrizione: tempDesc,
-        quantita: tempQuant ? Number(tempQuant) : undefined,
-        anno: tempAnno ? Number(tempAnno) : undefined,
-      })
-      const updated = temps.map(t => t.id === tempEdit ? res : t)
-      setTemps(updated)
-      saveTemps(updated)
-    } else {
-      const res = await createTemporarySignage({
-        luogo: tempLuogo,
-        fine_validita: tempFine,
-        descrizione: tempDesc,
-        quantita: tempQuant ? Number(tempQuant) : undefined,
-        anno: tempAnno ? Number(tempAnno) : undefined,
-      })
-      const updated = [...temps, res]
-      setTemps(updated)
-      saveTemps(updated)
-    }
-    resetTemp()
-    setTempOpen(false)
-  }
-
-  const submitVert = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!vertLuogo || !vertDesc) return
-    if (vertEdit) {
-      const res = await updateVerticalSignage(vertEdit, {
-        luogo: vertLuogo,
-        descrizione: vertDesc,
-        tipo: vertTipo,
-        anno: vertAnno ? Number(vertAnno) : undefined,
-        quantita: vertQuant ? Number(vertQuant) : undefined
-      })
-      const updated = verticals.map(v => v.id === vertEdit ? res : v)
-      setVerticals(updated)
-      saveVerticals(updated)
-    } else {
-      const res = await createVerticalSignage({
-        luogo: vertLuogo,
-        descrizione: vertDesc,
-        tipo: vertTipo,
-        anno: vertAnno ? Number(vertAnno) : undefined,
-        quantita: vertQuant ? Number(vertQuant) : undefined
-      })
-      const updated = [...verticals, res]
-      setVerticals(updated)
-      saveVerticals(updated)
-    }
-    resetVert()
-    setVertOpen(false)
-  }
 
 
 
   return (
     <div className="list-page">
       <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
-      <div className="inventory-wrapper">
+      <div className="inventory-wrapper devices-only">
         <div className="devices-section">
         <h2>Dispositivi</h2>
         <button type="button" onClick={() => { resetDevice(); setDevOpen(true); }}>Aggiungi</button>
@@ -232,81 +116,6 @@ const InventoryPage: React.FC = () => {
             ))}
           </tbody>
         </table>
-      </div>
-
-      <div className="temp-section">
-        <h2>Segnaletica Temporanea</h2>
-        <button type="button" onClick={() => { resetTemp(); setTempOpen(true); }}>Aggiungi</button>
-        <Modal open={tempOpen} onClose={resetTemp} title={tempEdit ? 'Modifica temporanea' : 'Nuova segnaletica'}>
-          <form onSubmit={submitTemp} className="item-form">
-            <input data-testid="temp-luogo" placeholder="Luogo" value={tempLuogo} onChange={e => setTempLuogo(e.target.value)} />
-            <input data-testid="temp-fine" type="date" value={tempFine} onChange={e => setTempFine(e.target.value)} />
-            <input data-testid="temp-desc" placeholder="Descrizione" value={tempDesc} onChange={e => setTempDesc(e.target.value)} />
-            <input data-testid="temp-anno" type="number" placeholder="Anno" value={tempAnno} onChange={e => setTempAnno(e.target.value)} />
-            <input data-testid="temp-quant" type="number" placeholder="Quantità" value={tempQuant} onChange={e => setTempQuant(e.target.value)} />
-            <button data-testid="temp-submit" type="submit">{tempEdit ? 'Salva' : 'Aggiungi'}</button>
-            <button data-testid="temp-cancel" type="button" onClick={resetTemp}>Annulla</button>
-          </form>
-        </Modal>
-        <input placeholder="Cerca" value={tempSearch} onChange={e => setTempSearch(e.target.value)} />
-        <table className="item-table">
-          <thead>
-            <tr><th>Luogo</th><th>Fine validità</th><th>Descrizione</th><th>Anno</th><th>Quantità</th><th></th></tr>
-          </thead>
-          <tbody>
-            {temps.filter(t => t.luogo.toLowerCase().includes(tempSearch.toLowerCase())).map(t => (
-              <tr key={t.id}>
-                <td>{t.luogo}</td>
-                <td>{t.fine_validita}</td>
-                <td>{t.descrizione}</td>
-                <td>{t.anno}</td>
-                <td>{t.quantita}</td>
-                <td>
-                  <button onClick={() => { setTempEdit(t.id); setTempLuogo(t.luogo); setTempFine(t.fine_validita); setTempDesc(t.descrizione || ''); setTempAnno(t.anno?.toString() || ''); setTempQuant(t.quantita?.toString() || ''); setTempOpen(true) }}>Modifica</button>
-                  <button onClick={async () => { await deleteTemporarySignage(t.id); const u = temps.filter(x => x.id !== t.id); setTemps(u); saveTemps(u) }}>Elimina</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
-      <div className="vertical-section">
-        <h2>Segnaletica Verticale</h2>
-        <button type="button" onClick={() => { resetVert(); setVertOpen(true); }}>Aggiungi</button>
-        <Modal open={vertOpen} onClose={resetVert} title={vertEdit ? 'Modifica verticale' : 'Nuova segnaletica'}>
-          <form onSubmit={submitVert} className="item-form">
-            <input data-testid="vert-luogo" placeholder="Luogo" value={vertLuogo} onChange={e => setVertLuogo(e.target.value)} />
-            <input data-testid="vert-desc" placeholder="Descrizione" value={vertDesc} onChange={e => setVertDesc(e.target.value)} />
-            <input data-testid="vert-tipo" placeholder="Tipo" value={vertTipo} onChange={e => setVertTipo(e.target.value)} />
-            <input data-testid="vert-anno" type="number" placeholder="Anno" value={vertAnno} onChange={e => setVertAnno(e.target.value)} />
-            <input data-testid="vert-quant" type="number" placeholder="Quantità" value={vertQuant} onChange={e => setVertQuant(e.target.value)} />
-            <button data-testid="vert-submit" type="submit">{vertEdit ? 'Salva' : 'Aggiungi'}</button>
-            <button data-testid="vert-cancel" type="button" onClick={resetVert}>Annulla</button>
-          </form>
-        </Modal>
-        <input placeholder="Cerca" value={vertSearch} onChange={e => setVertSearch(e.target.value)} />
-        <table className="item-table">
-          <thead>
-            <tr><th>Luogo</th><th>Descrizione</th><th>Tipo</th><th>Anno</th><th>Quantità</th><th></th></tr>
-          </thead>
-          <tbody>
-            {verticals.filter(v => v.luogo.toLowerCase().includes(vertSearch.toLowerCase())).map(v => (
-              <tr key={v.id}>
-                <td>{v.luogo}</td>
-                <td>{v.descrizione}</td>
-                <td>{v.tipo}</td>
-                <td>{v.anno}</td>
-                <td>{v.quantita}</td>
-                <td>
-                  <button onClick={() => { setVertEdit(v.id); setVertLuogo(v.luogo); setVertDesc(v.descrizione); setVertTipo(v.tipo || ''); setVertAnno(v.anno?.toString() || ''); setVertQuant(v.quantita?.toString() || ''); setVertOpen(true) }}>Modifica</button>
-                  <button onClick={async () => { await deleteVerticalSignage(v.id); const u = verticals.filter(x => x.id !== v.id); setVerticals(u); saveVerticals(u) }}>Elimina</button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-
       </div>
     </div>
   </div>

--- a/src/pages/ListPages.css
+++ b/src/pages/ListPages.css
@@ -249,11 +249,11 @@
   flex-wrap: wrap;
   gap: 1rem;
 }
-.inventory-wrapper > .temp-section,
-.inventory-wrapper > .vertical-section {
-  flex: 1;
-}
 .inventory-wrapper > .devices-section {
   order: 2;
   flex-basis: 100%;
+}
+
+.inventory-wrapper.devices-only {
+  justify-content: center;
 }


### PR DESCRIPTION
## Summary
- clean up `InventoryPage` to remove temporary and vertical signage
- keep devices table centered with `devices-only` wrapper
- update layout styles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_687a4157b57c8323b28e353b9eff94af