### PR TITLE
Add vertical signage route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const SchedulePage = React.lazy(() => import("./pages/SchedulePage"));
 const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 const InventoryPage = React.lazy(() => import("./pages/InventoryPage"));
 const HorizontalSignagePage = React.lazy(() => import("./pages/HorizontalSignagePage"));
+const VerticalTempSignagePage = React.lazy(() => import("./pages/VerticalTempSignagePage"));
 const SegnalazioniPage = React.lazy(() => import("./pages/SegnalazioniPage"));
 
 
@@ -49,6 +50,7 @@ const App: React.FC = () => {
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
           <Route path="/inventario" element={<InventoryPage />} />
+          <Route path="/segnaletica" element={<VerticalTempSignagePage />} />
           <Route path="/segnaletica-orizzontale" element={<HorizontalSignagePage />} />
           <Route path="/segnalazioni" element={<SegnalazioniPage />} />
         </Route>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -52,7 +52,7 @@ const Header: React.FC = () => {
             </button>
             {dropOpen && (
               <div className="dropdown-content">
-                <Link to="/inventario">Segnaletica verticale/temporanea</Link>
+                <Link to="/segnaletica">Segnaletica verticale/temporanea</Link>
                 <Link to="/segnaletica-orizzontale">Segnaletica orizzontale</Link>
               </div>
             )}

--- a/src/pages/VerticalTempSignagePage.tsx
+++ b/src/pages/VerticalTempSignagePage.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import './ListPages.css'
+
+const VerticalTempSignagePage: React.FC = () => (
+  <div className="list-page">
+    <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
+    <p>Gestione segnaletica verticale e temporanea</p>
+  </div>
+)
+
+export default VerticalTempSignagePage


### PR DESCRIPTION
## Summary
- add lazy import for VerticalTempSignagePage and route `/segnaletica`
- update header dropdown link to `/segnaletica`
- stub VerticalTempSignagePage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4155c0d0832384c69f852592c0d3