### PR TITLE
Update inventory tests

### DIFF
--- a/src/pages/__tests__/InventoryPage.test.tsx
+++ b/src/pages/__tests__/InventoryPage.test.tsx
@@ -4,8 +4,6 @@ import InventoryPage from '../InventoryPage'
 import PageTemplate from '../../components/PageTemplate'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import * as devicesApi from '../../api/devices'
-import * as tempApi from '../../api/temporarySignage'
-import * as vertApi from '../../api/verticalSignage'
 
 jest.mock('../../api/devices', () => ({
   __esModule: true,
@@ -15,41 +13,17 @@ jest.mock('../../api/devices', () => ({
   deleteDevice: jest.fn(),
 }))
 
-jest.mock('../../api/temporarySignage', () => ({
-  __esModule: true,
-  listTemporarySignage: jest.fn(),
-  createTemporarySignage: jest.fn(),
-  updateTemporarySignage: jest.fn(),
-  deleteTemporarySignage: jest.fn(),
-}))
-
-jest.mock('../../api/verticalSignage', () => ({
-  __esModule: true,
-  listVerticalSignage: jest.fn(),
-  createVerticalSignage: jest.fn(),
-  updateVerticalSignage: jest.fn(),
-  deleteVerticalSignage: jest.fn(),
-}))
 
 
 const mockedDevices = devicesApi as jest.Mocked<typeof devicesApi>
-const mockedTemps = tempApi as jest.Mocked<typeof tempApi>
-const mockedVerts = vertApi as jest.Mocked<typeof vertApi>
 
 
 beforeEach(() => {
   jest.resetAllMocks()
   localStorage.clear()
   mockedDevices.listDevices.mockResolvedValue([])
-  mockedTemps.listTemporarySignage.mockResolvedValue([])
-  mockedVerts.listVerticalSignage.mockResolvedValue([])
 
   mockedDevices.createDevice.mockResolvedValue({ id: '1', nome: 'Device 1' } as any)
-  mockedTemps.createTemporarySignage.mockResolvedValue({
-    id: 't1',
-    luogo: 'Luogo',
-    fine_validita: '2024-01-01',
-  } as any)
 })
 
 const renderPage = () =>
@@ -110,25 +84,5 @@ describe('InventoryPage', () => {
     expect(screen.queryByText('Device 2')).not.toBeInTheDocument()
   })
 
-  it('creates temporary signage with year', async () => {
-    renderPage()
-    const addButtons = screen.getAllByRole('button', { name: /aggiungi/i })
-
-    await userEvent.click(addButtons[1])
-    await userEvent.type(screen.getByTestId('temp-luogo'), 'Luogo')
-    await userEvent.type(screen.getByTestId('temp-fine'), '2024-01-01')
-    await userEvent.type(screen.getByTestId('temp-desc'), 'Desc')
-    await userEvent.type(screen.getByTestId('temp-anno'), '2024')
-    await userEvent.type(screen.getByTestId('temp-quant'), '3')
-    await userEvent.click(screen.getByTestId('temp-submit'))
-
-    expect(mockedTemps.createTemporarySignage).toHaveBeenCalledWith({
-      luogo: 'Luogo',
-      fine_validita: '2024-01-01',
-      descrizione: 'Desc',
-      anno: 2024,
-      quantita: 3,
-    })
-  })
 
 })


### PR DESCRIPTION
## Summary
- remove temporary/vertical signage mocks from `InventoryPage.test.tsx`
- drop signage form test so inventory tests focus on devices

## Testing
- `npm run lint` *(fails: missing eslint deps)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4157bfc883239c64f8ea41e5ec92