### PR TITLE
Add Segnaletica page route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ const PdfFilesPage = React.lazy(() => import("./pages/PdfFilesPage"));
 const InventoryPage = React.lazy(() => import("./pages/InventoryPage"));
 const HorizontalSignagePage = React.lazy(() => import("./pages/HorizontalSignagePage"));
 const SegnalazioniPage = React.lazy(() => import("./pages/SegnalazioniPage"));
+const VerticalTempSignagePage = React.lazy(() => import("./pages/VerticalTempSignagePage"));
 
 
 const App: React.FC = () => {
@@ -49,6 +50,7 @@ const App: React.FC = () => {
           <Route path="/orari" element={<SchedulePage />} />
           <Route path="/determinazioni" element={<DeterminationsPage />} />
           <Route path="/inventario" element={<InventoryPage />} />
+          <Route path="/segnaletica" element={<VerticalTempSignagePage />} />
           <Route path="/segnaletica-orizzontale" element={<HorizontalSignagePage />} />
           <Route path="/segnalazioni" element={<SegnalazioniPage />} />
         </Route>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -52,7 +52,7 @@ const Header: React.FC = () => {
             </button>
             {dropOpen && (
               <div className="dropdown-content">
-                <Link to="/inventario">Segnaletica verticale/temporanea</Link>
+                <Link to="/segnaletica">Segnaletica verticale/temporanea</Link>
                 <Link to="/segnaletica-orizzontale">Segnaletica orizzontale</Link>
               </div>
             )}


### PR DESCRIPTION
## Summary
- lazy load `VerticalTempSignagePage` in `App`
- create `/segnaletica` route
- update navigation link for vertical signage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4368627083239f70aa0e472bbb33