### PR TITLE
Fix Leaflet marker visibility

### DIFF
--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -1,3 +1,15 @@
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+import markerIcon from 'leaflet/dist/images/marker-icon.png'
+import markerShadow from 'leaflet/dist/images/marker-shadow.png'
+
+L.Marker.prototype.options.icon = L.icon({
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+  iconAnchor: [12, 41]
+})
+
 import React, { useEffect, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet'
 import { createSegnalazione, listSegnalazioni, Segnalazione } from '../api/segnalazioni'


### PR DESCRIPTION
## Summary
- configure Leaflet default marker inside `SegnalazioniPage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a4fb5240c8323af7d21fb0db46d48