### PR TITLE
Add backend entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,8 @@ Example JSON response:
 
 This repository now ships with a minimal FastAPI backend located in the
 `backend/` directory.  Install the Python dependencies and run the API with
-`uvicorn backend.main:app` after configuring the following environment
+`uvicorn backend.main:app` (or `python backend/main.py`) after configuring the
+following environment
 variables:
 
 - `DATABASE_URL` – connection string for the persistent database.
@@ -240,7 +241,7 @@ The backend must send an `Access-Control-Allow-Origin` header allowing the front
 
 After applying the Alembic migrations
 (`alembic -c backend/alembic.ini upgrade head`) you can start the API with
-`uvicorn backend.main:app`.
+`uvicorn backend.main:app` or simply run `python backend/main.py`.
 
 
 ## License

--- a/backend/main.py
+++ b/backend/main.py
@@ -64,3 +64,8 @@ def read_segnalazioni(skip: int = 0, limit: int = 100, db: Session = Depends(get
 @app.get("/users/me", response_model=schemas.User)
 def read_users_me(current_user: schemas.User = Depends(get_current_user)):
     return current_user
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("backend.main:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- run FastAPI directly via `python backend/main.py`
- document backend run command in README

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pip install -r backend/requirements.txt` *(fails: cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687a6157b16083238651eb1f7df20120