### PR TITLE
Remove work in progress banners from inventory and signage pages

### DIFF
--- a/src/pages/InventoryPage.tsx
+++ b/src/pages/InventoryPage.tsx
@@ -74,7 +74,6 @@ const InventoryPage: React.FC = () => {
 
   return (
     <div className="list-page">
-      <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
       <div className="inventory-wrapper devices-only">
         <div className="devices-section">
         <h2>Dispositivi</h2>

--- a/src/pages/VerticalTempSignagePage.tsx
+++ b/src/pages/VerticalTempSignagePage.tsx
@@ -147,7 +147,6 @@ const VerticalTempSignagePage: React.FC = () => {
 
   return (
     <div className="list-page">
-      <h2 className="wip-warning">🚧 LAVORI IN CORSO 🚧</h2>
       <div className="inventory-wrapper">
         <div className="temp-section">
           <h2>Segnaletica Temporanea</h2>


### PR DESCRIPTION
## Summary
- remove the WIP header from the vertical signage page
- remove the WIP header from the inventory page

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a646e87cc83239d34499bf2f8a8e2