### PR TITLE
Add horizontal signage excel import

### DIFF
--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -50,3 +50,11 @@ export const listHorizontalSignageByPlan = (
       params: { plan: planId },
     })
     .then(r => r.data)
+
+export const importHorizontalExcel = (file: File): Promise<Blob> => {
+  const form = new FormData()
+  form.append('file', file)
+  return api
+    .post('/segnaletica-orizzontale/import', form, { responseType: 'blob' })
+    .then(r => r.data)
+}

--- a/src/components/ImportHorizontalExcel.tsx
+++ b/src/components/ImportHorizontalExcel.tsx
@@ -1,0 +1,85 @@
+import React, { useRef, useState, ChangeEvent } from 'react'
+import { importHorizontalExcel } from '../api/horizontalSignage'
+import { getErrorDetail } from '../utils/errors'
+
+interface ImportHorizontalExcelProps {
+  onComplete?: (success: boolean) => void
+}
+
+export default function ImportHorizontalExcel({ onComplete }: ImportHorizontalExcelProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [busy, setBusy] = useState(false)
+  const [message, setMessage] = useState('')
+
+  const chooseFile = () => {
+    if (!busy) fileInputRef.current?.click()
+  }
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setBusy(true)
+    setMessage('')
+
+    try {
+      const pdfBlob = await importHorizontalExcel(file)
+      const pdfURL = URL.createObjectURL(pdfBlob)
+      const newWindow = window.open(pdfURL, '_blank')
+      if (newWindow) {
+        newWindow.addEventListener('load', () => {
+          URL.revokeObjectURL(pdfURL)
+        })
+      } else {
+        setTimeout(() => URL.revokeObjectURL(pdfURL))
+      }
+      setMessage('File importato correttamente.')
+      onComplete?.(true)
+    } catch (error) {
+      const detail = await getErrorDetail(error)
+      console.error('ImportHorizontalExcel error →', detail)
+      const msg = detail ? `Errore durante l'importazione del file: ${detail}` : 'Errore durante l\'importazione del file'
+      setMessage(msg)
+      onComplete?.(false)
+    } finally {
+      setBusy(false)
+      if (fileInputRef.current) fileInputRef.current.value = ''
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={chooseFile}
+        disabled={busy}
+        style={{
+          position: 'fixed',
+          bottom: '1rem',
+          right: '1rem',
+          backgroundColor: '#A52019',
+          color: '#fff',
+          padding: '0.75rem 1rem',
+          borderRadius: '9999px',
+          boxShadow: '0 4px 6px rgba(0,0,0,0.1)',
+          zIndex: 1000,
+        }}
+      >
+        {busy ? 'Caricamento…' : 'Importa Excel'}
+      </button>
+
+      {message && (
+        <p className={message.startsWith('Errore') ? 'error' : 'success-message'}>
+          {message}
+        </p>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".xlsx, .xls"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+    </>
+  )
+}

--- a/src/components/__tests__/ImportHorizontalExcel.test.tsx
+++ b/src/components/__tests__/ImportHorizontalExcel.test.tsx
@@ -1,0 +1,29 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import ImportHorizontalExcel from '../ImportHorizontalExcel'
+import * as horizApi from '../../api/horizontalSignage'
+
+jest.mock('../../api/horizontalSignage', () => ({
+  __esModule: true,
+  importHorizontalExcel: jest.fn(),
+}))
+
+const mockedImport = horizApi.importHorizontalExcel as jest.MockedFunction<typeof horizApi.importHorizontalExcel>
+
+describe('ImportHorizontalExcel', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('calls API when file selected', async () => {
+    mockedImport.mockResolvedValueOnce(new Blob())
+
+    const { container } = render(<ImportHorizontalExcel />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['1'], 'test.xlsx')
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(mockedImport).toHaveBeenCalledWith(file)
+    })
+  })
+})

--- a/src/pages/HorizontalSignagePage.tsx
+++ b/src/pages/HorizontalSignagePage.tsx
@@ -15,6 +15,7 @@ import {
   getHorizontalSignagePdf,
   HorizontalSign,
 } from '../api/horizontalSignage'
+import ImportHorizontalExcel from '../components/ImportHorizontalExcel'
 
 const HorizontalSignagePage: React.FC = () => {
   const [plans, setPlans] = useState<HorizontalPlan[]>([])
@@ -309,6 +310,7 @@ const HorizontalSignagePage: React.FC = () => {
             PDF anno
           </button>
         </div>
+        <ImportHorizontalExcel />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add API function `importHorizontalExcel`
- create `ImportHorizontalExcel` component
- show import button on HorizontalSignagePage
- test that file selection triggers API call

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a66402b308323b08dbe12382a57a9