### PR TITLE
Add PWA manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
+    <!-- Home screen icon -->
+    <link rel="apple-touch-icon" href="/logo.png" />
+    <link rel="manifest" href="/manifest.webmanifest" />
+
     <!-- Almendra SC font -->
     <link
       href="https://fonts.googleapis.com/css2?family=Almendra+SC&display=swap"

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Segretaria Digitale",
+  "short_name": "Segretaria",
+  "icons": [
+    {
+      "src": "/logo.png",
+      "sizes": "1024x1536",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#A52019"
+}


### PR DESCRIPTION
## Summary
- use existing logo for mobile home screen icon
- create `public/manifest.webmanifest`
- link icon & manifest in `index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a65d435148323bedac0086699d407