### PR TITLE
Add horizontal signage Excel import feature

### DIFF
--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -56,10 +56,10 @@ export const listHorizontalByYear = (
     })
     .then(r => r.data)
 
-export const importHorizontalExcel = (file: File): Promise<void> => {
+export const importHorizontalExcel = (file: File): Promise<Blob> => {
   const form = new FormData()
   form.append('file', file)
   return api
-    .post('/inventario/signage-horizontal/import/xlsx', form)
-    .then(() => undefined)
+    .post('/segnaletica-orizzontale/import', form, { responseType: 'blob' })
+    .then(r => r.data)
 }

--- a/src/components/ImportHorizontalExcel.tsx
+++ b/src/components/ImportHorizontalExcel.tsx
@@ -21,7 +21,16 @@ export default function ImportHorizontalExcel({ onComplete }: Props) {
     setBusy(true)
     setMessage('')
     try {
-      await importHorizontalExcel(file)
+      const pdfBlob = await importHorizontalExcel(file)
+      const pdfURL = URL.createObjectURL(pdfBlob)
+      const newWindow = window.open(pdfURL, '_blank')
+      if (newWindow) {
+        newWindow.addEventListener('load', () => {
+          URL.revokeObjectURL(pdfURL)
+        })
+      } else {
+        setTimeout(() => URL.revokeObjectURL(pdfURL))
+      }
       setMessage('File importato correttamente.')
       onComplete?.(true)
     } catch (err) {

--- a/src/components/__tests__/ImportHorizontalExcel.test.tsx
+++ b/src/components/__tests__/ImportHorizontalExcel.test.tsx
@@ -1,0 +1,28 @@
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import ImportHorizontalExcel from '../ImportHorizontalExcel'
+import { importHorizontalExcel } from '../../api/horizontalSignage'
+
+jest.mock('../../api/horizontalSignage', () => ({
+  __esModule: true,
+  importHorizontalExcel: jest.fn(),
+}))
+
+const mockedImport = importHorizontalExcel as jest.MockedFunction<typeof importHorizontalExcel>
+
+describe('ImportHorizontalExcel', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('calls API on file upload', async () => {
+    mockedImport.mockResolvedValueOnce(new Blob())
+    const { container } = render(<ImportHorizontalExcel />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const file = new File(['1'], 'test.xlsx')
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(mockedImport).toHaveBeenCalledWith(file)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- update `importHorizontalExcel` API to return PDF blob
- show PDF preview in `ImportHorizontalExcel` component
- add component unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7a3b044c8323889e647033b5dfe4