### PR TITLE
Fix segnalazione payload

### DIFF
--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -70,14 +70,14 @@ const SegnalazioniPage: React.FC = () => {
     if (!pos) return
     try {
       const res = await createSegnalazione({
-        tipo,
+        tipo, // solo uno tra: "Piante", "Danneggiamenti", "Reati", "Animali", "Altro"
         stato,
         priorita: priorita === "Alta" ? 1 : priorita === "Media" ? 2 : 3,
         data_segnalazione: data,
         descrizione,
-        lat: pos[0],
-        lng: pos[1]
-      })
+        latitudine: pos[0],
+        longitudine: pos[1]
+      } as any)
       setItems([...items, res])
       setTipo('')
       setPriorita('')


### PR DESCRIPTION
## Summary
- ensure `onSubmit` uses `latitudine` and `longitudine` when calling `createSegnalazione`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab85eb0a08323b6067228a1288cea