### PR TITLE
Fix segnalazione submission payload

### DIFF
--- a/src/api/segnalazioni.ts
+++ b/src/api/segnalazioni.ts
@@ -16,10 +16,19 @@ export interface Segnalazione {
   data_segnalazione?: string
 }
 
+export interface SegnalazioneCreate {
+  tipo: string
+  priorita: string
+  stato: string
+  descrizione?: string
+  lat?: number
+  lng?: number
+}
+
 export const listSegnalazioni = (): Promise<Segnalazione[]> =>
   api.get<Segnalazione[]>('/segnalazioni').then(r => r.data)
 
 export const createSegnalazione = (
-  data: Omit<Segnalazione, 'id'>
+  data: SegnalazioneCreate
 ): Promise<Segnalazione> =>
   api.post<Segnalazione>('/segnalazioni', data).then(r => r.data)

--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -12,7 +12,11 @@ L.Marker.prototype.options.icon = L.icon({
 
 import React, { useEffect, useState } from 'react'
 import { MapContainer, TileLayer, Marker, Popup, useMapEvents } from 'react-leaflet'
-import { createSegnalazione, listSegnalazioni, Segnalazione } from '../api/segnalazioni'
+import {
+  createSegnalazione,
+  listSegnalazioni,
+  Segnalazione,
+} from '../api/segnalazioni'
 import './ListPages.css'
 import Modal from '../components/ui/Modal'
 import Button from '../components/ui/button'
@@ -72,12 +76,11 @@ const SegnalazioniPage: React.FC = () => {
       const res = await createSegnalazione({
         tipo, // solo uno tra: "Piante", "Danneggiamenti", "Reati", "Animali", "Altro"
         stato,
-        priorita: priorita === "Alta" ? 1 : priorita === "Media" ? 2 : 3,
-        data_segnalazione: data,
+        priorita,
         descrizione,
-        latitudine: pos[0],
-        longitudine: pos[1]
-      } as any)
+        lat: pos[0],
+        lng: pos[1]
+      })
       setItems([...items, res])
       setTipo('')
       setPriorita('')


### PR DESCRIPTION
## Summary
- add `SegnalazioneCreate` type for POST requests
- send `lat`/`lng` when creating a segnalazione
- remove the `as any` cast in `SegnalazioniPage`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687abbcd76f88323ab12eaa7e05f5e4c