### PR TITLE
Fix segnalazione payload

### DIFF
--- a/src/api/segnalazioni.ts
+++ b/src/api/segnalazioni.ts
@@ -18,11 +18,12 @@ export interface Segnalazione {
 
 export interface SegnalazioneCreate {
   tipo: string
-  priorita: string
-  stato: string
+  priorita: number
+  stato: 'aperta' | 'in lavorazione' | 'chiusa'
   descrizione?: string
-  lat?: number
-  lng?: number
+  latitudine: number
+  longitudine: number
+  data_segnalazione: string
 }
 
 export const listSegnalazioni = (): Promise<Segnalazione[]> =>

--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -73,14 +73,21 @@ const SegnalazioniPage: React.FC = () => {
     setError('')
     if (!pos) return
     try {
+      const status = stato.toLowerCase()
+      const priorityMap: Record<string, number> = {
+        Alta: 1,
+        Media: 2,
+        Bassa: 3
+      }
       const res = await createSegnalazione({
         tipo, // solo uno tra: "Piante", "Danneggiamenti", "Reati", "Animali", "Altro"
-        stato,
-        priorita,
+        stato: status,
+        priorita: priorityMap[priorita] ?? (priorita as unknown as any),
         descrizione,
-        lat: pos[0],
-        lng: pos[1]
-      })
+        latitudine: pos[0],
+        longitudine: pos[1],
+        data_segnalazione: new Date(data).toISOString()
+      } as any)
       setItems([...items, res])
       setTipo('')
       setPriorita('')


### PR DESCRIPTION
## Summary
- ensure `createSegnalazione` accepts numeric priority, lowercase status and geographical fields
- map user inputs in `SegnalazioniPage` so the payload uses `latitudine`, `longitudine` and `data_segnalazione`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac2dfc7d88323b31a832519ebcd46