### PR TITLE
Fix status mapping for segnalazioni page

### DIFF
--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -73,7 +73,13 @@ const SegnalazioniPage: React.FC = () => {
     setError('')
     if (!pos) return
     try {
-      const status = stato.toLowerCase()
+      const statusMap: Record<string, 'aperta' | 'in lavorazione' | 'chiusa'> = {
+        Aperta: 'aperta',
+        'In lavorazione': 'in lavorazione',
+        Chiusa: 'chiusa'
+      }
+      const status =
+        statusMap[stato] ?? (stato.toLowerCase() as 'aperta' | 'in lavorazione' | 'chiusa')
       const priorityMap: Record<string, number> = {
         Alta: 1,
         Media: 2,


### PR DESCRIPTION
## Summary
- map UI status labels to lowercase formats expected by the backend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac4e74634832389315aa0ac4e78c0