### PR TITLE
Remove binary logo file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ pnpm-debug.log*
 .vscode/
 .idea/
 .DS_Store
+backend/logo.png

--- a/backend/logo.txt
+++ b/backend/logo.txt
@@ -1,0 +1,1 @@
+Replace this file with logo.png

--- a/backend/pdf.py
+++ b/backend/pdf.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tempfile
+
+HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset='utf-8'>
+<style>
+  body {{ font-family: Arial, sans-serif; }}
+  header {{ display: flex; align-items: center; gap: 10px; }}
+  header img {{ height: 60px; }}
+  table {{ border-collapse: collapse; width: 100%; margin-top: 1em; }}
+  th, td {{ border: 1px solid #000; padding: 4px; text-align: left; }}
+</style>
+</head>
+<body>
+<header>
+  <img src="logo.png" alt="logo">
+  <h1>Piano Segnaletica Orizzontale Anno {year}</h1>
+</header>
+<table>
+  <thead>
+    <tr><th>Azienda</th><th>Lavori da eseguire</th><th>Quantità</th></tr>
+  </thead>
+  <tbody>
+    {rows}
+  </tbody>
+</table>
+</body>
+</html>
+"""
+
+def build_segnaletica_orizzontale_pdf(year: int, azienda: str, lavori: list[dict]) -> Path:
+    """Build a very simple PDF file for horizontal signage.
+
+    The PDF here is actually an HTML file with .pdf extension so that browsers
+    can open it. It includes the Polizia logo next to the title and a table of
+    works with the 'Lavori da eseguire' header.
+    """
+    rows_html = "\n    ".join(
+        f"<tr><td>{azienda}</td><td>{l.get('descrizione','')}</td><td>{l.get('quantita','')}</td></tr>"
+        for l in lavori
+    )
+    html = HTML_TEMPLATE.format(year=year, rows=rows_html)
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
+    path = Path(tmp.name)
+    path.write_text(html, encoding="utf-8")
+    tmp.close()
+    return path

--- a/backend/tests/test_pdf.py
+++ b/backend/tests/test_pdf.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import sys
+from pathlib import Path as _P
+
+# ensure project root is on sys.path when running tests directly
+ROOT = _P(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.pdf import build_segnaletica_orizzontale_pdf
+
+
+def test_build_pdf_contains_logo_and_header(tmp_path: Path) -> None:
+    lavori = [
+        {"descrizione": "Tracciamento linee", "quantita": 1},
+    ]
+    pdf_path = build_segnaletica_orizzontale_pdf(2024, "ACME", lavori)
+
+    data = pdf_path.read_text(encoding="utf-8")
+    assert '<img src="logo.png"' in data
+    assert "Lavori da eseguire" in data
+
+    pdf_path.unlink()


### PR DESCRIPTION
## Summary
- replace binary logo placeholder file with `logo.txt`
- reference `logo.png` in PDF builder and test
- ignore `backend/logo.png`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b824cc8dc8323973689f00d62cdaa