### PR TITLE
Add segnalazione status update in modals

### DIFF
--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -216,6 +216,7 @@ const SegnalazioniPage: React.FC = () => {
               <th>Tipo</th>
               <th>Data</th>
               <th>Descrizione</th>
+              <th>Stato</th>
             </tr>
           </thead>
           <tbody>
@@ -224,6 +225,17 @@ const SegnalazioniPage: React.FC = () => {
                 <td>{item.tipo}</td>
                 <td>{new Date(item.data_segnalazione).toLocaleDateString()}</td>
                 <td>{item.descrizione}</td>
+                <td>
+                  <select
+                    aria-label="Stato segnalazione"
+                    value={item.stato}
+                    onChange={e => onChangeStato(item.id, e.target.value)}
+                  >
+                    <option value="aperta">Aperta</option>
+                    <option value="in lavorazione">In lavorazione</option>
+                    <option value="chiusa">Chiusa</option>
+                  </select>
+                </td>
               </tr>
             ))}
           </tbody>
@@ -241,6 +253,7 @@ const SegnalazioniPage: React.FC = () => {
               <th>Tipo</th>
               <th>Data</th>
               <th>Descrizione</th>
+              <th>Stato</th>
             </tr>
           </thead>
           <tbody>
@@ -249,6 +262,17 @@ const SegnalazioniPage: React.FC = () => {
                 <td>{item.tipo}</td>
                 <td>{new Date(item.data_segnalazione).toLocaleDateString()}</td>
                 <td>{item.descrizione}</td>
+                <td>
+                  <select
+                    aria-label="Stato segnalazione"
+                    value={item.stato}
+                    onChange={e => onChangeStato(item.id, e.target.value)}
+                  >
+                    <option value="aperta">Aperta</option>
+                    <option value="in lavorazione">In lavorazione</option>
+                    <option value="chiusa">Chiusa</option>
+                  </select>
+                </td>
               </tr>
             ))}
           </tbody>
@@ -266,6 +290,7 @@ const SegnalazioniPage: React.FC = () => {
               <th>Tipo</th>
               <th>Data</th>
               <th>Descrizione</th>
+              <th>Stato</th>
             </tr>
           </thead>
           <tbody>
@@ -274,6 +299,17 @@ const SegnalazioniPage: React.FC = () => {
                 <td>{item.tipo}</td>
                 <td>{new Date(item.data_segnalazione).toLocaleDateString()}</td>
                 <td>{item.descrizione}</td>
+                <td>
+                  <select
+                    aria-label="Stato segnalazione"
+                    value={item.stato}
+                    onChange={e => onChangeStato(item.id, e.target.value)}
+                  >
+                    <option value="aperta">Aperta</option>
+                    <option value="in lavorazione">In lavorazione</option>
+                    <option value="chiusa">Chiusa</option>
+                  </select>
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/pages/__tests__/SegnalazioniPage.test.tsx
+++ b/src/pages/__tests__/SegnalazioniPage.test.tsx
@@ -188,4 +188,48 @@ describe('SegnalazioniPage', () => {
     })
     expect((select as HTMLSelectElement).value).toBe('chiusa')
   })
+
+  it('changes segnalazione status from modal', async () => {
+    mockedApi.listSegnalazioni.mockResolvedValue([
+      {
+        id: '1',
+        tipo: 'Buco',
+        priorita: 'Alta',
+        data: '2024-01-01',
+        descrizione: 'desc',
+        stato: 'aperta',
+        latitudine: 0,
+        longitudine: 0,
+      },
+    ])
+    mockedApi.updateSegnalazione.mockResolvedValue({
+      id: '1',
+      tipo: 'Buco',
+      priorita: 'Alta',
+      data: '2024-01-01',
+      descrizione: 'desc',
+      stato: 'chiusa',
+      latitudine: 0,
+      longitudine: 0,
+    } as any)
+
+    render(
+      <MemoryRouter initialEntries={['/segnalazioni']}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/segnalazioni" element={<SegnalazioniPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /attive/i }))
+    const select = await screen.findByLabelText(/stato segnalazione/i)
+    await userEvent.selectOptions(select, 'chiusa')
+
+    expect(mockedApi.updateSegnalazione).toHaveBeenCalledWith('1', {
+      stato: 'chiusa',
+    })
+    expect((select as HTMLSelectElement).value).toBe('chiusa')
+  })
 })


### PR DESCRIPTION
## Summary
- allow changing segnalazione state directly from the Active, In progress and Completed modals
- test updating status from modal

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b852554e883238ee80df873441514