### PR TITLE
Fix dashboard to hide past events

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,12 +4,7 @@ import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
-import {
-  parseISO,
-  startOfWeek,
-  endOfWeek,
-  isWithinInterval,
-} from 'date-fns';
+import { parseISO, endOfWeek, isWithinInterval } from 'date-fns';
 import { DEFAULT_CALENDAR_ID, GOOGLE_COLOR_MAP } from '../constants';
 
 interface EventItem {
@@ -46,12 +41,11 @@ export default function Dashboard() {
   const [refreshCal, setRefreshCal] = useState(false);
 
   const today = new Date();
-  const weekStart = startOfWeek(today, { weekStartsOn: 1 });
   const weekEnd = endOfWeek(today, { weekStartsOn: 1 });
   const upcomingEvents = events.filter(e => {
     if (e.source !== 'gc') return false;
     const date = parseISO(e.dateTime);
-    return isWithinInterval(date, { start: weekStart, end: weekEnd });
+    return isWithinInterval(date, { start: today, end: weekEnd });
   });
   const dashboardTodos = todos;
 

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -77,5 +77,29 @@ describe('Dashboard', () => {
     expect(screen.queryByText(/GC next/)).not.toBeInTheDocument();
   });
 
+  it('hides past events from this week', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-03T10:00:00Z'));
+    localStorage.setItem(
+      'events',
+      JSON.stringify([
+        { id: '1', title: 'GC past', description: '', dateTime: '2023-05-01T10:00:00Z', isPublic: true, source: 'gc' },
+        { id: '2', title: 'GC future', description: '', dateTime: '2023-05-05T10:00:00Z', isPublic: true, source: 'gc' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/GC future/)).toBeInTheDocument();
+    expect(screen.queryByText(/GC past/)).not.toBeInTheDocument();
+  });
+
 });
 


### PR DESCRIPTION
## Summary
- filter out past events in the dashboard
- add regression test to ensure past events aren't shown

## Testing
- `npx jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb48209fc83238cf242dc44070576