### PR TITLE
Adjust dashboard event filter

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import { deleteTodo } from '../api/todos';
 import './Dashboard.css';
-import { parseISO, endOfWeek, isWithinInterval } from 'date-fns';
+import { parseISO, addDays, isWithinInterval } from 'date-fns';
 import { DEFAULT_CALENDAR_ID, GOOGLE_COLOR_MAP } from '../constants';
 
 interface EventItem {
@@ -41,11 +41,11 @@ export default function Dashboard() {
   const [refreshCal, setRefreshCal] = useState(false);
 
   const today = new Date();
-  const weekEnd = endOfWeek(today, { weekStartsOn: 1 });
+  const nextWeek = addDays(today, 7);
   const upcomingEvents = events.filter(e => {
     if (e.source !== 'gc') return false;
     const date = parseISO(e.dateTime);
-    return isWithinInterval(date, { start: today, end: weekEnd });
+    return isWithinInterval(date, { start: today, end: nextWeek });
   });
   const dashboardTodos = todos;
 

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -51,7 +51,7 @@ describe('Dashboard', () => {
     expect(screen.getByRole('button', { name: /Aggiorna calendario/i })).toBeInTheDocument();
   });
 
-  it('shows Google events for the current week only', () => {
+  it('shows Google events for the next 7 days only', () => {
     jest.useFakeTimers().setSystemTime(new Date('2023-05-03T10:00:00Z'));
     localStorage.setItem(
       'events',
@@ -77,7 +77,7 @@ describe('Dashboard', () => {
     expect(screen.queryByText(/GC next/)).not.toBeInTheDocument();
   });
 
-  it('hides past events from this week', () => {
+  it('hides past events from the next 7 days', () => {
     jest.useFakeTimers().setSystemTime(new Date('2023-05-03T10:00:00Z'));
     localStorage.setItem(
       'events',


### PR DESCRIPTION
## Summary
- show Google events for the next 7 days on the dashboard
- update related tests to match new behaviour

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb76452408323ba63c3814853bb1f