### PR TITLE
Add horizontal signage backend

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import Session
 from . import models, schemas
+import datetime
 
 
 def get_segnalazioni(db: Session, skip: int = 0, limit: int = 100):
@@ -31,3 +32,54 @@ def update_segnalazione(
     db.commit()
     db.refresh(db_segnalazione)
     return db_segnalazione
+
+
+def create_horizontal_sign(db: Session, sign: schemas.HorizontalSignCreate):
+    db_sign = models.HorizontalSign(**sign.model_dump(mode="json"))
+    db.add(db_sign)
+    db.commit()
+    db.refresh(db_sign)
+    return db_sign
+
+
+def get_horizontal_signs(
+    db: Session, plan: int | None = None, year: int | None = None
+):
+    query = db.query(models.HorizontalSign)
+    if plan is not None:
+        query = query.filter(models.HorizontalSign.piano_id == plan)
+    if year is not None:
+        start = datetime.datetime(year, 1, 1)
+        end = datetime.datetime(year + 1, 1, 1)
+        query = query.filter(models.HorizontalSign.data >= start)
+        query = query.filter(models.HorizontalSign.data < end)
+    return query.all()
+
+
+def update_horizontal_sign(
+    db: Session, sign_id: int, sign: schemas.HorizontalSignUpdate
+):
+    db_sign = db.query(models.HorizontalSign).filter(models.HorizontalSign.id == sign_id).first()
+    if not db_sign:
+        return None
+    for key, value in sign.dict(exclude_unset=True).items():
+        setattr(db_sign, key, value)
+    db.commit()
+    db.refresh(db_sign)
+    return db_sign
+
+
+def delete_horizontal_sign(db: Session, sign_id: int) -> bool:
+    db_sign = db.query(models.HorizontalSign).filter(models.HorizontalSign.id == sign_id).first()
+    if not db_sign:
+        return False
+    db.delete(db_sign)
+    db.commit()
+    return True
+
+
+def get_horizontal_years(db: Session) -> list[int]:
+    years = {
+        s.data.year for s in db.query(models.HorizontalSign).all() if s.data is not None
+    }
+    return sorted(years)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,10 @@
 import os
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException, status, Response
+from fastapi.responses import FileResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 import jwt
-from . import models, schemas, crud
+from . import models, schemas, crud, pdf
 from .database import SessionLocal, engine
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -91,6 +92,63 @@ def read_segnalazioni(skip: int = 0, limit: int = 100, db: Session = Depends(get
 @app.get("/users/me", response_model=schemas.User)
 def read_users_me(current_user: schemas.User = Depends(get_current_user)):
     return current_user
+
+
+@app.get(
+    "/inventario/signage-horizontal/",
+    response_model=list[schemas.HorizontalSign],
+)
+def list_horizontal_signs(
+    plan: int | None = None,
+    year: int | None = None,
+    db: Session = Depends(get_db),
+):
+    return crud.get_horizontal_signs(db, plan=plan, year=year)
+
+
+@app.post(
+    "/inventario/signage-horizontal/",
+    response_model=schemas.HorizontalSign,
+)
+def create_horizontal_sign(sign: schemas.HorizontalSignCreate, db: Session = Depends(get_db)):
+    return crud.create_horizontal_sign(db, sign)
+
+
+@app.put(
+    "/inventario/signage-horizontal/{sign_id}/",
+    response_model=schemas.HorizontalSign,
+)
+def update_horizontal_sign(sign_id: int, sign: schemas.HorizontalSignUpdate, db: Session = Depends(get_db)):
+    db_sign = crud.update_horizontal_sign(db, sign_id, sign)
+    if db_sign is None:
+        raise HTTPException(status_code=404, detail="Horizontal sign not found")
+    return db_sign
+
+
+@app.delete("/inventario/signage-horizontal/{sign_id}/", status_code=204)
+def delete_horizontal_sign(sign_id: int, db: Session = Depends(get_db)):
+    if not crud.delete_horizontal_sign(db, sign_id):
+        raise HTTPException(status_code=404, detail="Horizontal sign not found")
+    return Response(status_code=204)
+
+
+@app.get("/inventario/signage-horizontal/years/", response_model=list[int])
+def list_horizontal_years(db: Session = Depends(get_db)):
+    return crud.get_horizontal_years(db)
+
+
+@app.get("/inventario/signage-horizontal/pdf/")
+def horizontal_pdf(year: int, db: Session = Depends(get_db)):
+    signs = crud.get_horizontal_signs(db, year=year)
+    lavori = [
+        {"descrizione": s.descrizione or "", "quantita": s.quantita or ""} for s in signs
+    ]
+    pdf_path = pdf.build_segnaletica_orizzontale_pdf(year, "Azienda", lavori)
+    return FileResponse(
+        pdf_path,
+        media_type="application/pdf",
+        filename=f"segnaletica_orizzontale_{year}.pdf",
+    )
 
 
 if __name__ == "__main__":

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,4 +1,5 @@
-from sqlalchemy import Column, Integer, String, DateTime, Float
+from sqlalchemy import Column, Integer, String, DateTime, Float, ForeignKey
+from sqlalchemy.orm import relationship
 from .database import Base
 import datetime
 
@@ -13,3 +14,14 @@ class Segnalazione(Base):
     descrizione = Column(String, nullable=True)
     lat = Column(Float, nullable=True)
     lng = Column(Float, nullable=True)
+
+
+class HorizontalSign(Base):
+    __tablename__ = "horizontal_signs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    luogo = Column(String, nullable=False)
+    data = Column(DateTime, default=datetime.datetime.utcnow)
+    descrizione = Column(String, nullable=True)
+    quantita = Column(Integer, nullable=True)
+    piano_id = Column(Integer, nullable=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -57,3 +57,30 @@ class LoginRequest(BaseModel):
 
 class Token(BaseModel):
     access_token: str
+
+
+class HorizontalSignBase(BaseModel):
+    luogo: str
+    data: datetime
+    descrizione: str | None = None
+    quantita: int | None = None
+    piano_id: int | None = None
+
+
+class HorizontalSignCreate(HorizontalSignBase):
+    pass
+
+
+class HorizontalSignUpdate(BaseModel):
+    luogo: str | None = None
+    data: datetime | None = None
+    descrizione: str | None = None
+    quantita: int | None = None
+    piano_id: int | None = None
+
+
+class HorizontalSign(HorizontalSignBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/tests/test_horizontal_signs.py
+++ b/backend/tests/test_horizontal_signs.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path as _P
+import importlib
+
+from fastapi.testclient import TestClient
+
+# ensure project root is on sys.path when running tests directly
+ROOT = _P(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def get_test_app(tmp_path: _P):
+    db_path = tmp_path / "test.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+
+    from backend import database
+    importlib.reload(database)
+    from backend import models
+    importlib.reload(models)
+    from backend import crud
+    importlib.reload(crud)
+    from backend import main
+    importlib.reload(main)
+
+    return main.app
+
+
+def test_horizontal_crud(tmp_path: _P):
+    app = get_test_app(tmp_path)
+    client = TestClient(app)
+
+    data = {
+        "luogo": "Az",
+        "data": "2024-05-01T00:00:00",
+        "descrizione": "Desc",
+        "quantita": 1,
+        "piano_id": 2,
+    }
+    resp = client.post("/inventario/signage-horizontal/", json=data)
+    assert resp.status_code == 200
+    sign = resp.json()
+    sign_id = sign["id"]
+
+    resp = client.get("/inventario/signage-horizontal/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+    resp = client.put(
+        f"/inventario/signage-horizontal/{sign_id}/",
+        json={"descrizione": "New"},
+    )
+    assert resp.json()["descrizione"] == "New"
+
+    resp = client.get("/inventario/signage-horizontal/years/")
+    assert resp.json() == [2024]
+
+    resp = client.get("/inventario/signage-horizontal/pdf/", params={"year": 2024})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+
+    resp = client.delete(f"/inventario/signage-horizontal/{sign_id}/")
+    assert resp.status_code == 204
+    resp = client.get("/inventario/signage-horizontal/")
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- define `HorizontalSign` SQLAlchemy model
- create accompanying Pydantic schemas
- add CRUD helpers for horizontal signage
- expose new `/inventario/signage-horizontal` routes in the API
- test CRUD flow for the new endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb99ffbe88323969104b8ba42c355