### PR TITLE
Add deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ To run the backend and frontend together during development use:
 npm run dev:full
 ```
 
+The previous `piani` and `items` tables are **deprecated**. After confirming the new unified table works well in production we will drop the old tables to keep the schema clean.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document the deprecation of the previous `piani`/`items` tables

## Testing
- `npm run lint` *(fails: ESLint couldn't find the plugin `@typescript-eslint/eslint-plugin`)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbe540e608323b4f2621ed1a3ddf1