### PR TITLE
Add pdf cleanup background task

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,12 @@
 import os
-from fastapi import Depends, FastAPI, HTTPException, status, Response
+from fastapi import (
+    Depends,
+    FastAPI,
+    HTTPException,
+    status,
+    Response,
+    BackgroundTasks,
+)
 from fastapi.responses import FileResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
@@ -138,12 +145,17 @@ def list_horizontal_years(db: Session = Depends(get_db)):
 
 
 @app.get("/inventario/signage-horizontal/pdf/")
-def horizontal_pdf(year: int, db: Session = Depends(get_db)):
+def horizontal_pdf(
+    year: int,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
     signs = crud.get_horizontal_signs(db, year=year)
     lavori = [
         {"descrizione": s.descrizione or "", "quantita": s.quantita or ""} for s in signs
     ]
     pdf_path = pdf.build_segnaletica_orizzontale_pdf(year, "Azienda", lavori)
+    background_tasks.add_task(pdf_path.unlink)
     return FileResponse(
         pdf_path,
         media_type="application/pdf",

--- a/backend/tests/test_horizontal_signs.py
+++ b/backend/tests/test_horizontal_signs.py
@@ -66,3 +66,23 @@ def test_horizontal_crud(tmp_path: _P):
     assert resp.status_code == 204
     resp = client.get("/inventario/signage-horizontal/")
     assert resp.json() == []
+
+
+def test_pdf_removed_after_response(tmp_path: _P) -> None:
+    app = get_test_app(tmp_path)
+
+    from backend import main as main_module
+
+    pdf_file = tmp_path / "out.pdf"
+
+    def fake_pdf(year: int, azienda: str, lavori: list[dict]):
+        pdf_file.write_text("dummy", encoding="utf-8")
+        return pdf_file
+
+    main_module.pdf.build_segnaletica_orizzontale_pdf = fake_pdf
+
+    client = TestClient(app)
+    resp = client.get("/inventario/signage-horizontal/pdf/", params={"year": 2024})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+    assert not pdf_file.exists()


### PR DESCRIPTION
## Summary
- clean up generated PDFs in `/inventario/signage-horizontal/pdf/` using `BackgroundTasks`
- test that the file is removed after the response completes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687cbe5093048323b4c7a36fa79a1fe9