### PR TITLE
Remove unused piano_id from horizontal signage

### DIFF
--- a/backend/crud.py
+++ b/backend/crud.py
@@ -42,12 +42,8 @@ def create_horizontal_sign(db: Session, sign: schemas.HorizontalSignCreate):
     return db_sign
 
 
-def get_horizontal_signs(
-    db: Session, plan: int | None = None, year: int | None = None
-):
+def get_horizontal_signs(db: Session, year: int | None = None):
     query = db.query(models.HorizontalSign)
-    if plan is not None:
-        query = query.filter(models.HorizontalSign.piano_id == plan)
     if year is not None:
         start = datetime.datetime(year, 1, 1)
         end = datetime.datetime(year + 1, 1, 1)

--- a/backend/main.py
+++ b/backend/main.py
@@ -99,11 +99,10 @@ def read_users_me(current_user: schemas.User = Depends(get_current_user)):
     response_model=list[schemas.HorizontalSign],
 )
 def list_horizontal_signs(
-    plan: int | None = None,
     year: int | None = None,
     db: Session = Depends(get_db),
 ):
-    return crud.get_horizontal_signs(db, plan=plan, year=year)
+    return crud.get_horizontal_signs(db, year=year)
 
 
 @app.post(

--- a/backend/models.py
+++ b/backend/models.py
@@ -24,4 +24,3 @@ class HorizontalSign(Base):
     data = Column(DateTime, default=datetime.datetime.utcnow)
     descrizione = Column(String, nullable=True)
     quantita = Column(Integer, nullable=True)
-    piano_id = Column(Integer, nullable=True)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -64,7 +64,6 @@ class HorizontalSignBase(BaseModel):
     data: datetime
     descrizione: str | None = None
     quantita: int | None = None
-    piano_id: int | None = None
 
 
 class HorizontalSignCreate(HorizontalSignBase):
@@ -76,7 +75,6 @@ class HorizontalSignUpdate(BaseModel):
     data: datetime | None = None
     descrizione: str | None = None
     quantita: int | None = None
-    piano_id: int | None = None
 
 
 class HorizontalSign(HorizontalSignBase):

--- a/backend/tests/test_horizontal_signs.py
+++ b/backend/tests/test_horizontal_signs.py
@@ -38,7 +38,6 @@ def test_horizontal_crud(tmp_path: _P):
         "data": "2024-05-01T00:00:00",
         "descrizione": "Desc",
         "quantita": 1,
-        "piano_id": 2,
     }
     resp = client.post("/inventario/signage-horizontal/", json=data)
     assert resp.status_code == 200

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -6,7 +6,6 @@ export interface HorizontalSign {
   data: string
   descrizione?: string
   quantita?: number
-  piano_id?: string
 }
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>


### PR DESCRIPTION
## Summary
- drop `piano_id` column from HorizontalSign model and schemas
- stop filtering by plan in CRUD and API endpoint
- adapt API tests and frontend types

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687cbe4f5cc8832392f68bdb126daff7