### PR TITLE
Add CSV import endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,7 @@
 import os
+import csv
+from io import StringIO
+import datetime
 from fastapi import (
     Depends,
     FastAPI,
@@ -6,6 +9,8 @@ from fastapi import (
     status,
     Response,
     BackgroundTasks,
+    UploadFile,
+    File,
 )
 from fastapi.responses import FileResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -154,6 +159,58 @@ def horizontal_pdf(
         {"descrizione": s.descrizione or "", "quantita": s.quantita or ""} for s in signs
     ]
     pdf_path = pdf.build_segnaletica_orizzontale_pdf(year, "Azienda", lavori)
+    background_tasks.add_task(pdf_path.unlink)
+    return FileResponse(
+        pdf_path,
+        media_type="application/pdf",
+        filename=f"segnaletica_orizzontale_{year}.pdf",
+    )
+
+
+@app.post("/segnaletica-orizzontale/import")
+def import_horizontal_signs(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_db),
+):
+    """Import horizontal signage from a CSV file and return a PDF summary."""
+    try:
+        content = file.file.read().decode("utf-8")
+    finally:
+        file.file.close()
+
+    reader = csv.DictReader(StringIO(content))
+    if not reader.fieldnames or not {"azienda", "descrizione"}.issubset(
+        {h.strip().lower() for h in reader.fieldnames}
+    ):
+        raise HTTPException(status_code=400, detail="Invalid CSV format")
+
+    year = datetime.datetime.now().year
+    lavori: list[dict] = []
+    azienda_name: str | None = None
+
+    for row in reader:
+        azienda = (row.get("azienda") or "").strip()
+        descrizione = (row.get("descrizione") or "").strip()
+        if not descrizione:
+            continue
+        if azienda_name is None:
+            azienda_name = azienda
+        sign = schemas.HorizontalSignCreate(
+            luogo=azienda,
+            data=datetime.datetime(year, 1, 1),
+            descrizione=descrizione,
+            quantita=None,
+        )
+        crud.create_horizontal_sign(db, sign)
+        lavori.append({"descrizione": descrizione, "quantita": ""})
+
+    if not lavori:
+        raise HTTPException(status_code=400, detail="No valid rows found")
+
+    pdf_path = pdf.build_segnaletica_orizzontale_pdf(
+        year, azienda_name or "", lavori
+    )
     background_tasks.add_task(pdf_path.unlink)
     return FileResponse(
         pdf_path,

--- a/backend/tests/test_horizontal_signs.py
+++ b/backend/tests/test_horizontal_signs.py
@@ -4,6 +4,7 @@ import os
 import sys
 from pathlib import Path as _P
 import importlib
+import datetime
 
 from fastapi.testclient import TestClient
 
@@ -85,3 +86,36 @@ def test_pdf_removed_after_response(tmp_path: _P) -> None:
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/pdf"
     assert not pdf_file.exists()
+
+
+def test_import_signs(tmp_path: _P) -> None:
+    app = get_test_app(tmp_path)
+    client = TestClient(app)
+
+    csv_data = "azienda,descrizione,anno\nACME,Linee,2024\nACME, ,2024\nACME,Altro,2024"
+    resp = client.post(
+        "/segnaletica-orizzontale/import",
+        files={"file": ("data.csv", csv_data, "text/csv")},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/pdf"
+
+    year = datetime.datetime.now().year
+    resp = client.get("/inventario/signage-horizontal/")
+    data = resp.json()
+    assert len(data) == 2
+    for sign in data:
+        assert sign["luogo"] == "ACME"
+        assert sign["data"].startswith(str(year))
+
+
+def test_import_invalid_file(tmp_path: _P) -> None:
+    app = get_test_app(tmp_path)
+    client = TestClient(app)
+
+    csv_data = "foo,bar\n1,2"
+    resp = client.post(
+        "/segnaletica-orizzontale/import",
+        files={"file": ("data.csv", csv_data, "text/csv")},
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- support uploading segnaletica orizzontale data
- parse `azienda` and `descrizione` columns from CSV files
- store records for the current year and return a PDF
- test the new import flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687cc82c6eec8323bda73629f7b235f6