### PR TITLE
Add success modal on segnalazioni

### DIFF
--- a/src/pages/SegnalazioniPage.tsx
+++ b/src/pages/SegnalazioniPage.tsx
@@ -50,6 +50,7 @@ const SegnalazioniPage: React.FC = () => {
   const [showClosed, setShowClosed] = useState(false)
   const [showActive, setShowActive] = useState(false)
   const [showProgress, setShowProgress] = useState(false)
+  const [showSuccess, setShowSuccess] = useState(false)
 
   const closedItems = items.filter(
     i => i.stato === 'chiusa' || i.stato === 'Chiusa'
@@ -102,6 +103,7 @@ const SegnalazioniPage: React.FC = () => {
       setDescrizione('')
       setStato('')
       setPos(null)
+      setShowSuccess(true)
     } catch {
       setError('Errore durante la creazione della segnalazione')
     }
@@ -315,6 +317,10 @@ const SegnalazioniPage: React.FC = () => {
           </tbody>
         </table>
         <Button onClick={() => setShowClosed(false)}>Chiudi</Button>
+      </Modal>
+      <Modal open={showSuccess} onClose={() => setShowSuccess(false)}>
+        <p>Segnalazione inserita correttamente.</p>
+        <Button onClick={() => setShowSuccess(false)}>Chiudi</Button>
       </Modal>
     </div>
   )

--- a/src/pages/__tests__/SegnalazioniPage.test.tsx
+++ b/src/pages/__tests__/SegnalazioniPage.test.tsx
@@ -232,4 +232,35 @@ describe('SegnalazioniPage', () => {
     })
     expect((select as HTMLSelectElement).value).toBe('chiusa')
   })
+
+  it('shows success popup after segnalazione creation', async () => {
+    mockedApi.createSegnalazione.mockResolvedValue({
+      id: '1',
+      tipo: '',
+      priorita: '',
+      data: '',
+      descrizione: '',
+      lat: 0,
+      lng: 0,
+    } as any)
+
+    render(
+      <MemoryRouter initialEntries={['/segnalazioni']}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/segnalazioni" element={<SegnalazioniPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    )
+
+    const map = screen.getByTestId('map')
+    fireEvent.click(map)
+
+    await userEvent.click(screen.getByRole('button', { name: /invia/i }))
+
+    expect(
+      await screen.findByText('Segnalazione inserita correttamente.')
+    ).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- show a success dialog after creating a new segnalazione
- test the success dialog

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cea88a12883238ebde6ba9d4cbedb