### PR TITLE
Update signage import to CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,16 +170,16 @@ single view. Each item opens in a modal for editing and the table stores the
 quantità for every entry. Horizontal signage uses a dedicated page at
 `/segnaletica-orizzontale` where the available years are listed.
 
-### Excel import
+### CSV import
 
-The **Importa Excel** button accepts a spreadsheet with the header columns:
+The **Importa CSV** button uploads a file to `/segnaletica-orizzontale/import`.
+The CSV must include the header columns:
 
 ```
-Luogo | Descrizione | Quantità | Data | Piano_ID
+azienda,descrizione
 ```
 
-Dates must be in the `YYYY-MM-DD` format. Once uploaded the backend returns a PDF
-with the imported interventions.
+The endpoint returns a PDF summarizing the imported interventions.
 
 ### API endpoints
 
@@ -189,11 +189,12 @@ with the imported interventions.
 - `DELETE /inventario/signage-horizontal/{id}/` – delete
 - `GET /inventario/signage-horizontal/years/` – list available years
 - `GET /inventario/signage-horizontal/pdf/` – annual PDF by year
+- `POST /segnaletica-orizzontale/import` – import a CSV file and return a PDF
 
 ### Generate PDFs
 
 Open the **Segnaletica orizzontale** page, choose the year and click **PDF**.
-Importing an Excel file produces the same PDF automatically.
+Importing a CSV file produces the same PDF automatically.
 
 ## Segnalazioni
 

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -55,7 +55,7 @@ export const listHorizontalByYear = (
     })
     .then(r => r.data)
 
-export const importHorizontalExcel = (file: File): Promise<Blob> => {
+export const importHorizontalCsv = (file: File): Promise<Blob> => {
   const form = new FormData()
   form.append('file', file)
   return api

--- a/src/components/ImportHorizontalCsv.tsx
+++ b/src/components/ImportHorizontalCsv.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useState, ChangeEvent } from 'react'
-import { importHorizontalExcel } from '../api/horizontalSignage'
+import { importHorizontalCsv } from '../api/horizontalSignage'
 import { getErrorDetail } from '../utils/errors'
 
 interface Props {
   onComplete?: (success: boolean) => void
 }
 
-export default function ImportHorizontalExcel({ onComplete }: Props) {
+export default function ImportHorizontalCsv({ onComplete }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [busy, setBusy] = useState(false)
   const [message, setMessage] = useState('')
@@ -21,7 +21,7 @@ export default function ImportHorizontalExcel({ onComplete }: Props) {
     setBusy(true)
     setMessage('')
     try {
-      const pdfBlob = await importHorizontalExcel(file)
+      const pdfBlob = await importHorizontalCsv(file)
       const pdfURL = URL.createObjectURL(pdfBlob)
       const newWindow = window.open(pdfURL, '_blank')
       if (newWindow) {
@@ -35,7 +35,7 @@ export default function ImportHorizontalExcel({ onComplete }: Props) {
       onComplete?.(true)
     } catch (err) {
       const detail = await getErrorDetail(err)
-      console.error('ImportHorizontalExcel error →', detail)
+      console.error('ImportHorizontalCsv error →', detail)
       const msg = detail ? `Errore durante l'importazione del file: ${detail}` : 'Errore durante l\'importazione del file'
       setMessage(msg)
       onComplete?.(false)
@@ -63,7 +63,7 @@ export default function ImportHorizontalExcel({ onComplete }: Props) {
           zIndex: 1000,
         }}
       >
-        {busy ? 'Caricamento…' : 'Importa Excel'}
+        {busy ? 'Caricamento…' : 'Importa CSV'}
       </button>
       {message && (
         <p className={message.startsWith('Errore') ? 'error' : 'success-message'}>{message}</p>
@@ -71,7 +71,7 @@ export default function ImportHorizontalExcel({ onComplete }: Props) {
       <input
         ref={fileInputRef}
         type="file"
-        accept=".xlsx, .xls"
+        accept=".csv"
         style={{ display: 'none' }}
         onChange={handleFileChange}
       />

--- a/src/components/__tests__/ImportHorizontalCsv.test.tsx
+++ b/src/components/__tests__/ImportHorizontalCsv.test.tsx
@@ -1,24 +1,24 @@
 import { render, fireEvent, waitFor } from '@testing-library/react'
-import ImportHorizontalExcel from '../ImportHorizontalExcel'
-import { importHorizontalExcel } from '../../api/horizontalSignage'
+import ImportHorizontalCsv from '../ImportHorizontalCsv'
+import { importHorizontalCsv } from '../../api/horizontalSignage'
 
 jest.mock('../../api/horizontalSignage', () => ({
   __esModule: true,
-  importHorizontalExcel: jest.fn(),
+  importHorizontalCsv: jest.fn(),
 }))
 
-const mockedImport = importHorizontalExcel as jest.MockedFunction<typeof importHorizontalExcel>
+const mockedImport = importHorizontalCsv as jest.MockedFunction<typeof importHorizontalCsv>
 
-describe('ImportHorizontalExcel', () => {
+describe('ImportHorizontalCsv', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
 
   it('calls API on file upload', async () => {
     mockedImport.mockResolvedValueOnce(new Blob())
-    const { container } = render(<ImportHorizontalExcel />)
+    const { container } = render(<ImportHorizontalCsv />)
     const input = container.querySelector('input[type="file"]') as HTMLInputElement
-    const file = new File(['1'], 'test.xlsx')
+    const file = new File(['1'], 'test.csv')
     fireEvent.change(input, { target: { files: [file] } })
 
     await waitFor(() => {

--- a/src/pages/HorizontalSignagePage.tsx
+++ b/src/pages/HorizontalSignagePage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import './ListPages.css'
 import Modal from '../components/ui/Modal'
-import ImportHorizontalExcel from '../components/ImportHorizontalExcel'
+import ImportHorizontalCsv from '../components/ImportHorizontalCsv'
 import {
   listHorizontalYears,
   listHorizontalByYear,
@@ -97,7 +97,7 @@ const HorizontalSignagePage: React.FC = () => {
           </table>
         </Modal>
       </div>
-      <ImportHorizontalExcel />
+      <ImportHorizontalCsv />
     </div>
   )
 }

--- a/src/pages/__tests__/HorizontalSignagePage.test.tsx
+++ b/src/pages/__tests__/HorizontalSignagePage.test.tsx
@@ -72,6 +72,6 @@ describe('HorizontalSignagePage', () => {
 
   it('shows import button', async () => {
     renderPage()
-    expect(await screen.findByRole('button', { name: /importa excel/i })).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: /importa csv/i })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- document CSV import for `/segnaletica-orizzontale/import`
- switch ImportHorizontalExcel component to CSV and rename to `ImportHorizontalCsv`
- adjust tests and update API helper

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cea9341a083239030d6f5278b07ee