### PR TITLE
Update signage endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ The endpoint returns a PDF summarizing the imported interventions.
 
 ### API endpoints
 
-- `GET /inventario/signage-horizontal/` – list or filter records
-- `POST /inventario/signage-horizontal/` – create a record
-- `PUT /inventario/signage-horizontal/{id}/` – update
-- `DELETE /inventario/signage-horizontal/{id}/` – delete
-- `GET /inventario/signage-horizontal/years/` – list available years
-- `GET /inventario/signage-horizontal/pdf/` – annual PDF by year
+- `GET /segnaletica-orizzontale/` – list or filter records
+- `POST /segnaletica-orizzontale/` – create a record
+- `PUT /segnaletica-orizzontale/{id}/` – update
+- `DELETE /segnaletica-orizzontale/{id}/` – delete
+- `GET /segnaletica-orizzontale/years/` – list available years
+- `GET /segnaletica-orizzontale/pdf/` – annual PDF by year
 - `POST /segnaletica-orizzontale/import` – import a CSV file and return a PDF
 
 ### Generate PDFs

--- a/backend/main.py
+++ b/backend/main.py
@@ -107,7 +107,7 @@ def read_users_me(current_user: schemas.User = Depends(get_current_user)):
 
 
 @app.get(
-    "/inventario/signage-horizontal/",
+    "/segnaletica-orizzontale/",
     response_model=list[schemas.HorizontalSign],
 )
 def list_horizontal_signs(
@@ -118,7 +118,7 @@ def list_horizontal_signs(
 
 
 @app.post(
-    "/inventario/signage-horizontal/",
+    "/segnaletica-orizzontale/",
     response_model=schemas.HorizontalSign,
 )
 def create_horizontal_sign(sign: schemas.HorizontalSignCreate, db: Session = Depends(get_db)):
@@ -126,7 +126,7 @@ def create_horizontal_sign(sign: schemas.HorizontalSignCreate, db: Session = Dep
 
 
 @app.put(
-    "/inventario/signage-horizontal/{sign_id}/",
+    "/segnaletica-orizzontale/{sign_id}/",
     response_model=schemas.HorizontalSign,
 )
 def update_horizontal_sign(sign_id: int, sign: schemas.HorizontalSignUpdate, db: Session = Depends(get_db)):
@@ -136,19 +136,19 @@ def update_horizontal_sign(sign_id: int, sign: schemas.HorizontalSignUpdate, db:
     return db_sign
 
 
-@app.delete("/inventario/signage-horizontal/{sign_id}/", status_code=204)
+@app.delete("/segnaletica-orizzontale/{sign_id}/", status_code=204)
 def delete_horizontal_sign(sign_id: int, db: Session = Depends(get_db)):
     if not crud.delete_horizontal_sign(db, sign_id):
         raise HTTPException(status_code=404, detail="Horizontal sign not found")
     return Response(status_code=204)
 
 
-@app.get("/inventario/signage-horizontal/years/", response_model=list[int])
+@app.get("/segnaletica-orizzontale/years/", response_model=list[int])
 def list_horizontal_years(db: Session = Depends(get_db)):
     return crud.get_horizontal_years(db)
 
 
-@app.get("/inventario/signage-horizontal/pdf/")
+@app.get("/segnaletica-orizzontale/pdf/")
 def horizontal_pdf(
     year: int,
     background_tasks: BackgroundTasks,

--- a/backend/tests/test_horizontal_signs.py
+++ b/backend/tests/test_horizontal_signs.py
@@ -40,31 +40,31 @@ def test_horizontal_crud(tmp_path: _P):
         "descrizione": "Desc",
         "quantita": 1,
     }
-    resp = client.post("/inventario/signage-horizontal/", json=data)
+    resp = client.post("/segnaletica-orizzontale/", json=data)
     assert resp.status_code == 200
     sign = resp.json()
     sign_id = sign["id"]
 
-    resp = client.get("/inventario/signage-horizontal/")
+    resp = client.get("/segnaletica-orizzontale/")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
     resp = client.put(
-        f"/inventario/signage-horizontal/{sign_id}/",
+        f"/segnaletica-orizzontale/{sign_id}/",
         json={"descrizione": "New"},
     )
     assert resp.json()["descrizione"] == "New"
 
-    resp = client.get("/inventario/signage-horizontal/years/")
+    resp = client.get("/segnaletica-orizzontale/years/")
     assert resp.json() == [2024]
 
-    resp = client.get("/inventario/signage-horizontal/pdf/", params={"year": 2024})
+    resp = client.get("/segnaletica-orizzontale/pdf/", params={"year": 2024})
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/pdf"
 
-    resp = client.delete(f"/inventario/signage-horizontal/{sign_id}/")
+    resp = client.delete(f"/segnaletica-orizzontale/{sign_id}/")
     assert resp.status_code == 204
-    resp = client.get("/inventario/signage-horizontal/")
+    resp = client.get("/segnaletica-orizzontale/")
     assert resp.json() == []
 
 
@@ -82,7 +82,7 @@ def test_pdf_removed_after_response(tmp_path: _P) -> None:
     main_module.pdf.build_segnaletica_orizzontale_pdf = fake_pdf
 
     client = TestClient(app)
-    resp = client.get("/inventario/signage-horizontal/pdf/", params={"year": 2024})
+    resp = client.get("/segnaletica-orizzontale/pdf/", params={"year": 2024})
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/pdf"
     assert not pdf_file.exists()
@@ -101,7 +101,7 @@ def test_import_signs(tmp_path: _P) -> None:
     assert resp.headers["content-type"] == "application/pdf"
 
     year = datetime.datetime.now().year
-    resp = client.get("/inventario/signage-horizontal/")
+    resp = client.get("/segnaletica-orizzontale/")
     data = resp.json()
     assert len(data) == 2
     for sign in data:

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -10,14 +10,14 @@ export interface HorizontalSign {
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
   api
-    .get<HorizontalSign[]>('/inventario/signage-horizontal/')
+    .get<HorizontalSign[]>('/segnaletica-orizzontale/')
     .then(r => r.data)
 
 export const createHorizontalSignage = (
   data: Omit<HorizontalSign, 'id'>,
 ): Promise<HorizontalSign> =>
   api
-    .post<HorizontalSign>('/inventario/signage-horizontal/', data)
+    .post<HorizontalSign>('/segnaletica-orizzontale/', data)
     .then(r => r.data)
 
 export const updateHorizontalSignage = (
@@ -25,17 +25,17 @@ export const updateHorizontalSignage = (
   data: Partial<Omit<HorizontalSign, 'id'>>,
 ): Promise<HorizontalSign> =>
   api
-    .put<HorizontalSign>(`/inventario/signage-horizontal/${id}/`, data)
+    .put<HorizontalSign>(`/segnaletica-orizzontale/${id}/`, data)
     .then(r => r.data)
 
 export const deleteHorizontalSignage = (id: string): Promise<void> =>
   api
-    .delete(`/inventario/signage-horizontal/${id}/`)
+    .delete(`/segnaletica-orizzontale/${id}/`)
     .then(() => undefined)
 
 export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
   api
-    .get('/inventario/signage-horizontal/pdf/', {
+    .get('/segnaletica-orizzontale/pdf/', {
       params: { year },
       responseType: 'blob',
     })
@@ -43,14 +43,14 @@ export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
 
 export const listHorizontalYears = (): Promise<number[]> =>
   api
-    .get<number[]>('/inventario/signage-horizontal/years/')
+    .get<number[]>('/segnaletica-orizzontale/years/')
     .then(r => r.data)
 
 export const listHorizontalByYear = (
   year: number,
 ): Promise<HorizontalSign[]> =>
   api
-    .get<HorizontalSign[]>('/inventario/signage-horizontal/', {
+    .get<HorizontalSign[]>('/segnaletica-orizzontale/', {
       params: { year },
     })
     .then(r => r.data)


### PR DESCRIPTION
## Summary
- switch signage endpoints to `/segnaletica-orizzontale/`
- update docs and frontend API helpers
- adjust tests for new routes

## Testing
- `pytest backend/tests/test_horizontal_signs.py::test_horizontal_crud -vv` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687cf1c84778832388a8e4c370261924