### PR TITLE
Update horizontal signage endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,12 @@ The endpoint returns a PDF summarizing the imported interventions.
 
 ### API endpoints
 
-- `GET /inventario/signage-horizontal/` – list or filter records
-- `POST /inventario/signage-horizontal/` – create a record
-- `PUT /inventario/signage-horizontal/{id}/` – update
-- `DELETE /inventario/signage-horizontal/{id}/` – delete
-- `GET /inventario/signage-horizontal/years/` – list available years
-- `GET /inventario/signage-horizontal/pdf/` – annual PDF by year
+- `GET /segnaletica-orizzontale/` – list or filter records
+- `POST /segnaletica-orizzontale/` – create a record
+- `PUT /segnaletica-orizzontale/{id}/` – update
+- `DELETE /segnaletica-orizzontale/{id}/` – delete
+- `GET /segnaletica-orizzontale/years/` – list available years
+- `GET /segnaletica-orizzontale/pdf/` – annual PDF by year
 - `POST /segnaletica-orizzontale/import` – import a CSV file and return a PDF
 
 ### Generate PDFs

--- a/src/api/horizontalSignage.ts
+++ b/src/api/horizontalSignage.ts
@@ -10,14 +10,14 @@ export interface HorizontalSign {
 
 export const listHorizontalSignage = (): Promise<HorizontalSign[]> =>
   api
-    .get<HorizontalSign[]>('/inventario/signage-horizontal/')
+    .get<HorizontalSign[]>('/segnaletica-orizzontale/')
     .then(r => r.data)
 
 export const createHorizontalSignage = (
   data: Omit<HorizontalSign, 'id'>,
 ): Promise<HorizontalSign> =>
   api
-    .post<HorizontalSign>('/inventario/signage-horizontal/', data)
+    .post<HorizontalSign>('/segnaletica-orizzontale/', data)
     .then(r => r.data)
 
 export const updateHorizontalSignage = (
@@ -25,17 +25,17 @@ export const updateHorizontalSignage = (
   data: Partial<Omit<HorizontalSign, 'id'>>,
 ): Promise<HorizontalSign> =>
   api
-    .put<HorizontalSign>(`/inventario/signage-horizontal/${id}/`, data)
+    .put<HorizontalSign>(`/segnaletica-orizzontale/${id}/`, data)
     .then(r => r.data)
 
 export const deleteHorizontalSignage = (id: string): Promise<void> =>
   api
-    .delete(`/inventario/signage-horizontal/${id}/`)
+    .delete(`/segnaletica-orizzontale/${id}/`)
     .then(() => undefined)
 
 export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
   api
-    .get('/inventario/signage-horizontal/pdf/', {
+    .get('/segnaletica-orizzontale/pdf/', {
       params: { year },
       responseType: 'blob',
     })
@@ -43,14 +43,14 @@ export const getHorizontalSignagePdf = (year: number): Promise<Blob> =>
 
 export const listHorizontalYears = (): Promise<number[]> =>
   api
-    .get<number[]>('/inventario/signage-horizontal/years/')
+    .get<number[]>('/segnaletica-orizzontale/years/')
     .then(r => r.data)
 
 export const listHorizontalByYear = (
   year: number,
 ): Promise<HorizontalSign[]> =>
   api
-    .get<HorizontalSign[]>('/inventario/signage-horizontal/', {
+    .get<HorizontalSign[]>('/segnaletica-orizzontale/', {
       params: { year },
     })
     .then(r => r.data)


### PR DESCRIPTION
## Summary
- switch all axios endpoints in `horizontalSignage.ts` to `/segnaletica-orizzontale`
- update README examples for the new URL prefix

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing eslint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687cf1cb520c8323945c00ec6f39da57