### PR TITLE
Hide turno events from dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -44,6 +44,7 @@ export default function Dashboard() {
   const nextWeek = addDays(today, 7);
   const upcomingEvents = events.filter(e => {
     if (e.source !== 'gc') return false;
+    if (/^turno/i.test(e.title)) return false;
     const date = parseISO(e.dateTime);
     return isWithinInterval(date, { start: today, end: nextWeek });
   });

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -101,5 +101,29 @@ describe('Dashboard', () => {
     expect(screen.queryByText(/GC past/)).not.toBeInTheDocument();
   });
 
+  it('hides events that start with "turno"', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-03T10:00:00Z'));
+    localStorage.setItem(
+      'events',
+      JSON.stringify([
+        { id: '1', title: 'turno Mario', description: '', dateTime: '2023-05-05T10:00:00Z', isPublic: true, source: 'gc' },
+        { id: '2', title: 'Riunione', description: '', dateTime: '2023-05-05T11:00:00Z', isPublic: true, source: 'gc' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/Riunione/)).toBeInTheDocument();
+    expect(screen.queryByText(/turno Mario/i)).not.toBeInTheDocument();
+  });
+
 });
 


### PR DESCRIPTION
## Summary
- filter out events beginning with `turno` in the dashboard upcoming events list
- test that turno events are hidden

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7060f6e48323bbd781ae74d9d9a9