### PR TITLE
Fix dashboard upcoming events time display

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -97,7 +97,7 @@ export default function Dashboard() {
                     }}
                   />
                   Evento: <strong>{e.title}</strong> –{' '}
-                  {new Date(e.dateTime).toLocaleDateString()}
+                  {new Date(e.dateTime).toLocaleString()}
                 </li>
               ))}
               {!upcomingEvents.length && <li>Nessun evento imminente.</li>}


### PR DESCRIPTION
## Summary
- show time for upcoming events on Dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e718a5de88323bdfe8fe82669e910