### PR TITLE
Format upcoming event time

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -97,7 +97,13 @@ export default function Dashboard() {
                     }}
                   />
                   Evento: <strong>{e.title}</strong> –{' '}
-                  {new Date(e.dateTime).toLocaleString()}
+                  {(() => {
+                    const dt = new Date(e.dateTime);
+                    return `${dt.toLocaleDateString('it-IT')}, ORE ${dt.toLocaleTimeString('it-IT', {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}`;
+                  })()}
                 </li>
               ))}
               {!upcomingEvents.length && <li>Nessun evento imminente.</li>}


### PR DESCRIPTION
## Summary
- show upcoming event time as `ORE HH:MM` without seconds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e735774f0832382b1497ee11555d5