### PR TITLE
Modify event time format with clock emoji

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -98,7 +98,12 @@ export default function Dashboard() {
                     }}
                   />
                   <strong>
-                    Evento: {e.title} – {new Date(e.dateTime).toLocaleString()}
+                    Evento: {e.title} –{' '}
+                    {new Date(e.dateTime).toLocaleDateString()} 🕒 ORE{' '}
+                    {new Date(e.dateTime).toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
                   </strong>
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- format upcoming event times to remove seconds
- prepend a clock emoji and `ORE` label before the time

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7419e7f483238e0925cd87ea4d2c