### PR TITLE
Hide specific events

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -294,8 +294,14 @@ export default function EventsPage() {
     const start = new Date();
     const end = addDays(start, 15);
     const byKey = new Map<string, UnifiedEvent>();
+    const hiddenTitles = [
+      'apertura ufficio al pubblico',
+      'spunta mercato bratto',
+      'spunta mercato castione capoluogo',
+    ];
     events.forEach(ev => {
-      if (/^turno/i.test(ev.title) || ev.title === 'Apertura ufficio al pubblico') {
+      const normalized = ev.title.trim().toLowerCase();
+      if (/^turno/.test(normalized) || hiddenTitles.includes(normalized)) {
         return;
       }
       const date = parseISO(ev.dateTime);


### PR DESCRIPTION
## Summary
- filter out unwanted event titles in the Events page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e75b00b388323b531b82130e396a5