### PR TITLE
Apply TikTok Sans to dashboard date displays

### DIFF
--- a/src/pages/Dashboard.css
+++ b/src/pages/Dashboard.css
@@ -3,6 +3,10 @@
   font-family: 'Cormorant Garamond', serif;
 }
 
+.dashboard .digit-font {
+  font-family: 'TikTok Sans', sans-serif;
+}
+
 .dashboard {
   display: flex;
   flex-direction: column;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -72,7 +72,10 @@ export default function Dashboard() {
                 <li key={t.id}>
                   <span>
                     <strong>
-                      {t.text} – {new Date(t.due).toLocaleDateString()}
+                      {t.text} –{' '}
+                      <span className="digit-font">
+                        {new Date(t.due).toLocaleDateString()}
+                      </span>
                     </strong>
                   </span>
                   <button
@@ -99,11 +102,13 @@ export default function Dashboard() {
                   />
                   <strong>
                     Evento: {e.title} –{' '}
-                    {new Date(e.dateTime).toLocaleDateString()} 🕒 ORE{' '}
-                    {new Date(e.dateTime).toLocaleTimeString([], {
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
+                    <span className="digit-font">
+                      {new Date(e.dateTime).toLocaleDateString()} 🕒 ORE{' '}
+                      {new Date(e.dateTime).toLocaleTimeString([], {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
                   </strong>
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- use `.digit-font` for dashboard todo dates and upcoming event datetimes
- ensure `.digit-font` overrides dashboard base font

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e76c1624c8323bc9e789eccae9a66