### PR TITLE
Add todo status control

### DIFF
--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -4,6 +4,7 @@ export interface Todo {
   id: string
   descrizione: string
   scadenza: string        // ISO 8601: "2025-07-01T00:00:00"
+  stato: 'ATTIVO' | 'ARCHIVIATO'
 }
 
 export const listTodos = (): Promise<Todo[]> =>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,9 +2,10 @@ import React, { useMemo, useState } from 'react';
 import useLocalStorage from '../hooks/useLocalStorage';
 import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
-import { deleteTodo } from '../api/todos';
+import { deleteTodo, updateTodo } from '../api/todos';
 import './Dashboard.css';
 import { parseISO, addDays, isWithinInterval } from 'date-fns';
+import { withOffline } from '../utils/offline';
 import { DEFAULT_CALENDAR_ID, GOOGLE_COLOR_MAP } from '../constants';
 
 interface EventItem {
@@ -16,7 +17,7 @@ interface EventItem {
   source?: 'gc' | 'db';
   colorId?: string;
 }
-interface TodoItem { id: string; text: string; due: string; }
+interface TodoItem { id: string; text: string; due: string; stato: 'ATTIVO' | 'ARCHIVIATO'; }
 
 export default function Dashboard() {
   const token = useAuthStore(s => s.token);
@@ -48,7 +49,8 @@ export default function Dashboard() {
     const date = parseISO(e.dateTime);
     return isWithinInterval(date, { start: today, end: nextWeek });
   });
-  const dashboardTodos = todos;
+  const normalizedTodos = todos.map(t => ({ ...t, stato: t.stato || 'ATTIVO' }));
+  const dashboardTodos = normalizedTodos.filter(t => t.stato === 'ATTIVO');
 
   const onDelete = async (id: string): Promise<void> => {
     if (navigator.onLine) {
@@ -75,6 +77,23 @@ export default function Dashboard() {
                       {t.text} – {new Date(t.due).toLocaleDateString()}
                     </strong>
                   </span>
+                  <select
+                    value={t.stato}
+                    onChange={async e => {
+                      const stato = e.target.value as 'ATTIVO' | 'ARCHIVIATO';
+                      const res = await withOffline(
+                        () => updateTodo(t.id, { stato }),
+                        () => ({ id: t.id, descrizione: t.text, scadenza: t.due, stato })
+                      );
+                      const updated = todos.map(td =>
+                        td.id === t.id ? { ...td, stato: res.stato } : td
+                      );
+                      setTodos(updated);
+                    }}
+                  >
+                    <option value="ATTIVO">ATTIVO</option>
+                    <option value="ARCHIVIATO">ARCHIVIATO</option>
+                  </select>
                   <button
                     data-testid="dashboard-delete"
                     onClick={() => onDelete(t.id)}

--- a/src/pages/TodoPage.tsx
+++ b/src/pages/TodoPage.tsx
@@ -17,6 +17,7 @@ interface TodoItem {
   id: string;
   text: string;
   due: string;
+  stato: 'ATTIVO' | 'ARCHIVIATO';
   readonly?: boolean;
 }
 
@@ -45,7 +46,7 @@ export default function TodoPage() {
       if (navigator.onLine) {
         try {
           const data = await listTodos();
-          all = data.map(t => ({ id: t.id, text: t.descrizione, due: t.scadenza }));
+          all = data.map(t => ({ id: t.id, text: t.descrizione, due: t.scadenza, stato: t.stato }));
         } catch {
           // ignore and try local storage
         }
@@ -54,7 +55,12 @@ export default function TodoPage() {
       if (!all.length) {
         const stored = localStorage.getItem(storageKey);
         if (stored) {
-          try { all = JSON.parse(stored) as TodoItem[]; } catch {}
+          try {
+            all = (JSON.parse(stored) as TodoItem[]).map(t => ({
+              stato: 'stato' in t ? t.stato : 'ATTIVO',
+              ...t,
+            }));
+          } catch {}
         }
       }
 
@@ -83,6 +89,7 @@ export default function TodoPage() {
           id: `det-${d.id}`,
           text: `Determina ${d.numero}`,
           due: d.scadenza,
+          stato: 'ATTIVO',
           readonly: true,
         }));
 
@@ -104,25 +111,26 @@ export default function TodoPage() {
     if (!text || !due) return;
 
     if (edit) {
+      const original = todos.find(t => t.id === edit);
       const res = await withOffline(
         () => updateTodo(edit, { descrizione: text, scadenza: due }),
-        () => ({ id: edit, descrizione: text, scadenza: due })
+        () => ({ id: edit, descrizione: text, scadenza: due, stato: original?.stato || 'ATTIVO' })
       );
       const updated = todos.map(t =>
         t.id === edit
-          ? { id: res.id, text: res.descrizione, due: res.scadenza }
+          ? { id: res.id, text: res.descrizione, due: res.scadenza, stato: t.stato }
           : t
       );
       setTodos(updated);
       saveLocal(updated);
     } else {
       const res = await withOffline(
-        () => createTodo({ descrizione: text, scadenza: due }),
-        () => ({ id: Date.now().toString(), descrizione: text, scadenza: due })
+        () => createTodo({ descrizione: text, scadenza: due, stato: 'ATTIVO' }),
+        () => ({ id: Date.now().toString(), descrizione: text, scadenza: due, stato: 'ATTIVO' })
       );
       const updated = [
         ...todos,
-        { id: res.id, text: res.descrizione, due: res.scadenza },
+        { id: res.id, text: res.descrizione, due: res.scadenza, stato: res.stato },
       ];
       setTodos(updated);
       saveLocal(updated);
@@ -156,11 +164,13 @@ export default function TodoPage() {
           <tr>
             <th><strong>Attività</strong></th>
             <th><strong>Scadenza</strong></th>
+            <th><strong>Stato</strong></th>
             <th></th>
           </tr>
         </thead>
         <tbody>
           {[...todos]
+            .filter(t => t.stato === 'ATTIVO')
             .sort((a, b) =>
               new Date(a.due).getTime() - new Date(b.due).getTime(),
             )
@@ -168,6 +178,28 @@ export default function TodoPage() {
             <tr key={t.id}>
               <td className="desc-cell">{t.text}</td>
               <td className="digit-font">{new Date(t.due).toLocaleDateString()}</td>
+              <td>
+                {!t.readonly && (
+                  <select
+                    value={t.stato}
+                    onChange={async e => {
+                      const stato = e.target.value as 'ATTIVO' | 'ARCHIVIATO';
+                      const res = await withOffline(
+                        () => updateTodo(t.id, { stato }),
+                        () => ({ id: t.id, descrizione: t.text, scadenza: t.due, stato })
+                      );
+                      const updated = todos.map(td =>
+                        td.id === t.id ? { ...td, stato: res.stato } : td
+                      );
+                      setTodos(updated);
+                      saveLocal(updated);
+                    }}
+                  >
+                    <option value="ATTIVO">ATTIVO</option>
+                    <option value="ARCHIVIATO">ARCHIVIATO</option>
+                  </select>
+                )}
+              </td>
               <td>
                 {!t.readonly && (
                   <>

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -16,7 +16,7 @@ describe('Dashboard', () => {
   it('deletes todo from dashboard', async () => {
     localStorage.setItem(
       'todos',
-      JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01' }])
+      JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01', stato: 'ATTIVO' }])
     );
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
@@ -123,6 +123,29 @@ describe('Dashboard', () => {
 
     expect(screen.getByText(/Riunione/)).toBeInTheDocument();
     expect(screen.queryByText(/turno Mario/i)).not.toBeInTheDocument();
+  });
+
+  it('does not show archived todos', async () => {
+    localStorage.setItem(
+      'todos',
+      JSON.stringify([
+        { id: '1', text: 'Task', due: '2023-01-01', stato: 'ARCHIVIATO' },
+        { id: '2', text: 'Active', due: '2023-01-02', stato: 'ATTIVO' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.queryByText('Task')).not.toBeInTheDocument();
   });
 
 });

--- a/src/pages/__tests__/TodoPage.test.tsx
+++ b/src/pages/__tests__/TodoPage.test.tsx
@@ -54,7 +54,7 @@ describe('TodoPage offline', () => {
   });
 
   it('edits todo offline', async () => {
-    localStorage.setItem('todos', JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01' }]));
+    localStorage.setItem('todos', JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01', stato: 'ATTIVO' }]));
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
     render(
@@ -80,7 +80,7 @@ describe('TodoPage offline', () => {
   });
 
   it('deletes todo offline', async () => {
-    localStorage.setItem('todos', JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01' }]));
+    localStorage.setItem('todos', JSON.stringify([{ id: '1', text: 'Task', due: '2023-01-01', stato: 'ATTIVO' }]));
     Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
 
     render(
@@ -136,5 +136,29 @@ describe('TodoPage offline', () => {
 
     expect(await screen.findByText('Determina 001')).toBeInTheDocument();
     expect(screen.queryByText('Determina 002')).not.toBeInTheDocument();
+  });
+
+  it('hides archived todos', async () => {
+    localStorage.setItem(
+      'todos',
+      JSON.stringify([
+        { id: '1', text: 'Task', due: '2023-01-01', stato: 'ARCHIVIATO' },
+        { id: '2', text: 'Task2', due: '2023-02-02', stato: 'ATTIVO' },
+      ])
+    );
+    Object.defineProperty(window.navigator, 'onLine', { value: false, configurable: true });
+
+    render(
+      <MemoryRouter initialEntries={["/todo"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/todo" element={<TodoPage />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Task2')).toBeInTheDocument();
+    expect(screen.queryByText('Task')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- support `stato` field in todo API
- manage status from TodoPage with a select box
- hide archived todos in TodoPage and Dashboard
- allow status change from Dashboard as well
- update unit tests for new status behaviour

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e765b685c832395f9bd8520ab7bda