### PR TITLE
Add today's events on dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from '../store/auth';
 import { getUserStorageKey } from '../utils/auth';
 import { deleteTodo, updateTodo } from '../api/todos';
 import './Dashboard.css';
-import { parseISO, addDays, isWithinInterval } from 'date-fns';
+import { parseISO, addDays, isWithinInterval, isSameDay } from 'date-fns';
 import { withOffline } from '../utils/offline';
 import { DEFAULT_CALENDAR_ID, GOOGLE_COLOR_MAP } from '../constants';
 
@@ -43,11 +43,20 @@ export default function Dashboard() {
 
   const today = new Date();
   const nextWeek = addDays(today, 7);
+  const todaysEvents = events.filter(e => {
+    if (e.source !== 'gc') return false;
+    if (/^turno/i.test(e.title)) return false;
+    const date = parseISO(e.dateTime);
+    return isSameDay(date, today);
+  });
   const upcomingEvents = events.filter(e => {
     if (e.source !== 'gc') return false;
     if (/^turno/i.test(e.title)) return false;
     const date = parseISO(e.dateTime);
-    return isWithinInterval(date, { start: today, end: nextWeek });
+    return (
+      !isSameDay(date, today) &&
+      isWithinInterval(date, { start: today, end: nextWeek })
+    );
   });
   const normalizedTodos = todos.map(t => ({ ...t, stato: t.stato || 'ATTIVO' }));
   const dashboardTodos = normalizedTodos.filter(t => t.stato === 'ATTIVO');
@@ -106,6 +115,32 @@ export default function Dashboard() {
                 </li>
               ))}
               {!dashboardTodos.length && <li>Nessun todo.</li>}
+            </ul>
+          </div>
+          <div className="notifications dashboard-section">
+            <h2>Impegni di oggi ⏰</h2>
+            <ul>
+              {todaysEvents.map(e => (
+                <li key={e.id}>
+                  <span
+                    className="event-color-dot"
+                    style={{
+                      backgroundColor: e.colorId ? GOOGLE_COLOR_MAP[e.colorId] : 'transparent',
+                    }}
+                  />
+                  <strong>
+                    Evento: {e.title} –{' '}
+                    <span className="digit-font">
+                      {new Date(e.dateTime).toLocaleDateString()} 🕒 ORE{' '}
+                      {new Date(e.dateTime).toLocaleTimeString([], {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                  </strong>
+                </li>
+              ))}
+              {!todaysEvents.length && <li>Nessun evento oggi.</li>}
             </ul>
           </div>
           <div className="notifications dashboard-section">

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -51,11 +51,12 @@ describe('Dashboard', () => {
     expect(screen.getByRole('button', { name: /Aggiorna calendario/i })).toBeInTheDocument();
   });
 
-  it('shows Google events for the next 7 days only', () => {
+  it('shows today events and those for the next 7 days', () => {
     jest.useFakeTimers().setSystemTime(new Date('2023-05-03T10:00:00Z'));
     localStorage.setItem(
       'events',
       JSON.stringify([
+        { id: '0', title: 'Today', description: '', dateTime: '2023-05-03T12:00:00Z', isPublic: true, source: 'gc' },
         { id: '1', title: 'DB', description: '', dateTime: '2023-05-04T10:00:00Z', isPublic: true, source: 'db' },
         { id: '2', title: 'GC week', description: '', dateTime: '2023-05-05T10:00:00Z', isPublic: true, source: 'gc' },
         { id: '3', title: 'GC next', description: '', dateTime: '2023-05-12T10:00:00Z', isPublic: true, source: 'gc' },
@@ -72,6 +73,7 @@ describe('Dashboard', () => {
       </MemoryRouter>
     );
 
+    expect(screen.getByText(/Today/)).toBeInTheDocument();
     expect(screen.getByText(/GC week/)).toBeInTheDocument();
     expect(screen.queryByText(/DB/)).not.toBeInTheDocument();
     expect(screen.queryByText(/GC next/)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- show today's Google events above upcoming ones
- filter upcoming events to exclude today
- test today's events list

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e79739bb0832398a8082dffd3c60c