### PR TITLE
Fix private events visibility

### DIFF
--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -108,6 +108,7 @@ export default function EventsPage() {
           const dbEvents: UnifiedEvent[] = db
             .filter(ev =>
               ev.is_public === true ||
+              ev.owner_id == null ||
               (currentUserId
                 ? String(ev.owner_id) === String(currentUserId)
                 : false)
@@ -137,6 +138,7 @@ export default function EventsPage() {
           const parsed = JSON.parse(stored) as UnifiedEvent[];
           const filtered = parsed.filter(ev =>
             ev.isPublic ||
+            ev.owner_id == null ||
             (currentUserId
               ? String(ev.owner_id) === String(currentUserId)
               : false)


### PR DESCRIPTION
## Summary
- show events with no owner when filtering from API or localStorage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7a6fed208323ab200867f7cacb09