### PR TITLE
Fix dashboard events layout

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -142,8 +142,6 @@ export default function Dashboard() {
               ))}
               {!todaysEvents.length && <li>Nessun evento oggi.</li>}
             </ul>
-          </div>
-          <div className="notifications dashboard-section">
             <h2>Impegni dei prossimi giorni 📅</h2>
             <ul>
               {upcomingEvents.map(e => (


### PR DESCRIPTION
## Summary
- combine 'Impegni di oggi' with the upcoming events list so they share the same box

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687e7ccb86ac832388a1f2caafccbd42