### PR TITLE
Sort dashboard todos by due date

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -59,7 +59,11 @@ export default function Dashboard() {
     );
   });
   const normalizedTodos = todos.map(t => ({ ...t, stato: t.stato || 'ATTIVO' }));
-  const dashboardTodos = normalizedTodos.filter(t => t.stato === 'ATTIVO');
+  const dashboardTodos = normalizedTodos
+    .filter(t => t.stato === 'ATTIVO')
+    .sort(
+      (a, b) => new Date(a.due).getTime() - new Date(b.due).getTime()
+    );
 
   const onDelete = async (id: string): Promise<void> => {
     if (navigator.onLine) {


### PR DESCRIPTION
## Summary
- sort dashboard todos by due date so upcoming items appear first

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68821a2d43d08323a93bb677d6c97c86