### PR TITLE
Add todo order test

### DIFF
--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Dashboard from '../Dashboard';
 import PageTemplate from '../../components/PageTemplate';
@@ -148,6 +148,31 @@ describe('Dashboard', () => {
 
     expect(screen.getByText('Active')).toBeInTheDocument();
     expect(screen.queryByText('Task')).not.toBeInTheDocument();
+  });
+
+  it('orders todos by deadline', () => {
+    localStorage.setItem(
+      'todos',
+      JSON.stringify([
+        { id: '1', text: 'Due later', due: '2023-06-01', stato: 'ATTIVO' },
+        { id: '2', text: 'Due soon', due: '2023-05-01', stato: 'ATTIVO' },
+      ])
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<PageTemplate />}>
+            <Route path="/" element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const todoList = screen.getAllByRole('list')[0];
+    const items = within(todoList).getAllByRole('listitem');
+    expect(items[0]).toHaveTextContent('Due soon');
+    expect(items[1]).toHaveTextContent('Due later');
   });
 
 });


### PR DESCRIPTION
## Summary
- check ordering for dashboard todos

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68821a2e06f08323b851d4a9a0bd6a26